### PR TITLE
Feature/no ref/google codestyle

### DIFF
--- a/gce_rescue/bin/rescue.py
+++ b/gce_rescue/bin/rescue.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Main script to be used to set/reset rescue mode. """
+"""Main script to be used to set/reset rescue mode."""
 
 from datetime import datetime
 import argparse
@@ -25,25 +25,40 @@ from gce_rescue.rescue import Instance
 from gce_rescue.tasks.actions import call_tasks
 from gce_rescue.utils import read_input, set_logging
 
+
 def usage():
-  """ Print usage options. """
-  parser = argparse.ArgumentParser(description='GCE Rescue v0.0.2-1 - Set/Reset\
-    GCE instances to boot in rescue mode.')
-  parser.add_argument('-p', '--project',
-                      help='The project-id that has the instance.')
-  parser.add_argument('-z', '--zone', help='Zone where the instance \
-    is created.',
-                      required=True)
+  """Print usage options."""
+  parser = argparse.ArgumentParser(
+      description=(
+          'GCE Rescue v0.0.2-1 - Set/Reset GCE instances to boot in rescue'
+          ' mode.'
+      )
+  )
+  parser.add_argument(
+      '-p', '--project', help='The project-id that has the instance.'
+  )
+  parser.add_argument(
+      '-z',
+      '--zone',
+      help='Zone where the instance is created.',
+      required=True,
+  )
   parser.add_argument('-n', '--name', help='Instance name.', required=True)
-  parser.add_argument('-d', '--debug', action='store_true',
-                      help='Print to the log file in debug leve')
-  parser.add_argument('-f', '--force', action='store_true',
-                      help='Don\'t ask for confirmation.')
+  parser.add_argument(
+      '-d',
+      '--debug',
+      action='store_true',
+      help='Print to the log file in debug leve',
+  )
+  parser.add_argument(
+      '-f', '--force', action='store_true', help="Don't ask for confirmation."
+  )
 
   return parser
 
+
 def main():
-  """ Main script function. """
+  """Main script function."""
   parser = usage()
   args = parser.parse_args()
 
@@ -66,9 +81,11 @@ def main():
   rescue_on = vm.rescue_mode_status['rescue-mode']
   if not rescue_on:
     if not args.force:
-      info = (f'This option will boot the instance {vm.name} in '
-              'RESCUE MODE. \nIf your instance is running it will be rebooted. '
-              '\nDo you want to continue [y/N]: ')
+      info = (
+          f'This option will boot the instance {vm.name} in '
+          'RESCUE MODE. \nIf your instance is running it will be rebooted. '
+          '\nDo you want to continue [y/N]: '
+      )
       read_input(msg=info)
 
     print('Starting...')
@@ -82,9 +99,11 @@ def main():
     rescue_date = datetime.fromtimestamp(int(rescue_ts))
 
     if not args.force:
-      info = (f'The instance \"{vm.name}\" is currently configured '
-              f'to boot as rescue mode since {rescue_date}.\nWould you like to'
-              ' restore the original configuration ? [y/N]: ')
+      info = (
+          f'The instance "{vm.name}" is currently configured '
+          f'to boot as rescue mode since {rescue_date}.\nWould you like to'
+          ' restore the original configuration ? [y/N]: '
+      )
       read_input(msg=info)
 
     print('Restoring VM...')

--- a/gce_rescue/config.py
+++ b/gce_rescue/config.py
@@ -28,7 +28,7 @@ config = {
         ],
         'arm64': [
             'projects/debian-cloud/global/images/family/debian-11-arm64',
-            'projects/rocky-linux-cloud/global/images/family/rocky-linux-9-arm64',
+            'projects/rocky-linux-cloud/global/images/family/rocky-linux-9-arm64', # pylint: disable=line-too-long
         ],
     },
 }

--- a/gce_rescue/config.py
+++ b/gce_rescue/config.py
@@ -12,26 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Default configurations values. """
+"""Default configurations values."""
 
 import os
 
 dirname = os.path.dirname(__file__)
 
 config = {
-  'verbosity': 'INFO',
-  'startup-script-file': os.path.join(dirname, 'startup-script.txt'),
-  'source_guests': {
-    'x86_64':[
-      'projects/debian-cloud/global/images/family/debian-11',
-      'projects/rocky-linux-cloud/global/images/family/rocky-linux-9'
-      ],
-    'arm64':[
-      'projects/debian-cloud/global/images/family/debian-11-arm64',
-      'projects/rocky-linux-cloud/global/images/family/rocky-linux-9-arm64'
-    ]
-  }
+    'verbosity': 'INFO',
+    'startup-script-file': os.path.join(dirname, 'startup-script.txt'),
+    'source_guests': {
+        'x86_64': [
+            'projects/debian-cloud/global/images/family/debian-11',
+            'projects/rocky-linux-cloud/global/images/family/rocky-linux-9',
+        ],
+        'arm64': [
+            'projects/debian-cloud/global/images/family/debian-11-arm64',
+            'projects/rocky-linux-cloud/global/images/family/rocky-linux-9-arm64',
+        ],
+    },
 }
+
 
 def get_config(key):
   if key in config:

--- a/gce_rescue/messages.py
+++ b/gce_rescue/messages.py
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" List of messages to inform and educate the user. """
+"""List of messages to inform and educate the user."""
 
 from gce_rescue.rescue import Instance
 
+
 def tip_connect_ssh(vm: Instance) -> str:
-  return (f'└── Your instance is READY! You can now connect your instance '
-    f' {vm.name} via:\n  1. CLI. (add --tunnel-through-iap if necessary)\n'
-    f'    $ gcloud compute ssh {vm.name} --zone={vm.zone} '
-    f'--project={vm.project} --ssh-flag="-o StrictHostKeyChecking=no"\n  OR\n'
-    f'  2. Google Cloud Console:\n'
-    f'    https://ssh.cloud.google.com/v2/ssh/projects/{vm.project}/zones/'
-    f'{vm.zone}/instances/{vm.name}?authuser=0&hl=en_US&useAdminProxy=true&'
-    f'troubleshoot4005Enabled=true\n')
+  return (
+      '└── Your instance is READY! You can now connect your instance '
+      f' {vm.name} via:\n  1. CLI. (add --tunnel-through-iap if necessary)\n'
+      f'    $ gcloud compute ssh {vm.name} --zone={vm.zone} '
+      f'--project={vm.project} --ssh-flag="-o StrictHostKeyChecking=no"\n  OR\n'
+      '  2. Google Cloud Console:\n'
+      f'    https://ssh.cloud.google.com/v2/ssh/projects/{vm.project}/zones/'
+      f'{vm.zone}/instances/{vm.name}?authuser=0&hl=en_US&useAdminProxy=true&'
+      'troubleshoot4005Enabled=true\n'
+  )
+
 
 def tip_restore_disk(vm: Instance) -> str:
-  return (f'└── The instance {vm.name} was restored! Use the snapshot below '
-    f'if you need to restore the modification made while the instance was '
-    f'in rescue mode.\n Snapshot name: {vm.disks["disk_name"]}-{vm.ts}\n'
-    f' More information: '
-    f'https://cloud.google.com/compute/docs/disks/restore-snapshot\n')
+  return (
+      f'└── The instance {vm.name} was restored! Use the snapshot below '
+      'if you need to restore the modification made while the instance was '
+      f'in rescue mode.\n Snapshot name: {vm.disks["disk_name"]}-{vm.ts}\n'
+      ' More information: '
+      'https://cloud.google.com/compute/docs/disks/restore-snapshot\n'
+  )

--- a/gce_rescue/messages_test.py
+++ b/gce_rescue/messages_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Test code for messages.py. """
+"""Test code for messages.py."""
 
 from absl.testing import absltest
 from gce_rescue import messages
@@ -23,17 +23,14 @@ from gce_rescue.test.mocks import mock_api_object, MOCK_TEST_VM
 class MessagesTest(absltest.TestCase):
   vm: Instance
 
-
   def setUp(self):
     self.vm = Instance(test_mode=True, **MOCK_TEST_VM)
     self.vm.compute = mock_api_object(['compute'])
-    self.instance_data =  self.vm.data
-
+    self.instance_data = self.vm.data
 
   def test_tip_connect_ssh(self):
     output = messages.tip_connect_ssh(self.vm)
     self.assertTrue(len(output) > 1)
-
 
   def test_tip_restore_disk(self):
     output = messages.tip_restore_disk(self.vm)

--- a/gce_rescue/multitasks.py
+++ b/gce_rescue/multitasks.py
@@ -12,22 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Class to handle multithread tasks. """
+"""Class to handle multithread tasks."""
 
 from threading import Thread
+
 
 class Handler(Thread):
   """Handler for multithread tasks."""
 
   def __init__(
-      self,
-      group=None,
-      target=None,
-      name=None,
-      args=None,
-      kwargs=None
-    ):
-
+      self, group=None, target=None, name=None, args=None, kwargs=None
+  ):
     if not args:
       args = ()
 

--- a/gce_rescue/multitasks_test.py
+++ b/gce_rescue/multitasks_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Multitask test code """
+"""Multitask test code"""
 
 from absl.testing import absltest
 from gce_rescue.multitasks import Handler
@@ -24,10 +24,9 @@ OUTPUT2 = 'task1 done'
 
 class MultitasksTest(absltest.TestCase):
   status = {
-	  'task1_done': False,
-	  'task2_done': False,
-	}
-
+      'task1_done': False,
+      'task2_done': False,
+  }
 
   @classmethod
   def task1(cls):
@@ -37,7 +36,6 @@ class MultitasksTest(absltest.TestCase):
     MultitasksTest.status['task1_done'] = True
     return OUTPUT1
 
-
   @classmethod
   def task2(cls):
     for i in range(0, 3):
@@ -45,7 +43,6 @@ class MultitasksTest(absltest.TestCase):
       time.sleep(0.001)
     MultitasksTest.status['task2_done'] = True
     return OUTPUT2
-
 
   def test_multitasks(self):
     t1 = Handler(target=MultitasksTest.task1)

--- a/gce_rescue/rescue.py
+++ b/gce_rescue/rescue.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Initilization Instance() with VM information. """
+"""Initilization Instance() with VM information."""
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Union
@@ -21,15 +21,17 @@ from gce_rescue.tasks.backup import backup_metadata_items
 from gce_rescue.tasks.disks import list_disk
 from gce_rescue.tasks.pre_validations import Validations
 from gce_rescue.utils import (
-  validate_instance_mode,
-  guess_guest,
-  get_instance_info
+    validate_instance_mode,
+    guess_guest,
+    get_instance_info,
 )
 import googleapiclient.discovery
+
 
 @dataclass
 class Instance:
   """Initialize instance."""
+
   zone: str
   name: str
   project: str = None
@@ -40,25 +42,22 @@ class Instance:
   _status: str = ''
   _rescue_source_disk: str = ''
   _rescue_mode_status: Dict[str, Union[str, int]] = field(
-    default_factory=lambda: ({})
+      default_factory=lambda: ({})
   )
   _disks: Dict[str, str] = field(default_factory=lambda: ({}))
   _backup_items: Dict[str, Union[str, int]] = field(
-    default_factory=lambda: ([])
+      default_factory=lambda: ([])
   )
 
   def __post_init__(self):
     check = Validations(
-        name=self.name,
-        test_mode=self.test_mode,
-        **self.project_data
+        name=self.name, test_mode=self.test_mode, **self.project_data
     )
     self.compute = check.compute
     self.project = check.adc_project
     self.data = get_instance_info(
-        compute=self.compute,
-        name=self.name,
-        project_data=self.project_data)
+        compute=self.compute, name=self.name, project_data=self.project_data
+    )
 
     self._rescue_mode_status = validate_instance_mode(self.data)
     self.ts = self._rescue_mode_status['ts']
@@ -67,17 +66,14 @@ class Instance:
     self._disks = self._define_disks()
 
     # Backup metadata items
-    self._backup_items = backup_metadata_items(
-        data=self.data
-    )
+    self._backup_items = backup_metadata_items(data=self.data)
 
   def refresh_fingerprint(self) -> None:
     """Refresh the current metadata fingerprint value."""
 
     project_data = get_instance_info(
-        compute=self.compute,
-        name=self.name,
-        project_data=self.project_data)
+        compute=self.compute, name=self.name, project_data=self.project_data
+    )
 
     new_fingerprint = project_data['metadata']['fingerprint']
     self.data['metadata']['fingerprint'] = new_fingerprint
@@ -98,9 +94,7 @@ class Instance:
       disk_filter = f'labels.rescue={ts}'
 
       disk = list_disk(
-        vm=self,
-        project_data=self.project_data,
-        label_filter=disk_filter
+          vm=self, project_data=self.project_data, label_filter=disk_filter
       )
 
       disk_name = disk[0]['name']
@@ -111,10 +105,7 @@ class Instance:
         if disk_name == source:
           device_name = disk['deviceName']
 
-    result = {
-        'device_name': device_name,
-        'disk_name': disk_name
-    }
+    result = {'device_name': device_name, 'disk_name': disk_name}
     return result
 
   @property

--- a/gce_rescue/rescue_test.py
+++ b/gce_rescue/rescue_test.py
@@ -17,66 +17,58 @@
 from absl.testing import absltest
 from gce_rescue.rescue import Instance
 from gce_rescue.test.mocks import (
-  mock_api_object,
-  MOCK_TEST_VM,
-  MOCK_TEST_DATA
+    mock_api_object,
+    MOCK_TEST_VM,
+    MOCK_TEST_DATA,
 )
+
 
 class RescueTest(absltest.TestCase):
   vm: Instance
 
-
   def setUp(self):
     self.vm = Instance(test_mode=True, **MOCK_TEST_VM)
-    self.instance_data =  self.vm.data
-
+    self.instance_data = self.vm.data
 
   def test_instance(self):
     """Compare the properties values with the fixed values in instances.json."""
 
     self.assertEqual(self.vm.name, 'mock_vm')
+    self.assertEqual(self.vm.rescue_mode_status['rescue-mode'], False)
     self.assertEqual(
-      self.vm.rescue_mode_status['rescue-mode'],
-      False
-    )
-    self.assertEqual(
-      self.vm.project_data,
-      {
-        'project': MOCK_TEST_DATA['project'],
-        'zone': MOCK_TEST_DATA['zone']
-      }
+        self.vm.project_data,
+        {'project': MOCK_TEST_DATA['project'], 'zone': MOCK_TEST_DATA['zone']},
     )
     self.assertTrue(len(self.vm.backup_items) > 0)
 
-
   def test_define_disks(self):
     """Validate the vm._define_disks() by comparing the function returned
-    dict to MOCK_TEST_DATA"""
 
-    disks_test = self.vm._define_disks() # pylint: disable=protected-access
+    dict to MOCK_TEST_DATA
+    """
+
+    disks_test = self.vm._define_disks()  # pylint: disable=protected-access
 
     self.assertEqual(
-      disks_test,
-      {
-        'device_name': MOCK_TEST_DATA['device'],
-        'disk_name': MOCK_TEST_DATA['disk']
-      }
+        disks_test,
+        {
+            'device_name': MOCK_TEST_DATA['device'],
+            'disk_name': MOCK_TEST_DATA['disk'],
+        },
     )
-
 
   def test_refresh_fingerprint(self):
     """Validate the refresh fingerprint function by resetting the value,
-    calling the function and comparing the hearded code in instances.json."""
+
+    calling the function and comparing the hearded code in instances.json.
+    """
 
     self.vm.compute = mock_api_object(['compute'])
 
     self.vm.data['metadata']['fingerprint'] = ''
     self.vm.refresh_fingerprint()
 
-    self.assertEqual(
-      self.vm.data['metadata']['fingerprint'],
-      'cRcIE4_rlPM='
-    )
+    self.assertEqual(self.vm.data['metadata']['fingerprint'], 'cRcIE4_rlPM=')
 
 
 if __name__ == '__main__':

--- a/gce_rescue/tasks/backup.py
+++ b/gce_rescue/tasks/backup.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Different operations to guarantee VM disks backup, before performing
-    any modifications."""
+"""Different operations to guarantee VM disks backup, before performing
+
+any modifications.
+"""
 
 from gce_rescue.utils import wait_for_operation
 from typing import Dict, List
@@ -21,8 +23,10 @@ import logging
 
 _logger = logging.getLogger(__name__)
 
+
 def backup_metadata_items(data: Dict) -> List:
-  """ Returns the "items" content (ssh-keys, scripts, etc) to be restored
+  """Returns the "items" content (ssh-keys, scripts, etc) to be restored
+
   at the end of the process. After the instance booted and executed
   the rescue start-script
   """
@@ -30,9 +34,10 @@ def backup_metadata_items(data: Dict) -> List:
     return data['metadata']['items']
   return []
 
+
 def _create_snapshot(vm) -> Dict:
-  """
-  Create a snaphost of the instance boot disk, adding self._ts to the disk name.
+  """Create a snaphost of the instance boot disk, adding self._ts to the disk name.
+
   https://cloud.google.com/compute/docs/reference/rest/v1/disks/createSnapshot
   Returns:
     operation-result: Dict
@@ -40,19 +45,17 @@ def _create_snapshot(vm) -> Dict:
 
   disk_name = vm.disks['disk_name']
   snapshot_name = f'{disk_name}-{vm.ts}'
-  snapshot_body = {
-    'name': snapshot_name
-  }
+  snapshot_body = {'name': snapshot_name}
   _logger.info(f'Creating snapshot {snapshot_name}... ')
-  operation = vm.compute.disks().createSnapshot(
-    **vm.project_data,
-    disk = disk_name,
-    body = snapshot_body).execute()
+  operation = (
+      vm.compute.disks()
+      .createSnapshot(**vm.project_data, disk=disk_name, body=snapshot_body)
+      .execute()
+  )
   result = wait_for_operation(vm, oper=operation)
   return result
 
+
 def backup(vm) -> None:
-  """
-  List of methods to backup data and information from the orignal instance
-  """
+  """List of methods to backup data and information from the orignal instance"""
   _create_snapshot(vm)

--- a/gce_rescue/tasks/backup.py
+++ b/gce_rescue/tasks/backup.py
@@ -36,7 +36,8 @@ def backup_metadata_items(data: Dict) -> List:
 
 
 def _create_snapshot(vm) -> Dict:
-  """Create a snaphost of the instance boot disk, adding self._ts to the disk name.
+  """Create a snaphost of the instance boot disk, adding self._ts to the disk
+  name.
 
   https://cloud.google.com/compute/docs/reference/rest/v1/disks/createSnapshot
   Returns:

--- a/gce_rescue/tasks/backup_test.py
+++ b/gce_rescue/tasks/backup_test.py
@@ -21,13 +21,11 @@ from gce_rescue.rescue import Instance
 
 
 class BackupTest(absltest.TestCase):
-  vm : Instance
-
+  vm: Instance
 
   def setUp(self):
     self.vm = Instance(test_mode=True, **MOCK_TEST_VM)
     self.vm.compute = mock_api_object(['operations'])
-
 
   def test_backup_metadata_items(self):
     """Test Backup_metadata_Items."""
@@ -35,7 +33,6 @@ class BackupTest(absltest.TestCase):
     self.assertTrue(backup_data is not None)
     self.assertTrue('key' in backup_data[0])
     self.assertTrue('value' in backup_data[0])
-
 
   def test_backup(self):
     """Test backup task."""

--- a/gce_rescue/tasks/disks.py
+++ b/gce_rescue/tasks/disks.py
@@ -96,7 +96,8 @@ def _set_disk_label(vm, disk_name=str) -> Dict:
 
 
 def _delete_rescue_disk(vm, disk_name: str) -> Dict:
-  """Delete rescue disk after resetting the instance to the original configuration.
+  """Delete rescue disk after resetting the instance to the original
+  configuration.
 
   https://cloud.google.com/compute/docs/reference/rest/v1/disks/delete
   Param:

--- a/gce_rescue/tasks/disks_test.py
+++ b/gce_rescue/tasks/disks_test.py
@@ -20,68 +20,60 @@ from absl import logging
 from gce_rescue.rescue import Instance
 from gce_rescue.tasks import disks
 from gce_rescue.test.mocks import (
-  mock_api_object,
-  MOCK_TEST_VM,
-  MOCK_TEST_DATA,
+    mock_api_object,
+    MOCK_TEST_VM,
+    MOCK_TEST_DATA,
 )
 
 logging.set_verbosity('INFO')
 # logging.set_verbosity('DEBUG')
 
+
 class DisksTest(absltest.TestCase):
+
   def setUp(self):
     self.vm = Instance(test_mode=True, **MOCK_TEST_VM)
-    self.instance_data =  self.vm.data
+    self.instance_data = self.vm.data
 
   def test_list_disk(self):
     self.vm.compute = mock_api_object(['disks'])
     disk_filter = f'labels.rescue={self.vm.ts}'
-    result = disks.list_disk(self.vm,
-      self.vm.project_data,
-      disk_filter)
+    result = disks.list_disk(self.vm, self.vm.project_data, disk_filter)
     self.assertTrue(len(result) > 0)
     self.assertEqual(result[0]['name'], MOCK_TEST_DATA['disk'])
 
-
   def test_attach_disk(self):
     self.vm.compute = mock_api_object([
-      'disks',
-      'disks',
-      'operations',
-      'operations',
+        'disks',
+        'disks',
+        'operations',
+        'operations',
     ])
     disk_filter = f'labels.rescue={self.vm.ts}'
-    disk_list = disks.list_disk(self.vm,
-      self.vm.project_data,
-      disk_filter)
+    disk_list = disks.list_disk(self.vm, self.vm.project_data, disk_filter)
     disk_name = disk_list[0]['name']
     disks_ = self.instance_data['disks']
     disk = disks_[0]
     device_name = disk['deviceName']
-    disks.attach_disk(
-       self.vm,
-       disk_name,
-       device_name)
-
+    disks.attach_disk(self.vm, disk_name, device_name)
 
   def test_config_rescue_disks(self):
     self.vm.compute = mock_api_object([
-      'operations',
-      'operations',
-      'operations',
-      'operations',
-      'operations',
-      'disks',
+        'operations',
+        'operations',
+        'operations',
+        'operations',
+        'operations',
+        'disks',
     ])
     disks.config_rescue_disks(self.vm)
 
-
   def test_restore_original_disk(self):
     self.vm.compute = mock_api_object([
-      'operations',
-      'operations',
-      'operations',
-      'operations',
+        'operations',
+        'operations',
+        'operations',
+        'operations',
     ])
     disks.restore_original_disk(self.vm)
 

--- a/gce_rescue/tasks/metadata_test.py
+++ b/gce_rescue/tasks/metadata_test.py
@@ -19,31 +19,30 @@ from absl import logging
 
 from gce_rescue.rescue import Instance
 from gce_rescue.tasks import metadata
-from gce_rescue.test.mocks import  mock_api_object, MOCK_TEST_VM
+from gce_rescue.test.mocks import mock_api_object, MOCK_TEST_VM
 
 
 class MetadataTest(absltest.TestCase):
+
   def setUp(self):
     self.vm = Instance(test_mode=True, **MOCK_TEST_VM)
-    self.instance_data =  self.vm.data
-
+    self.instance_data = self.vm.data
 
   def test_set_metadata(self):
     self.vm.compute = mock_api_object(['operations'])
     result = metadata.set_metadata(self.vm)
-    self.assertTrue(len(result)> 1)
-
+    self.assertTrue(len(result) > 1)
 
   def test_restore_metadata(self):
     self.vm.ts = 1666774335
     self.vm.compute = mock_api_object([
-      'compute',
-      'serialconsole',
-      'operations',
+        'compute',
+        'serialconsole',
+        'operations',
     ])
     result = metadata.restore_metadata_items(self.vm)
-    self.assertTrue(len(result)> 1)
+    self.assertTrue(len(result) > 1)
+
 
 if __name__ == '__main__':
   absltest.main()
-

--- a/gce_rescue/tasks/operations.py
+++ b/gce_rescue/tasks/operations.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Standard VM operations. """
+"""Standard VM operations."""
 
 from gce_rescue.rescue import Instance
 from gce_rescue.utils import wait_for_operation
 import logging
 
 _logger = logging.getLogger(__name__)
+
 
 def start_instance(vm: Instance) -> str:
   """Start instance."""
@@ -28,9 +29,11 @@ def start_instance(vm: Instance) -> str:
     _logger.info(f'{vm.name} is already runnning.')
     return
 
-  operation = vm.compute.instances().start(
-    **vm.project_data,
-    instance = vm.name).execute()
+  operation = (
+      vm.compute.instances()
+      .start(**vm.project_data, instance=vm.name)
+      .execute()
+  )
   result = wait_for_operation(vm, oper=operation)
 
   if result['status'] == 'DONE':
@@ -45,12 +48,11 @@ def stop_instance(vm: Instance) -> str:
     _logger.info(f'{vm.name} is already stopped.')
     return
 
-  operation = vm.compute.instances().stop(
-    **vm.project_data,
-    instance = vm.name).execute()
+  operation = (
+      vm.compute.instances().stop(**vm.project_data, instance=vm.name).execute()
+  )
   result = wait_for_operation(vm, oper=operation)
 
   if result['status'] == 'DONE':
     vm.status = 'TERMINATED'
   return vm.status
-

--- a/gce_rescue/tasks/operations_test.py
+++ b/gce_rescue/tasks/operations_test.py
@@ -23,17 +23,14 @@ from gce_rescue.test.mocks import mock_api_object, MOCK_TEST_VM
 class OperationsTest(absltest.TestCase):
   vm: Instance
 
-
   def setUp(self):
     self.vm = Instance(test_mode=True, **MOCK_TEST_VM)
     self.vm.compute = mock_api_object(['operations'])
-    self.instance_data =  self.vm.data
-
+    self.instance_data = self.vm.data
 
   def test_start_instance(self):
     """test starting vm instance."""
     start_instance(self.vm)
-
 
   def test_stop_instance(self):
     """test stoping vm instance."""

--- a/gce_rescue/tasks/pre_validations.py
+++ b/gce_rescue/tasks/pre_validations.py
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Validations that should be performed before continue the script execution.
-    Each validations steps can be appended to the class Validations() and keep
-    the file under validations/ folder."""
+"""Validations that should be performed before continue the script execution.
+
+Each validations steps can be appended to the class Validations() and keep the
+file under validations/ folder.
+"""
 
 from dataclasses import dataclass, field
 import googleapiclient.discovery
 from gce_rescue.tasks.validations.authentication import (
-  authenticate_check,
-  project_name
+    authenticate_check,
+    project_name,
 )
+
 
 @dataclass
 class Validations:
   """Run different validations before continue the script.
-  	Return:
-  		discovery.build object.
+
+  Return:
+
+          discovery.build object.
   """
+
   zone: str
   name: str
   project: str = None
@@ -36,10 +42,10 @@ class Validations:
 
   def _authentication(self):
     return authenticate_check(
-      project = self.project,
-      zone = self.zone,
-      instance_name = self.name,
-      test_mode = self.test_mode,
+        project=self.project,
+        zone=self.zone,
+        instance_name=self.name,
+        test_mode=self.test_mode,
     )
 
   @property

--- a/gce_rescue/tasks/validations/authentication.py
+++ b/gce_rescue/tasks/validations/authentication.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Authentication validation to be called from ../pre_validations.py """
+"""Authentication validation to be called from ../pre_validations.py"""
 import googleapiclient.discovery
 import google.auth
 import sys
 from gce_rescue.test.mocks import mock_api_object
 
 PROJECT = ''
+
 
 def _get_auth():
   global PROJECT
@@ -36,11 +37,9 @@ def _get_auth():
     print(msg, file=sys.stderr)
     sys.exit(1)
 
+
 def authenticate_check(
-  zone: str,
-  instance_name: str,
-  project: str = None,
-  test_mode: bool = False
+    zone: str, instance_name: str, project: str = None, test_mode: bool = False
 ) -> googleapiclient.discovery.Resource:
   global PROJECT
   PROJECT = project
@@ -51,14 +50,11 @@ def authenticate_check(
   if not credentials:
     return False
   service = googleapiclient.discovery.build(
-    'compute',
-    'v1',
-    credentials = credentials
+      'compute', 'v1', credentials=credentials
   )
   request = service.instances().get(
-		project = PROJECT,
-		zone = zone,
-		instance = instance_name)
+      project=PROJECT, zone=zone, instance=instance_name
+  )
   try:
     request.execute()
     return service
@@ -67,26 +63,30 @@ def authenticate_check(
     print(msg, file=sys.stderr)
     sys.exit(1)
 
+
 def project_name() -> str:
   return PROJECT
 
+
 def _info_auth_refresh() -> str:
   return (
-	'    Please use application-default Credentials (ADC) to authenticate:\n'
-	'    $ gcloud auth login --update-adc'
+      '    Please use application-default Credentials (ADC) to authenticate:\n'
+      '    $ gcloud auth login --update-adc'
   )
+
 
 def _info_auth_cred() -> str:
   return (
-	'    Please use application-default Credentions (ADC) to authenticate:\n'
-	'     $ gcloud auth application-default login\n'
-	f'     $ gcloud auth application-default set-quota-project {PROJECT}'
+      '    Please use application-default Credentions (ADC) to authenticate:\n'
+      '     $ gcloud auth application-default login\n'
+      f'     $ gcloud auth application-default set-quota-project {PROJECT}'
   )
+
 
 def _info_no_project() -> str:
   return (
-	'    Was not possible to find the project where the VM is created.\n'
-	'    You can use the option --project to declare the project-id or '
-  'set to your configuration:\n'
-	'    $ gcloud config set project PROJECT_ID'
+      '    Was not possible to find the project where the VM is created.\n'
+      '    You can use the option --project to declare the project-id or '
+      'set to your configuration:\n'
+      '    $ gcloud config set project PROJECT_ID'
   )

--- a/gce_rescue/test/mocks.py
+++ b/gce_rescue/test/mocks.py
@@ -23,30 +23,30 @@ from googleapiclient.http import HttpMockSequence
 
 
 MOCK_TEST_VM = {
-  'project': 'mock_project',
-  'zone': 'europe-central1-a',
-  'name' : 'mock_vm'
+    'project': 'mock_project',
+    'zone': 'europe-central1-a',
+    'name': 'mock_vm',
 }
 
 MOCK_TEST_DATA = {
-  'project': 'mock_project',
-  'zone': 'europe-central1-a',
-  'name' : 'mock_vm',
-  'disk' : 'mock-vm',
-  'device': 'persistent-disk-0'
+    'project': 'mock_project',
+    'zone': 'europe-central1-a',
+    'name': 'mock_vm',
+    'disk': 'mock-vm',
+    'device': 'persistent-disk-0',
 }
 
-TESTDATA_PATH='test-data'
+TESTDATA_PATH = 'test-data'
 mock_data = {
-  'compute': f'{TESTDATA_PATH}/instances.json',
-  'disks': f'{TESTDATA_PATH}/disks.json',
-  'operations': f'{TESTDATA_PATH}/operations.json',
-  'serialconsole': f'{TESTDATA_PATH}/serialconsole.json',
+    'compute': f'{TESTDATA_PATH}/instances.json',
+    'disks': f'{TESTDATA_PATH}/disks.json',
+    'operations': f'{TESTDATA_PATH}/operations.json',
+    'serialconsole': f'{TESTDATA_PATH}/serialconsole.json',
 }
 
 
 def mock_api_object(mocks_list: List[str]):
-  """ Returns mock HTTP sequence Resources to be used in API tests calls """
+  """Returns mock HTTP sequence Resources to be used in API tests calls"""
   responses = []
   for mock in mocks_list:
     if mock not in mock_data:
@@ -56,9 +56,7 @@ def mock_api_object(mocks_list: List[str]):
       raise Exception(FileNotFoundError, file_name)
     with open(file_name, encoding='utf-8') as fd:
       data = json.load(fd)
-    responses.append(
-      ({'status': '200'}, json.dumps(data))
-    )
+    responses.append(({'status': '200'}, json.dumps(data)))
   http = HttpMockSequence(responses)
-  service = googleapiclient.discovery.build('compute', 'v1', http = http)
+  service = googleapiclient.discovery.build('compute', 'v1', http=http)
   return service


### PR DESCRIPTION
### Description

This PR was opened to apply the Google Python Style to our existing codebase.

In the future, this code style will be applied automatically to any commited code.
Let's format our code with Google Python formatter so far, to keep it uniform and clean.

### Tests

- Unit Tests
  <pre>
  user@host:~/Documents/gce-rescue$ python3 -m unittest discover -s gce_rescue -p '*_test.py'
  ..task 1, time 0
  task 2, time 0
  task 1, time 1
  task 2, time 1
  task 1, time 2
  task 2, time 2
  ..............
  ----------------------------------------------------------------------
  Ran 16 tests in 0.632s
  
  OK
  </pre>

- End-to-end tests
  <pre>
  user@host:~/Documents/gce-rescue$ gce-rescue --zone europe-central2-b --name debian
  This option will boot the instance debian in RESCUE MODE. 
  If your instance is running it will be rebooted. 
  Do you want to continue [y/N]: y
  Starting...
  ┌── Configuring...
  │   └── Progress 6/6 [█████████████████████████████████████████████████████████████]
  ├── Configurations finished.
  └── Your instance is READY! You can now connect your instance  debian via:
    1. CLI. (add --tunnel-through-iap if necessary)
      $ gcloud compute ssh debian --zone=europe-central2-b --project=test-project --ssh-flag="-o StrictHostKeyChecking=no"
    OR
    2. Google Cloud Console:
      https://ssh.cloud.google.com/v2/ssh/projects/test-project/zones/europe-central2-b/instances/debian?authuser=0&hl=en_US&useAdminProxy=true&troubleshoot4005Enabled=true
  
  user@host:~/Documents/gce-rescue$ gce-rescue --zone europe-central2-b --name debian
  The instance "debian" is currently configured to boot as rescue mode since 2023-03-28 18:09:45.
  Would you like to restore the original configuration ? [y/N]: y
  Restoring VM...
  ┌── Configuring...
  │   └── Progress 4/4 [█████████████████████████████████████████████████████████████]
  ├── Configurations finished.
  └── The instance debian was restored! Use the snapshot below if you need to restore the modification made while the instance was in rescue mode.
   Snapshot name: debian-1680019785
   More information: https://cloud.google.com/compute/docs/disks/restore-snapshot
  </pre>

<details>
  <summary>MD5 hashes to confirm the content</summary>
<pre>
$ find . -name "*.py" -exec md5sum {} \;
0b153f05bde0b2f203f9955fce5d5956  ./build/lib/gce_rescue/test/mocks.py
d41d8cd98f00b204e9800998ecf8427e  ./build/lib/gce_rescue/test/__init__.py
2681ec9ee851ae9969385e0b9ff00f8a  ./build/lib/gce_rescue/tasks/disks_test.py
2bf743407564484f187ff0d24ccbb6d8  ./build/lib/gce_rescue/tasks/pre_validations.py
3dfdac3cbe7d7da8885ae03083261d0b  ./build/lib/gce_rescue/tasks/disks.py
c1d7e2782bfda8ac95f0d02d5975b4d9  ./build/lib/gce_rescue/tasks/operations_test.py
3e610c198da613e257baddb4cc30339e  ./build/lib/gce_rescue/tasks/metadata_test.py
d41d8cd98f00b204e9800998ecf8427e  ./build/lib/gce_rescue/tasks/validations/__init__.py
edeb726cceff37f64aa9fb462fa9d7e6  ./build/lib/gce_rescue/tasks/validations/authentication.py
c653064a16656854754be973680daa2a  ./build/lib/gce_rescue/tasks/backup_test.py
2060f52c4cbc211763cdae2e8372a1cb  ./build/lib/gce_rescue/tasks/actions.py
b1488fc4373d094057ce54bbecce693f  ./build/lib/gce_rescue/tasks/operations.py
d41d8cd98f00b204e9800998ecf8427e  ./build/lib/gce_rescue/tasks/__init__.py
4152ecdb2aa8c1820ff4b37cb1f23122  ./build/lib/gce_rescue/tasks/metadata.py
7578873e6c994aae043992e32e356a63  ./build/lib/gce_rescue/tasks/backup.py
5368e40e00999a105b2e14e18c29543a  ./build/lib/gce_rescue/rescue.py
4907ece2aed6d98a0976dc1c440958d9  ./build/lib/gce_rescue/config.py
b32518648bf608825d8f2e020e4827f1  ./build/lib/gce_rescue/multitasks_test.py
21a96efeab8f96e207534944bc5875fb  ./build/lib/gce_rescue/bin/rescue.py
d41d8cd98f00b204e9800998ecf8427e  ./build/lib/gce_rescue/bin/__init__.py
7e92dde9d81dc735864ef757a86a373e  ./build/lib/gce_rescue/multitasks.py
9a669ec91f2f76d0ee16c4e150b80dd7  ./build/lib/gce_rescue/messages_test.py
d41d8cd98f00b204e9800998ecf8427e  ./build/lib/gce_rescue/__init__.py
8db33a88917e304d38181ca4e3d5ea55  ./build/lib/gce_rescue/rescue_test.py
0195f6fc173eb89a9802f6a82c7a3c16  ./build/lib/gce_rescue/utils.py
6c15d7f704954671357070fd0d482412  ./build/lib/gce_rescue/messages.py
0b153f05bde0b2f203f9955fce5d5956  ./gce_rescue/test/mocks.py
d41d8cd98f00b204e9800998ecf8427e  ./gce_rescue/test/__init__.py
2681ec9ee851ae9969385e0b9ff00f8a  ./gce_rescue/tasks/disks_test.py
2bf743407564484f187ff0d24ccbb6d8  ./gce_rescue/tasks/pre_validations.py
f1c63f5ae49cf26aaa768200abdfa213  ./gce_rescue/tasks/disks.py
c1d7e2782bfda8ac95f0d02d5975b4d9  ./gce_rescue/tasks/operations_test.py
3e610c198da613e257baddb4cc30339e  ./gce_rescue/tasks/metadata_test.py
d41d8cd98f00b204e9800998ecf8427e  ./gce_rescue/tasks/validations/__init__.py
edeb726cceff37f64aa9fb462fa9d7e6  ./gce_rescue/tasks/validations/authentication.py
c653064a16656854754be973680daa2a  ./gce_rescue/tasks/backup_test.py
2060f52c4cbc211763cdae2e8372a1cb  ./gce_rescue/tasks/actions.py
b1488fc4373d094057ce54bbecce693f  ./gce_rescue/tasks/operations.py
d41d8cd98f00b204e9800998ecf8427e  ./gce_rescue/tasks/__init__.py
4152ecdb2aa8c1820ff4b37cb1f23122  ./gce_rescue/tasks/metadata.py
ef2f6b8752d9bff4260d6ab33dc05b0a  ./gce_rescue/tasks/backup.py
5368e40e00999a105b2e14e18c29543a  ./gce_rescue/rescue.py
10feb6ce4cf8556ba453e4f2becad94b  ./gce_rescue/config.py
b32518648bf608825d8f2e020e4827f1  ./gce_rescue/multitasks_test.py
21a96efeab8f96e207534944bc5875fb  ./gce_rescue/bin/rescue.py
d41d8cd98f00b204e9800998ecf8427e  ./gce_rescue/bin/__init__.py
7e92dde9d81dc735864ef757a86a373e  ./gce_rescue/multitasks.py
9a669ec91f2f76d0ee16c4e150b80dd7  ./gce_rescue/messages_test.py
d41d8cd98f00b204e9800998ecf8427e  ./gce_rescue/__init__.py
8db33a88917e304d38181ca4e3d5ea55  ./gce_rescue/rescue_test.py
0195f6fc173eb89a9802f6a82c7a3c16  ./gce_rescue/utils.py
6c15d7f704954671357070fd0d482412  ./gce_rescue/messages.py
aa6f2171d4ee70a33256624e78a9e223  ./setup.py
</pre>
</details>