### PR TITLE
feat: Local SSD handling and enhanced error messages

### DIFF
--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -49,12 +49,12 @@ class OutputFormatter:
 
     @staticmethod
     def _format_table(data: Dict[str, Any]) -> str:
-        """Format as table."""
+        """Format as table (ASCII-safe for Windows compatibility)."""
         lines = []
-        lines.append("┌─" + "─" * 50 + "─┐")
+        lines.append("+-" + "-" * 50 + "-+")
         for key, value in data.items():
-            lines.append(f"│ {key:20} │ {str(value):27} │")
-        lines.append("└─" + "─" * 50 + "─┘")
+            lines.append(f"| {key:20} | {str(value):27} |")
+        lines.append("+-" + "-" * 50 + "-+")
         return "\n".join(lines)
 
     @staticmethod
@@ -230,8 +230,8 @@ def _add_common_args(parser: argparse.ArgumentParser):
         '--format',
         metavar='FORMAT',
         choices=['json', 'yaml', 'table', 'disable'],
-        default='table',
-        help='Output format: json, yaml, table, disable. Default: table'
+        default='disable',
+        help='Output format: json, yaml, table, disable. Default: disable'
     )
     output.add_argument(
         '--verbosity',
@@ -247,6 +247,11 @@ def _add_common_args(parser: argparse.ArgumentParser):
         '--quiet',
         action='store_true',
         help='Disable interactive prompts (for automation)'
+    )
+    interactive.add_argument(
+        '--force',
+        action='store_true',
+        help='Required with --quiet if VM has Local SSDs (data on Local SSDs will be LOST)'
     )
 
 
@@ -303,6 +308,10 @@ def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:
     if hasattr(args, 'snapshot'):
         config.create_snapshot = args.snapshot
 
+    # Force setting (for Local SSD VMs)
+    if hasattr(args, 'force'):
+        config.force = args.force
+
     # Verbosity to log level
     verbosity_map = {
         'debug': 'DEBUG',
@@ -322,6 +331,10 @@ def args_to_restore_config(args: argparse.Namespace) -> RestoreConfig:
     # Keep rescue disk setting (only configurable restore option in beta)
     config.delete_rescue_disk = not args.keep_rescue_disk
 
+    # Force setting (for Local SSD VMs)
+    if hasattr(args, 'force'):
+        config.force = args.force
+
     # Verbosity to log level
     verbosity_map = {
         'debug': 'DEBUG',
@@ -334,8 +347,28 @@ def args_to_restore_config(args: argparse.Namespace) -> RestoreConfig:
     return config
 
 
+def _check_local_ssds(compute, project: str, zone: str, vm_name: str) -> list:
+    """Check if VM has Local SSDs attached using GCP API. Returns list of Local SSD names."""
+    try:
+        vm = compute.instances().get(
+            project=project,
+            zone=zone,
+            instance=vm_name
+        ).execute()
+
+        local_ssds = []
+        for disk in vm.get('disks', []):
+            if disk.get('type') == 'SCRATCH':
+                local_ssds.append(disk.get('deviceName', 'unknown'))
+        return local_ssds
+    except Exception:
+        pass
+    return []
+
+
 def handle_rescue(args: argparse.Namespace) -> int:
     """Handle rescue command."""
+    from .core.auth import AuthManager
 
     # Get project from args or gcloud config
     project = args.project or get_gcloud_config('core/project')
@@ -350,6 +383,30 @@ def handle_rescue(args: argparse.Namespace) -> int:
         print("  3. Set CLOUDSDK_CORE_PROJECT environment variable", file=sys.stderr)
         return 1
 
+    # Get compute client for API calls
+    try:
+        auth = AuthManager()
+        compute, project = auth.get_client(project)
+    except Exception as e:
+        print(f"ERROR: Authentication failed: {e}", file=sys.stderr)
+        return 1
+
+    # Check for Local SSDs using API
+    local_ssds = _check_local_ssds(compute, project, args.zone, args.instance_name)
+    has_local_ssd = len(local_ssds) > 0
+
+    # In quiet mode with Local SSDs, require --force
+    if args.quiet and has_local_ssd and not args.force:
+        print("ERROR: VM has Local SSDs attached.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("WARNING: Stopping this VM will PERMANENTLY DELETE all data on Local SSDs!", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
+        print(f"  gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --quiet --force", file=sys.stderr)
+        return 1
+
     # Interactive confirmation (unless --quiet)
     if not args.quiet:
         print(f"\nYou are about to rescue VM '{args.instance_name}' in zone '{args.zone}'.")
@@ -357,6 +414,18 @@ def handle_rescue(args: argparse.Namespace) -> int:
         print("  - Stop the VM")
         print("  - Create a rescue disk and boot from it")
         print("  - Attach the affected disk as secondary")
+
+        # Show Local SSD warning if applicable
+        if has_local_ssd:
+            print("")
+            print("  " + "=" * 54)
+            print("  WARNING: LOCAL SSD DETECTED!")
+            print("  " + "=" * 54)
+            print(f"  This VM has {len(local_ssds)} Local SSD(s): {', '.join(local_ssds)}")
+            print("  Stopping the VM will PERMANENTLY DELETE all Local SSD data!")
+            print("  This cannot be undone.")
+            print("  " + "=" * 54)
+
         print("")
         response = input("Do you want to continue? [y/N]: ").strip().lower()
         if response not in ('y', 'yes'):
@@ -365,6 +434,10 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
     # Convert to config
     config = args_to_rescue_config(args)
+
+    # If Local SSDs present, set force=True since user confirmed
+    if has_local_ssd:
+        config.force = True
 
     # Execute
     debug = args.verbosity == 'debug'
@@ -386,8 +459,7 @@ def handle_rescue(args: argparse.Namespace) -> int:
             'operation': 'rescue',
             'success': True
         }
-        if args.format != 'table':  # table already printed by main
-            print(OutputFormatter.format_output(result, args.format))
+        print(OutputFormatter.format_output(result, args.format))
 
     return 0 if success else 1
 
@@ -445,8 +517,7 @@ def handle_restore(args: argparse.Namespace) -> int:
             'operation': 'restore',
             'success': True
         }
-        if args.format != 'table':  # table already printed by main
-            print(OutputFormatter.format_output(result, args.format))
+        print(OutputFormatter.format_output(result, args.format))
 
     return 0 if success else 1
 

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0-beta.1'
+VERSION = 'test-1'
 
 # OS Types
 OS_TYPE_LINUX = 'linux'
@@ -68,6 +68,7 @@ class RescueConfig:
     # Advanced settings
     preserve_rescue_disk: bool = False  # Keep rescue disk after restore
     skip_health_check: bool = False  # Skip health checks
+    force: bool = False  # Force operation (e.g., stop VM with Local SSDs)
 
 
 @dataclass
@@ -99,6 +100,7 @@ class RestoreConfig:
     interactive: bool = False
     auto_rollback: bool = True
     skip_health_check: bool = False
+    force: bool = False  # Force operation (e.g., stop VM with Local SSDs)
 
 
 # Default configurations

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = 'test-1'
+VERSION = '2.0.0-beta.2'
 
 # OS Types
 OS_TYPE_LINUX = 'linux'

--- a/gce_rescue_v2/core/error_messages.py
+++ b/gce_rescue_v2/core/error_messages.py
@@ -1,0 +1,390 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Error messages with actionable suggestions for GCE Rescue V2.
+
+Provides user-friendly error messages with:
+- Clear explanation of what went wrong
+- Possible causes
+- Actionable steps to resolve
+"""
+
+from typing import Optional
+
+
+class ErrorSuggestion:
+    """Container for error message with suggestions."""
+
+    def __init__(self, message: str, causes: list = None, suggestions: list = None,
+                 commands: list = None):
+        self.message = message
+        self.causes = causes or []
+        self.suggestions = suggestions or []
+        self.commands = commands or []
+
+    def format(self, vm_name: str = None, zone: str = None, project: str = None,
+               disk_name: str = None) -> str:
+        """Format the error with context-specific details."""
+        lines = [f"ERROR: {self.message}"]
+
+        if self.causes:
+            lines.append("")
+            lines.append("Possible causes:")
+            for cause in self.causes:
+                lines.append(f"  - {cause}")
+
+        if self.suggestions:
+            lines.append("")
+            lines.append("Suggestions:")
+            for suggestion in self.suggestions:
+                lines.append(f"  - {suggestion}")
+
+        if self.commands:
+            lines.append("")
+            lines.append("Helpful commands:")
+            for cmd in self.commands:
+                # Replace placeholders
+                cmd = cmd.replace("{vm_name}", vm_name or "<VM_NAME>")
+                cmd = cmd.replace("{zone}", zone or "<ZONE>")
+                cmd = cmd.replace("{project}", project or "<PROJECT>")
+                cmd = cmd.replace("{disk_name}", disk_name or "<DISK_NAME>")
+                lines.append(f"  $ {cmd}")
+
+        return "\n".join(lines)
+
+
+# =============================================================================
+# VM Operations Errors
+# =============================================================================
+
+VM_NOT_FOUND = ErrorSuggestion(
+    message="VM not found",
+    causes=[
+        "VM name is misspelled",
+        "VM is in a different zone",
+        "VM is in a different project",
+        "VM was recently deleted",
+    ],
+    suggestions=[
+        "Verify the VM name and zone are correct",
+        "Check if you're using the correct project",
+    ],
+    commands=[
+        "gcloud compute instances list --filter='name={vm_name}'",
+        "gcloud compute instances describe {vm_name} --zone={zone}",
+    ]
+)
+
+VM_STOP_TIMEOUT = ErrorSuggestion(
+    message="Timeout waiting for VM to stop",
+    causes=[
+        "VM has processes that are slow to shut down",
+        "VM guest agent is not responding",
+        "VM is stuck in a stopping state",
+    ],
+    suggestions=[
+        "Wait a few minutes and try again",
+        "Force stop the VM from GCP Console if needed",
+        "Check if there are long-running processes in the VM",
+    ],
+    commands=[
+        "gcloud compute instances describe {vm_name} --zone={zone} --format='value(status)'",
+        "gcloud compute instances stop {vm_name} --zone={zone}",
+    ]
+)
+
+VM_START_TIMEOUT = ErrorSuggestion(
+    message="Timeout waiting for VM to start",
+    causes=[
+        "VM boot disk has issues",
+        "VM configuration is invalid",
+        "Resource quota exceeded",
+        "Zone capacity issues",
+    ],
+    suggestions=[
+        "Check VM serial console output for boot errors",
+        "Verify the boot disk is healthy",
+        "Check project quotas",
+    ],
+    commands=[
+        "gcloud compute instances describe {vm_name} --zone={zone} --format='value(status)'",
+        "gcloud compute instances get-serial-port-output {vm_name} --zone={zone}",
+        "gcloud compute project-info describe --format='value(quotas)'",
+    ]
+)
+
+VM_ALREADY_IN_RESCUE = ErrorSuggestion(
+    message="VM is already in rescue mode",
+    causes=[
+        "A previous rescue operation was not restored",
+    ],
+    suggestions=[
+        "Run restore command to exit rescue mode first",
+        "Or use --force to re-rescue (not recommended)",
+    ],
+    commands=[
+        "gce-rescue-v2 restore {vm_name} --zone={zone}",
+    ]
+)
+
+VM_NOT_IN_RESCUE = ErrorSuggestion(
+    message="VM is not in rescue mode",
+    causes=[
+        "VM was already restored",
+        "VM was never put in rescue mode",
+        "Rescue metadata was manually removed",
+    ],
+    suggestions=[
+        "Verify the VM is in rescue mode before restoring",
+        "Run rescue command first if needed",
+    ],
+    commands=[
+        "gcloud compute instances describe {vm_name} --zone={zone} --format='value(metadata.items)'",
+    ]
+)
+
+# =============================================================================
+# Disk Operations Errors
+# =============================================================================
+
+DISK_ATTACH_FAILED = ErrorSuggestion(
+    message="Failed to attach disk",
+    causes=[
+        "Disk is already attached to another VM",
+        "Disk is in a different zone than the VM",
+        "Maximum number of disks already attached",
+        "Disk type incompatible with VM",
+    ],
+    suggestions=[
+        "Verify the disk is not attached to another VM",
+        "Ensure disk and VM are in the same zone",
+        "Check if VM has reached disk attachment limit (typically 128)",
+    ],
+    commands=[
+        "gcloud compute disks describe {disk_name} --zone={zone} --format='value(users)'",
+        "gcloud compute instances describe {vm_name} --zone={zone} --format='table(disks[].source)'",
+    ]
+)
+
+DISK_DETACH_FAILED = ErrorSuggestion(
+    message="Failed to detach disk",
+    causes=[
+        "Disk is the only boot disk",
+        "Disk is not attached to this VM",
+        "VM must be stopped to detach boot disk",
+    ],
+    suggestions=[
+        "Ensure VM is stopped before detaching boot disk",
+        "Verify the disk is actually attached to this VM",
+    ],
+    commands=[
+        "gcloud compute instances describe {vm_name} --zone={zone} --format='table(disks[].source,disks[].boot)'",
+    ]
+)
+
+DISK_CREATE_FAILED = ErrorSuggestion(
+    message="Failed to create disk",
+    causes=[
+        "Disk quota exceeded",
+        "Disk name already exists",
+        "Source image not found",
+        "Invalid disk size or type",
+    ],
+    suggestions=[
+        "Check project disk quota",
+        "Use a unique disk name",
+        "Verify the source image exists",
+    ],
+    commands=[
+        "gcloud compute disks list --filter='name~rescue'",
+        "gcloud compute project-info describe --format='value(quotas)'",
+        "gcloud compute images list --filter='family=debian-12'",
+    ]
+)
+
+DISK_DELETE_FAILED = ErrorSuggestion(
+    message="Failed to delete disk",
+    causes=[
+        "Disk is still attached to a VM",
+        "Disk is being used by a snapshot",
+        "Permission denied",
+    ],
+    suggestions=[
+        "Detach the disk from all VMs first",
+        "Wait for any pending snapshots to complete",
+    ],
+    commands=[
+        "gcloud compute disks describe {disk_name} --zone={zone} --format='value(users)'",
+    ]
+)
+
+# =============================================================================
+# Snapshot Errors
+# =============================================================================
+
+SNAPSHOT_CREATE_FAILED = ErrorSuggestion(
+    message="Failed to create snapshot",
+    causes=[
+        "Snapshot quota exceeded",
+        "Snapshot name already exists",
+        "Source disk not found",
+        "Permission denied",
+    ],
+    suggestions=[
+        "Check project snapshot quota",
+        "Delete old snapshots if quota exceeded",
+        "Use --no-snapshot to skip snapshot creation",
+    ],
+    commands=[
+        "gcloud compute snapshots list --filter='sourceDisk~{disk_name}'",
+        "gcloud compute project-info describe --format='value(quotas)'",
+    ]
+)
+
+SNAPSHOT_TIMEOUT = ErrorSuggestion(
+    message="Snapshot creation timed out",
+    causes=[
+        "Large disk takes longer to snapshot",
+        "High disk activity during snapshot",
+        "GCP service experiencing delays",
+    ],
+    suggestions=[
+        "Snapshot may still be creating in background",
+        "Check snapshot status in GCP Console",
+        "Use --no-snapshot for faster rescue (riskier)",
+    ],
+    commands=[
+        "gcloud compute snapshots list --filter='name~pre-rescue-{vm_name}'",
+        "gcloud compute operations list --filter='targetLink~{vm_name}' --limit=5",
+    ]
+)
+
+# =============================================================================
+# Permission Errors
+# =============================================================================
+
+PERMISSION_DENIED = ErrorSuggestion(
+    message="Permission denied",
+    causes=[
+        "Missing required IAM permissions",
+        "Service account doesn't have access",
+        "Project-level restrictions",
+    ],
+    suggestions=[
+        "Verify you have Compute Admin or equivalent role",
+        "Check if organization policies are blocking the action",
+    ],
+    commands=[
+        "gcloud auth list",
+        "gcloud projects get-iam-policy {project} --flatten='bindings[].members' --filter='bindings.members:$(gcloud auth list --filter=status:ACTIVE --format=\"value(account)\")'",
+    ]
+)
+
+CREDENTIALS_INVALID = ErrorSuggestion(
+    message="Invalid or expired credentials",
+    causes=[
+        "Credentials have expired",
+        "Not logged in to gcloud",
+        "Application default credentials not set",
+    ],
+    suggestions=[
+        "Re-authenticate with gcloud",
+        "Set up application default credentials",
+    ],
+    commands=[
+        "gcloud auth login",
+        "gcloud auth application-default login",
+        "gcloud auth list",
+    ]
+)
+
+# =============================================================================
+# Metadata Errors
+# =============================================================================
+
+METADATA_SET_FAILED = ErrorSuggestion(
+    message="Failed to set VM metadata",
+    causes=[
+        "Metadata size limit exceeded (512KB)",
+        "Invalid metadata key format",
+        "Concurrent metadata modification",
+    ],
+    suggestions=[
+        "Check total metadata size",
+        "Retry the operation",
+    ],
+    commands=[
+        "gcloud compute instances describe {vm_name} --zone={zone} --format='value(metadata)'",
+    ]
+)
+
+# =============================================================================
+# Helper function to get error suggestion based on error message
+# =============================================================================
+
+def get_error_suggestion(error_msg: str, operation: str = None) -> Optional[ErrorSuggestion]:
+    """
+    Get appropriate error suggestion based on error message content.
+
+    Args:
+        error_msg: The error message string
+        operation: Optional operation context (e.g., 'stop_vm', 'attach_disk')
+
+    Returns:
+        ErrorSuggestion if a match is found, None otherwise
+    """
+    error_lower = error_msg.lower()
+
+    # Permission errors
+    if 'permission' in error_lower or 'forbidden' in error_lower or '403' in error_lower:
+        return PERMISSION_DENIED
+
+    # Authentication errors
+    if 'credential' in error_lower or 'authentication' in error_lower or 'token' in error_lower:
+        return CREDENTIALS_INVALID
+
+    # Not found errors
+    if 'not found' in error_lower or '404' in error_lower:
+        if operation and 'disk' in operation:
+            return DISK_CREATE_FAILED
+        return VM_NOT_FOUND
+
+    # Timeout errors
+    if 'timeout' in error_lower:
+        if operation == 'stop_vm':
+            return VM_STOP_TIMEOUT
+        elif operation == 'start_vm':
+            return VM_START_TIMEOUT
+        elif operation == 'snapshot':
+            return SNAPSHOT_TIMEOUT
+
+    # Already exists
+    if 'already exists' in error_lower or 'already attached' in error_lower:
+        if 'disk' in error_lower:
+            return DISK_ATTACH_FAILED
+
+    # Quota errors
+    if 'quota' in error_lower or 'limit' in error_lower:
+        if 'snapshot' in error_lower:
+            return SNAPSHOT_CREATE_FAILED
+        return DISK_CREATE_FAILED
+
+    # Rescue mode errors
+    if 'rescue-mode' in error_lower or 'rescue mode' in error_lower:
+        if 'already' in error_lower:
+            return VM_ALREADY_IN_RESCUE
+        return VM_NOT_IN_RESCUE
+
+    return None

--- a/gce_rescue_v2/operations/attach_disk.py
+++ b/gce_rescue_v2/operations/attach_disk.py
@@ -7,6 +7,7 @@ the disk using the provided rollback metadata.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, DISK_ATTACH_FAILED
 
 
 class AttachDiskOperation(BaseOperation):
@@ -71,10 +72,18 @@ class AttachDiskOperation(BaseOperation):
 
             # Wait for operation to complete
             if not self._wait_for_operation(operation):
+                error_detail = DISK_ATTACH_FAILED.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+                self._log_error(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
-                    message="Timeout waiting for disk attach operation"
+                    message="Timeout waiting for disk attach operation",
+                    error=error_detail
                 )
 
             self._log_debug("Disk attached")
@@ -91,12 +100,22 @@ class AttachDiskOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to attach disk: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='attach_disk')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+            else:
+                error_detail = f"Failed to attach disk: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to attach disk: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/operations/create_disk.py
+++ b/gce_rescue_v2/operations/create_disk.py
@@ -7,6 +7,7 @@ the disk that was created by this operation.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, DISK_CREATE_FAILED
 
 
 class CreateDiskOperation(BaseOperation):
@@ -89,10 +90,18 @@ class CreateDiskOperation(BaseOperation):
                     return 'CREATING'
 
             if not self._wait_for_status(get_status, 'READY', timeout):
+                error_detail = DISK_CREATE_FAILED.format(
+                    vm_name=None,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+                self._log_error(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
-                    message=f"Timeout waiting for disk creation (>{timeout}s)"
+                    message=f"Timeout waiting for disk creation (>{timeout}s)",
+                    error=error_detail
                 )
 
             duration = time.time() - start_time
@@ -109,12 +118,22 @@ class CreateDiskOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to create disk: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='create_disk')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=None,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+            else:
+                error_detail = f"Failed to create disk: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to create disk: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/operations/create_snapshot.py
+++ b/gce_rescue_v2/operations/create_snapshot.py
@@ -7,6 +7,7 @@ operations. Rollback removes only snapshots created by this operation.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, SNAPSHOT_CREATE_FAILED, SNAPSHOT_TIMEOUT
 
 
 class CreateSnapshotOperation(BaseOperation):
@@ -107,12 +108,18 @@ class CreateSnapshotOperation(BaseOperation):
                 # Check timeout
                 elapsed = time.time() - start_time
                 if elapsed > timeout:
-                    self._log_error(f"Snapshot creation timeout after {timeout}s")
+                    error_detail = SNAPSHOT_TIMEOUT.format(
+                        vm_name=disk_name,
+                        zone=self.zone,
+                        project=self.project,
+                        disk_name=disk_name
+                    )
+                    self._log_error(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
                         message=f"Snapshot creation timeout after {timeout}s",
-                        error="timeout"
+                        error=error_detail
                     )
 
                 # Get snapshot status
@@ -140,12 +147,18 @@ class CreateSnapshotOperation(BaseOperation):
                             }
                         )
                     elif status == 'FAILED':
-                        self._log_error("Snapshot creation failed")
+                        error_detail = SNAPSHOT_CREATE_FAILED.format(
+                            vm_name=disk_name,
+                            zone=self.zone,
+                            project=self.project,
+                            disk_name=disk_name
+                        )
+                        self._log_error(error_detail)
                         return OperationResult(
                             operation_name=self.name,
                             success=False,
                             message="Snapshot creation failed",
-                            error="snapshot_failed"
+                            error=error_detail
                         )
 
                 except Exception as e:
@@ -156,12 +169,22 @@ class CreateSnapshotOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to create snapshot: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='snapshot')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=disk_name,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+            else:
+                error_detail = f"Failed to create snapshot: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to create snapshot: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/operations/delete_disk.py
+++ b/gce_rescue_v2/operations/delete_disk.py
@@ -7,6 +7,7 @@ irreversible and should only be used after completing the rescue workflow.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, DISK_DELETE_FAILED
 
 
 class DeleteDiskOperation(BaseOperation):
@@ -53,10 +54,18 @@ class DeleteDiskOperation(BaseOperation):
 
             # Wait for operation to complete
             if not self._wait_for_operation(operation):
+                error_detail = DISK_DELETE_FAILED.format(
+                    vm_name=None,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+                self._log_error(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
-                    message="Timeout waiting for disk delete operation"
+                    message="Timeout waiting for disk delete operation",
+                    error=error_detail
                 )
 
             self._log_debug(f"Disk {disk_name} deleted")
@@ -70,12 +79,22 @@ class DeleteDiskOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to delete disk: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='delete_disk')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=None,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=disk_name
+                )
+            else:
+                error_detail = f"Failed to delete disk: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to delete disk: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/operations/detach_disk.py
+++ b/gce_rescue_v2/operations/detach_disk.py
@@ -7,6 +7,7 @@ attaches the disk using the captured original configuration.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, DISK_DETACH_FAILED
 
 
 class DetachDiskOperation(BaseOperation):
@@ -84,10 +85,18 @@ class DetachDiskOperation(BaseOperation):
 
             # Wait for operation to complete
             if not self._wait_for_operation(operation):
+                error_detail = DISK_DETACH_FAILED.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=device_name
+                )
+                self._log_error(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
-                    message="Timeout waiting for disk detach operation"
+                    message="Timeout waiting for disk detach operation",
+                    error=error_detail
                 )
 
             self._log_debug("Disk detached")
@@ -104,12 +113,22 @@ class DetachDiskOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to detach disk: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='detach_disk')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project,
+                    disk_name=device_name
+                )
+            else:
+                error_detail = f"Failed to detach disk: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to detach disk: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/operations/set_metadata.py
+++ b/gce_rescue_v2/operations/set_metadata.py
@@ -1,12 +1,32 @@
 """
 Set Metadata operation.
 
-Replaces instance metadata with the provided items, preserving the original
-metadata for rollback. Rollback restores the prior metadata set.
+Manages instance metadata for rescue operations. Preserves existing metadata
+by backing up conflicting keys with a prefix, and supports full restoration.
 """
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, METADATA_SET_FAILED
+
+
+# Prefix used to backup original metadata keys that conflict with rescue keys
+RESCUE_BACKUP_PREFIX = 'rescue-backup-'
+
+# Keys that rescue mode needs to set (may conflict with existing metadata)
+RESCUE_CONFLICT_KEYS = [
+    'startup-script',
+    'windows-startup-script-ps1',
+]
+
+# All rescue-related keys (for cleanup during restore)
+RESCUE_METADATA_KEYS = [
+    'rescue-mode',
+    'rescue-original-disk',
+    'rescue-os-type',
+    'startup-script',
+    'windows-startup-script-ps1',
+]
 
 
 class SetMetadataOperation(BaseOperation):
@@ -25,25 +45,29 @@ class SetMetadataOperation(BaseOperation):
         """
         return "Set Metadata"
 
-    def execute(self, vm_name: str, metadata_items: list) -> OperationResult:
+    def execute(self, vm_name: str, metadata_items: list, preserve_existing: bool = True) -> OperationResult:
         """
-        Replace the metadata of the specified VM instance.
+        Set metadata on the specified VM instance, preserving existing metadata.
+
+        When preserve_existing=True (default):
+        - Existing metadata keys are preserved
+        - Conflicting keys (e.g., startup-script) are backed up with prefix
+        - Backed up keys can be restored later using restore_backup_keys()
 
         Args:
             vm_name (str): Name of the VM instance.
             metadata_items (list): List of metadata items as dictionaries of
                 form {'key': str, 'value': str}.
+            preserve_existing (bool): If True, merge with existing metadata
+                and backup conflicting keys. Default True.
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
             and `original_metadata` for restoration.
-
-        Raises:
-            None
         """
 
         self._log_debug(f"Executing {self.name} for {vm_name}")
-        self._log_debug(f"  Setting {len(metadata_items)} metadata items")
+        self._log_debug(f"  Setting {len(metadata_items)} metadata items (preserve_existing={preserve_existing})")
 
         try:
             # Get current metadata for rollback
@@ -55,13 +79,20 @@ class SetMetadataOperation(BaseOperation):
 
             original_metadata = vm.get('metadata', {})
             fingerprint = original_metadata.get('fingerprint')
+            original_items = original_metadata.get('items', [])
 
-            self._log_debug(f"Original metadata has {len(original_metadata.get('items', []))} items")
+            self._log_debug(f"Original metadata has {len(original_items)} items")
+
+            if preserve_existing:
+                # Build final metadata: existing + backup conflicting + new items
+                final_items = self._merge_with_backup(original_items, metadata_items)
+            else:
+                final_items = metadata_items
 
             # Set new metadata
             new_metadata = {
                 'fingerprint': fingerprint,
-                'items': metadata_items
+                'items': final_items
             }
 
             operation = self.compute.instances().setMetadata(
@@ -73,10 +104,17 @@ class SetMetadataOperation(BaseOperation):
 
             # Wait for operation to complete
             if not self._wait_for_operation(operation):
+                error_detail = METADATA_SET_FAILED.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project
+                )
+                self._log_error(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
-                    message="Timeout waiting for metadata operation"
+                    message="Timeout waiting for metadata operation",
+                    error=error_detail
                 )
 
             self._log_debug("Metadata set")
@@ -84,7 +122,7 @@ class SetMetadataOperation(BaseOperation):
             return OperationResult(
                 operation_name=self.name,
                 success=True,
-                message=f"Metadata set ({len(metadata_items)} items)",
+                message=f"Metadata set ({len(final_items)} items)",
                 rollback_data={
                     'vm_name': vm_name,
                     'original_metadata': original_metadata
@@ -93,13 +131,69 @@ class SetMetadataOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to set metadata: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='set_metadata')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project
+                )
+            else:
+                error_detail = f"Failed to set metadata: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to set metadata: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
+
+    def _merge_with_backup(self, original_items: list, new_items: list) -> list:
+        """
+        Merge new metadata items with existing ones, backing up conflicts.
+
+        For keys that exist in both original and new items:
+        - If it's a conflict key (like startup-script), backup original with prefix
+        - Then set the new value
+
+        Args:
+            original_items: Existing metadata items from VM
+            new_items: New items to set (rescue metadata)
+
+        Returns:
+            List of merged metadata items with backups
+        """
+        # Get keys we're about to set
+        new_keys = {item['key'] for item in new_items}
+
+        # Build result starting with original items
+        result = {}
+
+        for item in original_items:
+            key = item['key']
+            value = item['value']
+
+            # Skip if this is already a backup key (don't double-backup)
+            if key.startswith(RESCUE_BACKUP_PREFIX):
+                result[key] = value
+                continue
+
+            # Check if this key will be overwritten by new items
+            if key in new_keys and key in RESCUE_CONFLICT_KEYS:
+                # Backup this key with prefix
+                backup_key = f"{RESCUE_BACKUP_PREFIX}{key}"
+                result[backup_key] = value
+                self._log_debug(f"  Backing up '{key}' as '{backup_key}'")
+            elif key not in new_keys:
+                # Keep original key as-is (not being overwritten)
+                result[key] = value
+
+        # Add all new items
+        for item in new_items:
+            result[item['key']] = item['value']
+
+        # Convert back to list format
+        return [{'key': k, 'value': v} for k, v in result.items()]
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/start_vm.py
+++ b/gce_rescue_v2/operations/start_vm.py
@@ -7,6 +7,7 @@ stops the VM only if it was previously stopped (TERMINATED) before execution.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, VM_START_TIMEOUT
 
 
 class StartVMOperation(BaseOperation):
@@ -76,10 +77,17 @@ class StartVMOperation(BaseOperation):
                     return vm['status']
 
                 if not self._wait_for_status(get_status, 'RUNNING', timeout):
+                    error_detail = VM_START_TIMEOUT.format(
+                        vm_name=vm_name,
+                        zone=self.zone,
+                        project=self.project
+                    )
+                    self._log_error(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
-                        message=f"Timeout waiting for VM to start (>{timeout}s)"
+                        message=f"Timeout waiting for VM to start (>{timeout}s)",
+                        error=error_detail
                     )
 
                 duration = time.time() - start_time
@@ -118,12 +126,21 @@ class StartVMOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to start VM: {error_msg}")
+            suggestion = get_error_suggestion(error_msg, operation='start_vm')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project
+                )
+            else:
+                error_detail = f"Failed to start VM: {error_msg}"
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to start VM: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/operations/stop_vm.py
+++ b/gce_rescue_v2/operations/stop_vm.py
@@ -7,6 +7,7 @@ Rollback restarts the VM only if it was originally running prior to execution.
 
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.error_messages import get_error_suggestion, VM_STOP_TIMEOUT, VM_NOT_FOUND
 
 
 class StopVMOperation(BaseOperation):
@@ -25,7 +26,7 @@ class StopVMOperation(BaseOperation):
         """
         return "Stop VM"
 
-    def execute(self, vm_name: str, timeout: int = 300) -> OperationResult:
+    def execute(self, vm_name: str, timeout: int = 300, discard_local_ssd: bool = False) -> OperationResult:
         """
         Stop the specified VM and wait until it is TERMINATED.
 
@@ -33,6 +34,8 @@ class StopVMOperation(BaseOperation):
             vm_name (str): Name of the VM to stop.
             timeout (int): Maximum seconds to wait for the VM to reach
                 TERMINATED. Default is 300.
+            discard_local_ssd (bool): If True, allows stopping VMs with Local SSDs
+                attached (data on Local SSDs will be lost). Default is False.
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
@@ -60,11 +63,19 @@ class StopVMOperation(BaseOperation):
             if original_status == 'RUNNING':
                 self._log_debug(f"VM is RUNNING, stopping...")
 
-                self.compute.instances().stop(
-                    project=self.project,
-                    zone=self.zone,
-                    instance=vm_name
-                ).execute()
+                # Build stop request parameters
+                stop_params = {
+                    'project': self.project,
+                    'zone': self.zone,
+                    'instance': vm_name
+                }
+
+                # Add discardLocalSsd if needed (for VMs with Local SSDs)
+                if discard_local_ssd:
+                    stop_params['discardLocalSsd'] = True
+                    self._log_debug("Using discardLocalSsd=True for Local SSD VM")
+
+                self.compute.instances().stop(**stop_params).execute()
 
                 # Step 3: Wait for VM to stop
                 self._log_debug("Waiting for VM to stop...")
@@ -79,10 +90,18 @@ class StopVMOperation(BaseOperation):
                     return vm['status']
 
                 if not self._wait_for_status(get_status, 'TERMINATED', timeout):
+                    # Enhanced error message with suggestions
+                    error_detail = VM_STOP_TIMEOUT.format(
+                        vm_name=vm_name,
+                        zone=self.zone,
+                        project=self.project
+                    )
+                    self._log_error(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
-                        message=f"Timeout waiting for VM to stop (>{timeout}s)"
+                        message=f"Timeout waiting for VM to stop (>{timeout}s)",
+                        error=error_detail
                     )
 
                 duration = time.time() - start_time
@@ -122,12 +141,24 @@ class StopVMOperation(BaseOperation):
 
         except Exception as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"Failed to stop VM: {error_msg}")
+
+            # Get enhanced error suggestion based on error type
+            suggestion = get_error_suggestion(error_msg, operation='stop_vm')
+            if suggestion:
+                error_detail = suggestion.format(
+                    vm_name=vm_name,
+                    zone=self.zone,
+                    project=self.project
+                )
+            else:
+                error_detail = f"Failed to stop VM: {error_msg}"
+
+            self._log_error(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,
                 message=f"Failed to stop VM: {error_msg}",
-                error=error_msg
+                error=error_detail
             )
 
     def rollback(self, rollback_data: dict) -> bool:

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -125,6 +125,7 @@ class RescueOrchestrator:
         - Credentials
         - IAM permissions
         - VM state
+        - Local SSD warning (requires --force)
 
         Returns:
             True if all validations passed
@@ -138,7 +139,8 @@ class RescueOrchestrator:
         # Add validators
         runner.add(CredentialsValidator(self.compute, self.project, self.zone))
         runner.add(IAMPermissionsValidator(self.compute, self.project, self.zone, self.vm_name))
-        runner.add(VMStateValidator(self.compute, self.project, self.zone, self.vm_name))
+        vm_validator = VMStateValidator(self.compute, self.project, self.zone, self.vm_name)
+        runner.add(vm_validator)
 
         # Run validations
         results = runner.run_all(self.logger)
@@ -148,6 +150,16 @@ class RescueOrchestrator:
             self._log_error("Pre-flight validation failed!")
             results.print_failures()
             return False
+
+        # Check for Local SSDs (after validation passes)
+        # Store in instance for CLI to access during confirmation
+        vm_result = results.get_result("VM State")
+        if vm_result and vm_result.details.get("has_local_ssd"):
+            self.has_local_ssd = True
+            self.local_ssds = vm_result.details.get("local_ssds", [])
+        else:
+            self.has_local_ssd = False
+            self.local_ssds = []
 
         self._log_debug("All validations passed")
         return True
@@ -196,7 +208,11 @@ class RescueOrchestrator:
 
             # Step 1: Stop VM
             self._log_info("  Stopping VM...")
-            result = stop_vm.execute(vm_name=self.vm_name, timeout=self.config.vm_stop_timeout)
+            result = stop_vm.execute(
+                vm_name=self.vm_name,
+                timeout=self.config.vm_stop_timeout,
+                discard_local_ssd=self.config.force  # Allow stopping VMs with Local SSDs if --force
+            )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -180,7 +180,11 @@ class RestoreOrchestrator:
 
             # Step 1: Stop VM
             self._log_info("  Stopping VM...")
-            result = stop_vm.execute(vm_name=self.vm_name, timeout=self.config.vm_stop_timeout)
+            result = stop_vm.execute(
+                vm_name=self.vm_name,
+                timeout=self.config.vm_stop_timeout,
+                discard_local_ssd=self.config.force  # Allow stopping VMs with Local SSDs if --force
+            )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -214,10 +218,12 @@ class RestoreOrchestrator:
                 return False
             self._log_info(f"  [OK] {result.message}")
 
-            # Step 5: Remove rescue metadata
-            self._log_info("  Removing rescue metadata...")
+            # Step 5: Remove rescue metadata and restore backed up keys
+            self._log_info("  Restoring original metadata...")
             clean_metadata = self._get_clean_metadata()
-            result = set_metadata.execute(vm_name=self.vm_name, metadata_items=clean_metadata)
+            # Use preserve_existing=False to REPLACE metadata (not merge)
+            # because clean_metadata already contains the correct final state
+            result = set_metadata.execute(vm_name=self.vm_name, metadata_items=clean_metadata, preserve_existing=False)
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -287,7 +293,13 @@ class RestoreOrchestrator:
 
         # Find rescue and original disks
         for disk in vm.get('disks', []):
-            disk_name = disk['source'].split('/')[-1]
+            # Skip Local SSDs (type='SCRATCH') - they don't have a 'source' field
+            if disk.get('type') == 'SCRATCH':
+                continue
+            source = disk.get('source', '')
+            if not source:
+                continue
+            disk_name = source.split('/')[-1]
             device_name = disk['deviceName']
 
             if 'rescue-disk' in disk_name:
@@ -313,7 +325,16 @@ class RestoreOrchestrator:
             raise ValueError(f"Original disk '{self.original_disk_name}' not found on VM")
 
     def _get_clean_metadata(self) -> list:
-        """Get metadata with rescue items removed."""
+        """Get metadata with rescue items removed and backed up items restored.
+
+        This method:
+        1. Removes all rescue-related keys (rescue-mode, rescue-*, startup-script)
+        2. Restores backed up keys (rescue-backup-* -> original key name)
+
+        Example:
+            Before: [rescue-backup-startup-script="user script", startup-script="rescue script", rescue-mode="123"]
+            After:  [startup-script="user script"]
+        """
         vm = self.compute.instances().get(
             project=self.project,
             zone=self.zone,
@@ -323,20 +344,39 @@ class RestoreOrchestrator:
         metadata = vm.get('metadata', {})
         items = metadata.get('items', [])
 
-        # Remove rescue-related metadata (including both Linux and Windows startup scripts)
+        # Keys to remove (rescue-related)
         rescue_keys = [
             'rescue-mode',
-            'startup-script',                  # Linux startup script
-            'windows-startup-script-ps1',      # Windows startup script
+            'startup-script',
+            'windows-startup-script-ps1',
             'rescue-original-disk',
             'rescue-os-type'
         ]
-        clean_items = [
-            item for item in items
-            if item['key'] not in rescue_keys
-        ]
 
-        return clean_items
+        # Prefix for backed up keys
+        backup_prefix = 'rescue-backup-'
+
+        # Build clean metadata
+        result = {}
+
+        for item in items:
+            key = item['key']
+            value = item['value']
+
+            if key in rescue_keys:
+                # Skip rescue-related keys
+                continue
+            elif key.startswith(backup_prefix):
+                # Restore backed up key to original name
+                original_key = key[len(backup_prefix):]
+                result[original_key] = value
+                self._log_debug(f"  Restoring '{key}' as '{original_key}'")
+            else:
+                # Keep other keys as-is
+                result[key] = value
+
+        # Convert back to list format
+        return [{'key': k, 'value': v} for k, v in result.items()]
 
     def _check_snapshot_status(self):
         """Check if safety snapshot was created successfully during rescue."""

--- a/gce_rescue_v2/tests/test_attach_disk.py
+++ b/gce_rescue_v2/tests/test_attach_disk.py
@@ -58,7 +58,7 @@ class TestAttachDiskOperation:
 
         # Assert
         assert result.success is False
-        assert "Disk not found" in result.error
+        assert "Disk not found" in result.message
 
     def test_attach_disk_rollback(self):
         """Test rollback detaches the disk."""

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -47,6 +47,13 @@ class TestCLIExecution:
         monkeypatch.setattr(cli, "get_gcloud_config", lambda key: "cfg-project")
         monkeypatch.setattr(cli, "rescue_vm", lambda **kwargs: True)
 
+        # Mock AuthManager for Local SSD check
+        mock_auth = Mock()
+        mock_compute = Mock()
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {"disks": []}
+        mock_auth.get_client.return_value = (mock_compute, "cfg-project")
+        monkeypatch.setattr("gce_rescue_v2.core.auth.AuthManager", lambda: mock_auth)
+
         exit_code = cli.handle_rescue(args)
 
         assert exit_code == 0

--- a/gce_rescue_v2/tests/test_create_disk.py
+++ b/gce_rescue_v2/tests/test_create_disk.py
@@ -66,7 +66,7 @@ class TestCreateDiskOperation:
 
         # Assert
         assert result.success is False
-        assert "Quota Exceeded" in result.error
+        assert "Quota Exceeded" in result.message
 
     def test_create_disk_rollback(self):
         """Test rollback deletes the disk."""

--- a/gce_rescue_v2/tests/test_detach_disk.py
+++ b/gce_rescue_v2/tests/test_detach_disk.py
@@ -110,7 +110,7 @@ class TestDetachDiskOperation:
         result = op.execute(vm_name="vm-1", device_name="test-disk")
 
         assert result.success is False
-        assert result.error == "api failure"
+        assert "api failure" in result.message
 
     def test_detach_disk_rollback(self, mock_compute):
         """Test rollback re-attaches the disk."""

--- a/gce_rescue_v2/tests/test_edge_cases.py
+++ b/gce_rescue_v2/tests/test_edge_cases.py
@@ -152,7 +152,7 @@ class TestSnapshotEdgeCases:
         result = op.execute(disk_name="d1", snapshot_name="snap-1", wait=True, timeout=10)
 
         assert result.success is False
-        assert result.error == "snapshot_failed"
+        assert "failed" in result.message.lower()
 
 
 class TestNetworkEdgeCases:

--- a/gce_rescue_v2/validators/base.py
+++ b/gce_rescue_v2/validators/base.py
@@ -57,6 +57,13 @@ class ValidationResults:
         """Get only failed validations."""
         return [r for r in self.results if not r.passed]
 
+    def get_result(self, validator_name: str) -> Optional[ValidationResult]:
+        """Get result by validator name."""
+        for result in self.results:
+            if result.validator_name == validator_name:
+                return result
+        return None
+
     def print_all(self):
         """Print all validation results."""
         for result in self.results:

--- a/gce_rescue_v2/validators/vm_state.py
+++ b/gce_rescue_v2/validators/vm_state.py
@@ -106,12 +106,16 @@ class VMStateValidator(BaseValidator):
                     }
                 )
 
-            # Check boot disk
+            # Check boot disk and detect Local SSDs
             boot_disk = None
+            local_ssds = []
             for disk in vm.get('disks', []):
-                if disk.get('boot'):
+                if disk.get('boot') and boot_disk is None:
+                    # Take the first boot disk (if multiple exist)
                     boot_disk = disk['source'].split('/')[-1]
-                    break
+                # Local SSDs have type='SCRATCH'
+                if disk.get('type') == 'SCRATCH':
+                    local_ssds.append(disk.get('deviceName', 'unknown'))
 
             if not boot_disk:
                 return ValidationResult(
@@ -121,18 +125,31 @@ class VMStateValidator(BaseValidator):
                     details={"error": "No boot disk found"}
                 )
 
+            # Build result details
+            details = {
+                "vm_name": self.vm_name,
+                "current_state": current_state,
+                "boot_disk": boot_disk,
+                "zone": self.zone,
+                "project": self.project
+            }
+
+            # Add Local SSD warning if present
+            if local_ssds:
+                details["local_ssds"] = local_ssds
+                details["has_local_ssd"] = True
+                details["local_ssd_warning"] = (
+                    f"VM has {len(local_ssds)} Local SSD(s) attached. "
+                    "Local SSD data will be LOST when the VM is stopped. "
+                    "Use --force flag to proceed."
+                )
+
             # All good!
             return ValidationResult(
                 validator_name=self.name,
                 passed=True,
                 message=f"VM exists and is {current_state}",
-                details={
-                    "vm_name": self.vm_name,
-                    "current_state": current_state,
-                    "boot_disk": boot_disk,
-                    "zone": self.zone,
-                    "project": self.project
-                }
+                details=details
             )
 
         except HttpError as e:
@@ -236,7 +253,14 @@ class VMRestoreStateValidator(BaseValidator):
             original_disk = None
 
             for disk in disks:
-                disk_name = disk['source'].split('/')[-1]
+                # Skip Local SSDs (type='SCRATCH') - they don't have a 'source' field
+                if disk.get('type') == 'SCRATCH':
+                    continue
+                # Get disk name from source URL
+                source = disk.get('source', '')
+                if not source:
+                    continue
+                disk_name = source.split('/')[-1]
                 if 'rescue-disk' in disk_name:
                     rescue_disk = disk_name
                 elif not disk.get('boot'):


### PR DESCRIPTION
## Summary

- Add Local SSD detection with clear warnings before stopping VMs
- Add detailed error messages with causes, suggestions, and gcloud commands
- Fix metadata preservation during restore
- Fix various edge cases for VMs with Local SSDs

## Changes

### Local SSD Handling
- Detect VMs with Local SSDs attached (type='SCRATCH')
- Interactive mode: Show warning in confirmation prompt, user confirms with 'y'
- Quiet mode: Requires --force flag for automation safety
- Pass discardLocalSsd=true to GCP API when stopping VMs with Local SSDs

### Enhanced Error Messages
- New error_messages.py module with detailed error suggestions
- Each error includes: cause, suggestions, and helpful gcloud commands
- Applied to all operations (stop_vm, start_vm, attach_disk, etc.)

### Bug Fixes
- Fix metadata preservation during restore (use preserve_existing=False)
- Fix table format output and Windows encoding (ASCII instead of Unicode)
- Skip SCRATCH disks in validators/orchestrators (no source field)
- Change default --format to disable (less output noise)

## Testing

- All 97 unit tests passing
- Tested on Windows VM with Local SSD: rescue and restore both work correctly