### PR TITLE
feat: V2 Beta.3 - CLI UX improvements, progress tracking, and safety features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Confirms startup script actually ran successfully
 
 - **Progress Spinner**: Visual progress indicator during operations
-  - Shows current phase (Validating, Stopping VM, etc.)
+  - Shows current phase with step count (e.g., `(3/5) [Stopping -> ...]`)
   - Clean single-line updates
+
+- **Browser SSH Option**: Added browser-based SSH connection option
+  - Shows both gcloud CLI and Cloud Console SSH URL
+  - Includes IAP tunnel hint for private VMs
+
+- **Safer Confirmation Default**: Changed default from Yes to No (`y/N`)
+  - Prevents accidental confirmations
+  - Explicit 'y' required to proceed
 
 - **Usage Tracking**: User-Agent headers for internal metrics
   - Tracks rescue/restore lifecycle phases
@@ -34,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SCRATCH disk handling in restore orchestration
 - User-Agent format consistency (hyphen not underscore)
+- Local SSD warning clarified: "data lost" instead of "disk deleted"
 
 ## [2.0.0-beta.2] - 2025-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.3] - 2025-01-14
+
+### Added
+
+- **Serial Console Verification**: Polls serial console for `GCE-RESCUE-COMPLETE` marker
+  - 120 second timeout with warning (doesn't fail)
+  - Confirms startup script actually ran successfully
+
+- **Progress Spinner**: Visual progress indicator during operations
+  - Shows current phase (Validating, Stopping VM, etc.)
+  - Clean single-line updates
+
+- **Usage Tracking**: User-Agent headers for internal metrics
+  - Tracks rescue/restore lifecycle phases
+  - Hierarchical labels (rescue/validate, rescue/execute, etc.)
+
+- **Auto Debug Log**: Automatic log file creation on errors
+  - Saved to temp directory with timestamp
+  - Includes full debug output for troubleshooting
+
+- **Improved CLI Output**: gcloud-style formatting
+  - Color-coded status (green OK, red FAIL, yellow WARN)
+  - Better error messages with permission guidance
+  - Clear next steps after rescue/restore
+
+### Fixed
+
+- SCRATCH disk handling in restore orchestration
+- User-Agent format consistency (hyphen not underscore)
+
+## [2.0.0-beta.2] - 2025-01-07
+
+### Added
+
+- **Local SSD Handling**: Proper handling of VMs with scratch disks
+  - SCRATCH disks excluded from detach/restore operations
+  - Clear warning when Local SSD data will be lost
+  - Prevents restore failures on VMs with ephemeral storage
+
+- **Enhanced Error Messages**: More actionable error guidance
+  - Specific suggestions for common failure scenarios
+
+### Fixed
+
+- Early validation for missing project ID
+- CLI updated to industry standard format
+- Suppressed noisy httplib2 timeout warnings
+- Resolved pylint warnings in V1 code
+
+### Documentation
+
+- Comprehensive V2 README rewrite with customer focus
+- Added Linux and Windows example workflows
+- Updated What's New comparison table
+
 ## [2.0.0-beta.1] - 2025-12-11
 
 ### Added

--- a/gce_rescue_v2/README.md
+++ b/gce_rescue_v2/README.md
@@ -6,13 +6,12 @@
 
 ## What's New in V2
 
-| Feature | V1 | V2 |
-|---------|----|----|
-| **Windows VMs** | Not supported | Full support with RDP credentials |
-| **If rescue fails** | Manual cleanup needed | Automatic rollback to original state |
-| **XFS filesystems** | May fail with duplicate UUID | Handled automatically |
-| **CLI commands** | Same command toggles mode | Clear `rescue` and `restore` commands |
-| **Automation** | Text output only | JSON/YAML output for scripts |
+| Area | V1 | V2 |
+|------|----|----|
+| **OS Support** | Linux only | Linux + Windows |
+| **CLI Style** | Short flags (`-n`, `-z`) | gcloud-style (`--zone=`) |
+| **Commands** | Single command (toggles) | Separate `rescue` / `restore` |
+| **Architecture** | Task-based | Operation-based with rollback |
 
 ## Prerequisites
 
@@ -84,46 +83,45 @@ gce-rescue-v2 restore VM_NAME --zone ZONE [--project PROJECT] [--quiet]
 
 ## Example: Linux VM
 
+**Rescue:**
+
 ```bash
-$ gce-rescue-v2 rescue web-server --zone us-central1-a
+$ gce-rescue-v2 rescue web-server --zone=us-central1-a
 
-============================================================
-GCE Rescue V2 - Rescue Mode
-============================================================
-VM: web-server
-Zone: us-central1-a
+You are about to rescue instance [web-server] in zone [us-central1-a].
 
-Validating...
-  [OK] Credentials valid
-  [OK] VM exists
-  [OK] VM state: RUNNING
-  [OK] OS detected: Linux
+The following actions will be performed:
+ - Stop instance [web-server].
+ - Create a snapshot of your affected boot disk.
+ - Create a rescue disk and boot from it.
+ - Attach your affected boot disk for repair.
 
-Executing rescue...
-  [OK] Snapshot created: rescue-snapshot-web-server-1702060800
-  [OK] VM stopped
-  [OK] Rescue disk created
-  [OK] Boot configuration updated
-  [OK] VM started in rescue mode
+Do you want to continue (y/N)? y
 
-============================================================
-[OK] Rescue completed successfully!
-============================================================
+Rescuing instance [web-server]:
+ (5/5) [Stopping -> Snapshotting -> Creating rescue disk -> Starting -> Attaching affected disk] done.
 
-Your VM is now in rescue mode.
-Connect via SSH: gcloud compute ssh web-server --zone=us-central1-a
-Affected disk mounted at: /mnt/disk
+Rescue mode enabled for instance [web-server].
 
-When done, restore your VM:
-  gce-rescue-v2 restore web-server --zone=us-central1-a
+Affected disk mounted at: /mnt/sysroot
+Backup snapshot: rescue-snapshot-web-server-1736871234
+
+Next Steps:
+1. Connect to the instance:
+   $ gcloud compute ssh web-server --zone=us-central1-a --project=my-project
+
+2. Fix the issue (affected boot disk is mounted at /mnt/sysroot).
+
+3. Restore original configuration:
+   $ gce-rescue-v2 restore web-server --zone=us-central1-a --project=my-project
 ```
 
 **Connect and fix:**
 
 ```bash
-$ gcloud compute ssh web-server --zone us-central1-a
+$ gcloud compute ssh web-server --zone=us-central1-a
 
-user@web-server:~$ sudo nano /mnt/disk/etc/fstab
+user@web-server:~$ sudo nano /mnt/sysroot/etc/fstab
 # Fix the issue, save and exit
 
 user@web-server:~$ exit
@@ -132,110 +130,99 @@ user@web-server:~$ exit
 **Restore:**
 
 ```bash
-$ gce-rescue-v2 restore web-server --zone us-central1-a
+$ gce-rescue-v2 restore web-server --zone=us-central1-a
 
-============================================================
-GCE Rescue V2 - Restore Mode
-============================================================
-VM: web-server
-Zone: us-central1-a
+You are about to restore instance [web-server] in zone [us-central1-a] project [my-project].
 
-Validating...
-  [OK] VM is in rescue mode
+The following actions will be performed:
+ - Stop instance [web-server].
+ - Delete the rescue disk.
+ - Restore your affected boot disk as the primary boot device.
+ - Start instance [web-server].
 
-Executing restore...
-  [OK] VM stopped
-  [OK] Rescue disk detached
-  [OK] Boot disk restored
-  [OK] VM started
+Do you want to continue (y/N)? y
 
-============================================================
-[OK] Restore completed successfully!
-============================================================
+Restoring instance [web-server]:
+ (3/3) [Stopping -> Restoring affected disk -> Starting] done.
 
-Your VM has been restored to normal operation.
-Connect via SSH: gcloud compute ssh web-server --zone=us-central1-a
+Instance [web-server] restored to normal operation.
+
+Connect to the instance:
+  a. Using gcloud CLI (add --tunnel-through-iap if needed):
+     $ gcloud compute ssh web-server --zone=us-central1-a --project=my-project
+  OR
+  b. Using Google Cloud Console:
+     https://ssh.cloud.google.com/v2/ssh/projects/my-project/zones/us-central1-a/instances/web-server?authuser=0&hl=en_US&useAdminProxy=true
 ```
 
 ## Example: Windows VM
 
+**Rescue:**
+
 ```bash
-$ gce-rescue-v2 rescue win-server --zone us-central1-a
+$ gce-rescue-v2 rescue win-server --zone=us-central1-a
 
-============================================================
-GCE Rescue V2 - Rescue Mode
-============================================================
-VM: win-server
-Zone: us-central1-a
+You are about to rescue instance [win-server] in zone [us-central1-a].
 
-Validating...
-  [OK] Credentials valid
-  [OK] VM exists
-  [OK] VM state: RUNNING
-  [OK] OS detected: Windows
+The following actions will be performed:
+ - Stop instance [win-server].
+ - Create a snapshot of your affected boot disk.
+ - Create a rescue disk and boot from it.
+ - Attach your affected boot disk for repair.
 
-Executing rescue...
-  [OK] Snapshot created: rescue-snapshot-win-server-1702060800
-  [OK] VM stopped
-  [OK] Rescue disk created
-  [OK] Boot configuration updated
-  [OK] VM started in rescue mode
+Do you want to continue (y/N)? y
 
-============================================================
-[OK] Rescue completed successfully!
-============================================================
+Rescuing instance [win-server]:
+ (5/5) [Stopping -> Snapshotting -> Creating rescue disk -> Starting -> Attaching affected disk] done.
 
-Your VM is now in rescue mode.
+Rescue mode enabled for instance [win-server].
 
-==================================================
-  Windows RDP Login Credentials
-==================================================
-  IP Address: 35.192.0.100
-  Username:   rescue_admin
-  Password:   xK9mP2nQ5rT8wY3z
-==================================================
+Affected disk mounted at: D:\
+Backup snapshot: rescue-snapshot-win-server-1736871234
 
-Note: Wait 2-3 minutes for Windows to fully boot before connecting.
+Next Steps:
+1. Connect via RDP:
+   IP: <EXTERNAL_IP>
+   User: rescue_admin
+   Password: <GENERATED_PASSWORD>
 
-Affected disk mounted at: D:\ (or next available drive letter)
+2. Fix the issue (affected boot disk is mounted at D:\).
 
-When done, restore your VM:
-  gce-rescue-v2 restore win-server --zone=us-central1-a
+3. Restore original configuration:
+   $ gce-rescue-v2 restore win-server --zone=us-central1-a --project=my-project
 ```
 
 **Connect and fix:**
 
 1. Open Remote Desktop Connection
-2. Enter the IP address, username, and password shown above
+2. Enter the IP address, username, and password shown in output
 3. Your broken disk is at `D:\` - browse and fix files
 4. Example: `D:\Windows\System32\config\` for registry hives
 
 **Restore:**
 
 ```bash
-$ gce-rescue-v2 restore win-server --zone us-central1-a
+$ gce-rescue-v2 restore win-server --zone=us-central1-a
 
-============================================================
-GCE Rescue V2 - Restore Mode
-============================================================
-VM: win-server
-Zone: us-central1-a
+You are about to restore instance [win-server] in zone [us-central1-a] project [my-project].
 
-Validating...
-  [OK] VM is in rescue mode
+The following actions will be performed:
+ - Stop instance [win-server].
+ - Delete the rescue disk.
+ - Restore your affected boot disk as the primary boot device.
+ - Start instance [win-server].
 
-Executing restore...
-  [OK] VM stopped
-  [OK] Rescue disk detached
-  [OK] Boot disk restored
-  [OK] VM started
+Do you want to continue (y/N)? y
 
-============================================================
-[OK] Restore completed successfully!
-============================================================
+Restoring instance [win-server]:
+ (3/3) [Stopping -> Restoring affected disk -> Starting] done.
 
-Your VM has been restored to normal operation.
-Connect via RDP: gcloud compute reset-windows-password win-server --zone=us-central1-a
+Instance [win-server] restored to normal operation.
+
+Connect via RDP using your original credentials.
+
+Forgot password? Reset it:
+  $ gcloud compute reset-windows-password win-server --zone=us-central1-a --project=my-project
 ```
 
 ## Upgrading from V1

--- a/gce_rescue_v2/README.md
+++ b/gce_rescue_v2/README.md
@@ -112,7 +112,7 @@ Executing rescue...
 
 Your VM is now in rescue mode.
 Connect via SSH: gcloud compute ssh web-server --zone=us-central1-a
-Affected disk mounted at: /mnt/sysroot
+Affected disk mounted at: /mnt/disk
 
 When done, restore your VM:
   gce-rescue-v2 restore web-server --zone=us-central1-a
@@ -123,7 +123,7 @@ When done, restore your VM:
 ```bash
 $ gcloud compute ssh web-server --zone us-central1-a
 
-user@web-server:~$ sudo nano /mnt/sysroot/etc/fstab
+user@web-server:~$ sudo nano /mnt/disk/etc/fstab
 # Fix the issue, save and exit
 
 user@web-server:~$ exit

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -409,27 +409,22 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
     # Interactive confirmation (unless --quiet)
     if not args.quiet:
-        print(f"\nYou are about to rescue VM '{args.instance_name}' in zone '{args.zone}'.")
-        print("This will:")
-        print("  - Stop the VM")
-        print("  - Create a rescue disk and boot from it")
-        print("  - Attach the affected disk as secondary")
+        print(f"\nYou are about to rescue instance [{args.instance_name}] in zone [{args.zone}].")
+        print("")
+        print("The following actions will be performed:")
+        print(f" - Stop instance [{args.instance_name}].")
+        print(" - Create a temporary rescue disk and boot the instance from it.")
+        print(" - Attach the original boot disk as a secondary disk.")
 
         # Show Local SSD warning if applicable
         if has_local_ssd:
-            print("")
-            print("  " + "=" * 54)
-            print("  WARNING: LOCAL SSD DETECTED!")
-            print("  " + "=" * 54)
-            print(f"  This VM has {len(local_ssds)} Local SSD(s): {', '.join(local_ssds)}")
-            print("  Stopping the VM will PERMANENTLY DELETE all Local SSD data!")
-            print("  This cannot be undone.")
-            print("  " + "=" * 54)
+            print(f" - WARNING: Local SSDs ({', '.join(local_ssds)}) will be permanently deleted.")
 
         print("")
-        response = input("Do you want to continue? [y/N]: ").strip().lower()
-        if response not in ('y', 'yes'):
-            print("\nOperation cancelled.")
+        response = input("Do you want to continue (Y/n)? ").strip().lower()
+        print("")
+        if response not in ('y', 'yes', ''):
+            print("Aborted by user.")
             return 0
 
     # Convert to config
@@ -482,16 +477,18 @@ def handle_restore(args: argparse.Namespace) -> int:
 
     # Interactive confirmation (unless --quiet)
     if not args.quiet:
-        print(f"\nYou are about to restore VM '{args.instance_name}' in zone '{args.zone}'.")
-        print("This will:")
-        print("  - Stop the VM")
-        print("  - Remove the rescue disk")
-        print("  - Re-attach the affected disk as boot")
-        print("  - Start the VM normally")
+        print(f"\nYou are about to restore instance [{args.instance_name}] in zone [{args.zone}].")
         print("")
-        response = input("Do you want to continue? [y/N]: ").strip().lower()
-        if response not in ('y', 'yes'):
-            print("\nOperation cancelled.")
+        print("The following actions will be performed:")
+        print(f" - Stop instance [{args.instance_name}].")
+        print(" - Remove the temporary rescue disk.")
+        print(" - Re-attach the original boot disk.")
+        print(f" - Start instance [{args.instance_name}].")
+        print("")
+        response = input("Do you want to continue (Y/n)? ").strip().lower()
+        print("")
+        if response not in ('y', 'yes', ''):
+            print("Aborted by user.")
             return 0
 
     # Convert to config

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -100,6 +100,10 @@ def get_gcloud_config(key: str) -> Optional[str]:
 class CustomArgumentParser(argparse.ArgumentParser):
     """Custom ArgumentParser with cleaner error messages."""
 
+    # Flags specific to each command (for helpful error messages)
+    RESCUE_ONLY_FLAGS = ['--snapshot', '--no-snapshot']
+    RESTORE_ONLY_FLAGS = ['--keep-rescue-disk']
+
     def error(self, message: str):
         """Override to provide cleaner error format."""
         import re
@@ -107,18 +111,64 @@ class CustomArgumentParser(argparse.ArgumentParser):
         lines = []
 
         if "invalid choice:" in message:
-            # Format: "argument command: invalid choice: 'restor' (choose from rescue, restore)"
-            match = re.search(r"invalid choice: '(\w+)' \(choose from (.+)\)", message)
-            if match:
-                invalid = match.group(1)
-                valid_options = match.group(2)
-                lines.append(f"Invalid command '{invalid}'.")
-                lines.append("")
-                lines.append("Available commands:")
-                for opt in valid_options.split(", "):
-                    lines.append(f"  {opt}")
+            # Check if it's an invalid subcommand or invalid flag value
+            # Subcommand: "argument command: invalid choice: 'restor' (choose from rescue, restore)"
+            # Flag value: "argument --format: invalid choice: 'invalid' (choose from 'json', ...)"
+            if "argument command:" in message:
+                # Invalid subcommand
+                match = re.search(r"invalid choice: '(\w+)' \(choose from (.+)\)", message)
+                if match:
+                    invalid = match.group(1)
+                    valid_options = match.group(2)
+                    lines.append(f"Invalid command '{invalid}'.")
+                    lines.append("")
+                    lines.append("Available commands:")
+                    for opt in valid_options.split(", "):
+                        lines.append(f"  {opt}")
+                else:
+                    lines.append(f"{message}")
             else:
-                lines.append(f"{message}")
+                # Invalid value for a flag (e.g., --format=invalid)
+                flag_match = re.search(r"argument (--[\w-]+):", message)
+                value_match = re.search(r"invalid choice: '(\w+)' \(choose from (.+)\)", message)
+                if flag_match and value_match:
+                    flag_name = flag_match.group(1)
+                    invalid_value = value_match.group(1)
+                    # Clean up valid options (remove quotes)
+                    valid_options = value_match.group(2).replace("'", "")
+                    lines.append(f"Invalid value '{invalid_value}' for {flag_name}.")
+                    lines.append("")
+                    lines.append("Valid options:")
+                    for opt in valid_options.split(", "):
+                        lines.append(f"  {opt.strip()}")
+                else:
+                    lines.append(f"{message}")
+        elif "unrecognized arguments:" in message.lower():
+            # Extract the unrecognized argument
+            match = re.search(r"unrecognized arguments: (.+)", message, re.IGNORECASE)
+            if match:
+                unrecognized = match.group(1).strip()
+                lines.append(f"Unrecognized argument: {unrecognized}")
+
+                # Check if it's a flag from another command
+                for flag in self.RESCUE_ONLY_FLAGS:
+                    if flag in unrecognized:
+                        lines.append("")
+                        lines.append(f"Note: '{flag}' is only available for the 'rescue' command.")
+                        lines.append("")
+                        lines.append("Example:")
+                        lines.append(f"  $ gce-rescue-v2 rescue VM_NAME --zone=ZONE {flag}")
+                        break
+                for flag in self.RESTORE_ONLY_FLAGS:
+                    if flag in unrecognized:
+                        lines.append("")
+                        lines.append(f"Note: '{flag}' is only available for the 'restore' command.")
+                        lines.append("")
+                        lines.append("Example:")
+                        lines.append(f"  $ gce-rescue-v2 restore VM_NAME --zone=ZONE {flag}")
+                        break
+            else:
+                lines.append(f"{message.capitalize()}")
         elif "required: command" in message.lower():
             lines.append("No command specified.")
             lines.append("")

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -20,6 +20,7 @@ import yaml
 from typing import Optional, Dict, Any
 from .core.config import RescueConfig, RestoreConfig, VERSION
 from .main import rescue_vm, restore_vm
+from .utils.colors import error_prefix, warning_prefix, clear_lines
 
 
 class OutputFormatter:
@@ -78,20 +79,71 @@ def get_gcloud_config(key: str) -> Optional[str]:
     try:
         # Try to read from gcloud config
         import subprocess
+        import platform
+
+        # On Windows, gcloud is a batch file, need shell=True
+        use_shell = platform.system() == 'Windows'
         result = subprocess.run(
             ['gcloud', 'config', 'get-value', key],
             capture_output=True,
             text=True,
-            timeout=5
+            timeout=5,
+            shell=use_shell
         )
         value = result.stdout.strip()
         return value if value and value != '(unset)' else None
-    except (subprocess.SubprocessError, FileNotFoundError):
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
         # gcloud not available or error
         return None
 
 
-def create_parser() -> argparse.ArgumentParser:
+class CustomArgumentParser(argparse.ArgumentParser):
+    """Custom ArgumentParser with cleaner error messages."""
+
+    def error(self, message: str):
+        """Override to provide cleaner error format."""
+        import re
+
+        lines = []
+
+        if "invalid choice:" in message:
+            # Format: "argument command: invalid choice: 'restor' (choose from rescue, restore)"
+            match = re.search(r"invalid choice: '(\w+)' \(choose from (.+)\)", message)
+            if match:
+                invalid = match.group(1)
+                valid_options = match.group(2)
+                lines.append(f"Invalid command '{invalid}'.")
+                lines.append("")
+                lines.append("Available commands:")
+                for opt in valid_options.split(", "):
+                    lines.append(f"  {opt}")
+            else:
+                lines.append(f"{message}")
+        elif "required: command" in message.lower():
+            lines.append("No command specified.")
+            lines.append("")
+            lines.append("Available commands:")
+            lines.append("  rescue   - Boot a VM into rescue mode")
+            lines.append("  restore  - Restore a VM from rescue mode")
+        elif "required:" in message.lower():
+            # Extract what's required
+            match = re.search(r"required: (.+)", message.lower())
+            if match:
+                required = match.group(1)
+                lines.append(f"Missing required argument: {required}")
+            else:
+                lines.append(f"{message.capitalize()}")
+        else:
+            lines.append(f"{message.capitalize()}")
+
+        lines.append("")
+        lines.append("For help, run:")
+        lines.append("  $ gce-rescue-v2 --help")
+
+        self.exit(2, f"{error_prefix()} " + "\n".join(lines) + "\n\n")
+
+
+def create_parser() -> CustomArgumentParser:
     """
     Create argument parser with gcloud-compatible structure.
 
@@ -100,7 +152,7 @@ def create_parser() -> argparse.ArgumentParser:
     """
 
     # Main parser
-    parser = argparse.ArgumentParser(
+    parser = CustomArgumentParser(
         prog='gce-rescue-v2',
         description='Google Compute Engine VM Rescue Tool (Beta)',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -175,7 +227,7 @@ TO EXIT RESCUE MODE
     restore_parser = subparsers.add_parser(
         'restore',
         help='Restore a VM from rescue mode',
-        description='Restore a VM to normal operation by re-attaching the original boot disk.',
+        description='Restore a VM to normal operation by re-attaching your affected boot disk.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 EXAMPLES
@@ -347,8 +399,70 @@ def args_to_restore_config(args: argparse.Namespace) -> RestoreConfig:
     return config
 
 
-def _check_local_ssds(compute, project: str, zone: str, vm_name: str) -> list:
-    """Check if VM has Local SSDs attached using GCP API. Returns list of Local SSD names."""
+def _parse_api_error(e: Exception, vm_name: str, zone: str, project: str = None) -> str:
+    """Parse GCP API error and return user-friendly message."""
+    error_str = str(e)
+
+    if 'was not found' in error_str or 'notFound' in error_str:
+        list_cmd = f"gcloud compute instances list --project={project}" if project else "gcloud compute instances list"
+        lines = [
+            f"Instance [{vm_name}] not found.",
+            f"  Zone: {zone}",
+        ]
+        if project:
+            lines.append(f"  Project: {project}")
+        lines.append("")
+        lines.append("To see available instances, run:")
+        lines.append(f"  $ {list_cmd}")
+        lines.append("")
+        return "\n".join(lines)
+
+    if 'Unknown zone' in error_str or ("Invalid value for field" in error_str and "'zone'" in error_str):
+        lines = [
+            f"Invalid zone '{zone}'.",
+            "",
+            "To see available zones, run:",
+            "  $ gcloud compute zones list",
+            ""
+        ]
+        return "\n".join(lines)
+
+    if 'forbidden' in error_str.lower() or 'permission' in error_str.lower() or '403' in error_str:
+        lines = [
+            "Permission denied.",
+        ]
+        if project:
+            lines.append(f"  Project: {project}")
+        lines.append("")
+        lines.append("To verify project access, run:")
+        lines.append("  $ gcloud projects list")
+        lines.append("")
+        return "\n".join(lines)
+
+    if 'Invalid value for field' in error_str:
+        lines = [
+            "Invalid request parameters.",
+            "",
+            "Verify the following are correct:",
+            f"  Instance: {vm_name}",
+            f"  Zone: {zone}",
+        ]
+        if project:
+            lines.append(f"  Project: {project}")
+        lines.append("")
+        return "\n".join(lines)
+
+    # Fallback: return simplified error
+    return f"API error: {error_str[:200]}\n"
+
+
+def _validate_vm_exists(compute, project: str, zone: str, vm_name: str) -> tuple:
+    """
+    Validate VM exists and is in a valid state for rescue.
+
+    Returns:
+        (success: bool, vm_info: dict or None, error_message: str or None)
+    """
     try:
         vm = compute.instances().get(
             project=project,
@@ -356,14 +470,88 @@ def _check_local_ssds(compute, project: str, zone: str, vm_name: str) -> list:
             instance=vm_name
         ).execute()
 
-        local_ssds = []
-        for disk in vm.get('disks', []):
-            if disk.get('type') == 'SCRATCH':
-                local_ssds.append(disk.get('deviceName', 'unknown'))
-        return local_ssds
-    except Exception:
-        pass
-    return []
+        # Check if already in rescue mode
+        metadata = vm.get('metadata', {}).get('items', [])
+        for item in metadata:
+            if item.get('key') == 'rescue-mode':
+                lines = [
+                    f"Instance [{vm_name}] is already in rescue mode.",
+                    "",
+                    "To exit rescue mode and restore the VM, run:",
+                    f"  $ gce-rescue-v2 restore {vm_name} --zone={zone} --project={project}",
+                    ""
+                ]
+                return (False, None, "\n".join(lines))
+
+        # Check VM state
+        status = vm.get('status', 'UNKNOWN')
+        invalid_states = ['STAGING', 'PROVISIONING', 'SUSPENDING', 'SUSPENDED', 'REPAIRING']
+        if status in invalid_states:
+            lines = [
+                f"Instance [{vm_name}] is in state '{status}'.",
+                "",
+                "The VM must be in RUNNING or TERMINATED state to rescue.",
+                "",
+                "To check the current VM status, run:",
+                f"  $ gcloud compute instances describe {vm_name} --zone={zone} --project={project} --format='value(status)'",
+                ""
+            ]
+            return (False, None, "\n".join(lines))
+
+        return (True, vm, None)
+
+    except Exception as e:
+        return (False, None, _parse_api_error(e, vm_name, zone, project))
+
+
+def _check_local_ssds(vm_info: dict) -> list:
+    """Check if VM has Local SSDs attached. Returns list of Local SSD names."""
+    if not vm_info:
+        return []
+
+    local_ssds = []
+    for disk in vm_info.get('disks', []):
+        if disk.get('type') == 'SCRATCH':
+            local_ssds.append(disk.get('deviceName', 'unknown'))
+    return local_ssds
+
+
+def _validate_vm_for_restore(compute, project: str, zone: str, vm_name: str) -> tuple:
+    """
+    Validate VM exists and is in rescue mode for restore.
+
+    Returns:
+        (success: bool, vm_info: dict or None, error_message: str or None)
+    """
+    try:
+        vm = compute.instances().get(
+            project=project,
+            zone=zone,
+            instance=vm_name
+        ).execute()
+
+        # Check if in rescue mode
+        metadata = vm.get('metadata', {}).get('items', [])
+        in_rescue_mode = False
+        for item in metadata:
+            if item.get('key') == 'rescue-mode':
+                in_rescue_mode = True
+                break
+
+        if not in_rescue_mode:
+            lines = [
+                f"Instance [{vm_name}] is not in rescue mode.",
+                "",
+                "To put the VM into rescue mode first, run:",
+                f"  $ gce-rescue-v2 rescue {vm_name} --zone={zone} --project={project}",
+                ""
+            ]
+            return (False, None, "\n".join(lines))
+
+        return (True, vm, None)
+
+    except Exception as e:
+        return (False, None, _parse_api_error(e, vm_name, zone, project))
 
 
 def handle_rescue(args: argparse.Namespace) -> int:
@@ -375,7 +563,7 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
     # Validate project is set
     if not project:
-        print("ERROR: No project specified.", file=sys.stderr)
+        print(f"{error_prefix()} No project specified.", file=sys.stderr)
         print("", file=sys.stderr)
         print("Please specify a project using one of these methods:", file=sys.stderr)
         print("  1. --project=PROJECT_ID flag", file=sys.stderr)
@@ -388,16 +576,22 @@ def handle_rescue(args: argparse.Namespace) -> int:
         auth = AuthManager()
         compute, project = auth.get_client(project)
     except Exception as e:
-        print(f"ERROR: Authentication failed: {e}", file=sys.stderr)
+        print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
         return 1
 
-    # Check for Local SSDs using API
-    local_ssds = _check_local_ssds(compute, project, args.zone, args.instance_name)
+    # Validate VM exists and state BEFORE confirmation
+    valid, vm_info, error_msg = _validate_vm_exists(compute, project, args.zone, args.instance_name)
+    if not valid:
+        print(f"{error_prefix()} {error_msg}", file=sys.stderr)
+        return 1
+
+    # Check for Local SSDs using validated VM info
+    local_ssds = _check_local_ssds(vm_info)
     has_local_ssd = len(local_ssds) > 0
 
     # In quiet mode with Local SSDs, require --force
     if args.quiet and has_local_ssd and not args.force:
-        print("ERROR: VM has Local SSDs attached.", file=sys.stderr)
+        print(f"{error_prefix()} VM has Local SSDs attached.", file=sys.stderr)
         print("", file=sys.stderr)
         print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
         print("", file=sys.stderr)
@@ -409,23 +603,40 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
     # Interactive confirmation (unless --quiet)
     if not args.quiet:
+        # Count lines for clearing after confirmation
+        lines_printed = 0
+
         print(f"\nYou are about to rescue instance [{args.instance_name}] in zone [{args.zone}].")
+        lines_printed += 2  # includes leading newline
         print("")
+        lines_printed += 1
         print("The following actions will be performed:")
+        lines_printed += 1
         print(f" - Stop instance [{args.instance_name}].")
-        print(" - Create a temporary rescue disk and boot the instance from it.")
-        print(" - Attach the original boot disk as a secondary disk.")
+        lines_printed += 1
+        print(" - Create a snapshot of your affected boot disk.")
+        lines_printed += 1
+        print(" - Create a rescue disk and boot from it.")
+        lines_printed += 1
+        print(" - Attach your affected boot disk for repair.")
+        lines_printed += 1
 
         # Show Local SSD warning if applicable
         if has_local_ssd:
-            print(f" - WARNING: Local SSDs ({', '.join(local_ssds)}) will be permanently deleted.")
+            print(f" - {warning_prefix()} Local SSDs ({', '.join(local_ssds)}) will be permanently deleted.")
+            lines_printed += 1
 
         print("")
+        lines_printed += 1
         response = input("Do you want to continue (Y/n)? ").strip().lower()
-        print("")
+        lines_printed += 1  # The input line
+
         if response not in ('y', 'yes', ''):
-            print("Aborted by user.")
+            print("\nAborted by user.")
             return 0
+
+        # Clear confirmation message after user confirms
+        clear_lines(lines_printed)
 
     # Convert to config
     config = args_to_rescue_config(args)
@@ -461,13 +672,14 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
 def handle_restore(args: argparse.Namespace) -> int:
     """Handle restore command."""
+    from .core.auth import AuthManager
 
     # Get project from args or gcloud config
     project = args.project or get_gcloud_config('core/project')
 
     # Validate project is set
     if not project:
-        print("ERROR: No project specified.", file=sys.stderr)
+        print(f"{error_prefix()} No project specified.", file=sys.stderr)
         print("", file=sys.stderr)
         print("Please specify a project using one of these methods:", file=sys.stderr)
         print("  1. --project=PROJECT_ID flag", file=sys.stderr)
@@ -475,21 +687,50 @@ def handle_restore(args: argparse.Namespace) -> int:
         print("  3. Set CLOUDSDK_CORE_PROJECT environment variable", file=sys.stderr)
         return 1
 
+    # Get compute client for API calls
+    try:
+        auth = AuthManager()
+        compute, project = auth.get_client(project)
+    except Exception as e:
+        print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
+        return 1
+
+    # Validate VM exists and is in rescue mode BEFORE confirmation
+    valid, vm_info, error_msg = _validate_vm_for_restore(compute, project, args.zone, args.instance_name)
+    if not valid:
+        print(f"{error_prefix()} {error_msg}", file=sys.stderr)
+        return 1
+
     # Interactive confirmation (unless --quiet)
     if not args.quiet:
-        print(f"\nYou are about to restore instance [{args.instance_name}] in zone [{args.zone}].")
+        # Count lines for clearing after confirmation
+        lines_printed = 0
+
+        print(f"\nYou are about to restore instance [{args.instance_name}] in zone [{args.zone}] project [{project}].")
+        lines_printed += 2  # includes leading newline
         print("")
+        lines_printed += 1
         print("The following actions will be performed:")
+        lines_printed += 1
         print(f" - Stop instance [{args.instance_name}].")
-        print(" - Remove the temporary rescue disk.")
-        print(" - Re-attach the original boot disk.")
+        lines_printed += 1
+        print(" - Delete the rescue disk.")
+        lines_printed += 1
+        print(" - Restore your affected boot disk as the primary boot device.")
+        lines_printed += 1
         print(f" - Start instance [{args.instance_name}].")
+        lines_printed += 1
         print("")
+        lines_printed += 1
         response = input("Do you want to continue (Y/n)? ").strip().lower()
-        print("")
+        lines_printed += 1  # The input line
+
         if response not in ('y', 'yes', ''):
-            print("Aborted by user.")
+            print("\nAborted by user.")
             return 0
+
+        # Clear confirmation message after user confirms
+        clear_lines(lines_printed)
 
     # Convert to config
     config = args_to_restore_config(args)
@@ -537,14 +778,14 @@ def main():
         elif args.command == 'restore':
             return handle_restore(args)
         else:
-            print(f"ERROR: (gce-rescue) Unknown command: {args.command}", file=sys.stderr)
+            print(f"{error_prefix()} (gce-rescue) Unknown command: {args.command}", file=sys.stderr)
             return 1
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.", file=sys.stderr)
         return 130  # Standard exit code for SIGINT
     except Exception as e:
-        print(f"ERROR: (gce-rescue) Unexpected error: {str(e)}", file=sys.stderr)
+        print(f"{error_prefix()} (gce-rescue) Unexpected error: {str(e)}", file=sys.stderr)
         if '--verbosity=debug' in sys.argv or '--verbosity debug' in sys.argv:
             import traceback
             traceback.print_exc()

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -663,7 +663,7 @@ def handle_rescue(args: argparse.Namespace) -> int:
         print("", file=sys.stderr)
         print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
         print("", file=sys.stderr)
-        print("WARNING: Stopping this VM will PERMANENTLY DELETE all data on Local SSDs!", file=sys.stderr)
+        print("WARNING: Stopping this VM will PERMANENTLY LOSE all data on Local SSDs!", file=sys.stderr)
         print("", file=sys.stderr)
         print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
         print(f"  gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --quiet --force", file=sys.stderr)
@@ -691,15 +691,15 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
         # Show Local SSD warning if applicable
         if has_local_ssd:
-            print(f" - {warning_prefix()} Local SSDs ({', '.join(local_ssds)}) will be permanently deleted.")
+            print(f" - {warning_prefix()} Data on Local SSDs ({', '.join(local_ssds)}) will be permanently lost.")
             lines_printed += 1
 
         print("")
         lines_printed += 1
-        response = input("Do you want to continue (Y/n)? ").strip().lower()
+        response = input("Do you want to continue (y/N)? ").strip().lower()
         lines_printed += 1  # The input line
 
-        if response not in ('y', 'yes', ''):
+        if response not in ('y', 'yes'):
             print("\nAborted by user.")
             return 0
 
@@ -790,10 +790,10 @@ def handle_restore(args: argparse.Namespace) -> int:
         lines_printed += 1
         print("")
         lines_printed += 1
-        response = input("Do you want to continue (Y/n)? ").strip().lower()
+        response = input("Do you want to continue (y/N)? ").strip().lower()
         lines_printed += 1  # The input line
 
-        if response not in ('y', 'yes', ''):
+        if response not in ('y', 'yes'):
             print("\nAborted by user.")
             return 0
 

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -119,12 +119,13 @@ class CustomArgumentParser(argparse.ArgumentParser):
                 match = re.search(r"invalid choice: '(\w+)' \(choose from (.+)\)", message)
                 if match:
                     invalid = match.group(1)
-                    valid_options = match.group(2)
                     lines.append(f"Invalid command '{invalid}'.")
                     lines.append("")
+                    lines.append("Usage: gce-rescue-v2 COMMAND VM_NAME --zone=ZONE [OPTIONS]")
+                    lines.append("")
                     lines.append("Available commands:")
-                    for opt in valid_options.split(", "):
-                        lines.append(f"  {opt}")
+                    lines.append("  rescue   Boot a VM into rescue mode")
+                    lines.append("  restore  Restore a VM from rescue mode")
                 else:
                     lines.append(f"{message}")
             else:
@@ -170,17 +171,34 @@ class CustomArgumentParser(argparse.ArgumentParser):
             else:
                 lines.append(f"{message.capitalize()}")
         elif "required: command" in message.lower():
-            lines.append("No command specified.")
-            lines.append("")
-            lines.append("Available commands:")
-            lines.append("  rescue   - Boot a VM into rescue mode")
-            lines.append("  restore  - Restore a VM from rescue mode")
+            # Not an error - user just wants to know how to use the tool
+            usage_lines = [
+                "Usage: gce-rescue-v2 COMMAND VM_NAME --zone=ZONE [OPTIONS]",
+                "",
+                "Commands:",
+                "  rescue   Boot a VM into rescue mode",
+                "  restore  Restore a VM from rescue mode",
+                "",
+                "Examples:",
+                "  $ gce-rescue-v2 rescue my-vm --zone=us-central1-a",
+                "  $ gce-rescue-v2 restore my-vm --zone=us-central1-a",
+                "",
+                "For detailed help:",
+                "  $ gce-rescue-v2 --help",
+                ""
+            ]
+            self.exit(0, "\n".join(usage_lines) + "\n")
         elif "required:" in message.lower():
             # Extract what's required
             match = re.search(r"required: (.+)", message.lower())
             if match:
                 required = match.group(1)
                 lines.append(f"Missing required argument: {required}")
+                lines.append("")
+                lines.append("Usage: gce-rescue-v2 COMMAND VM_NAME --zone=ZONE [OPTIONS]")
+                lines.append("")
+                lines.append("Example:")
+                lines.append("  $ gce-rescue-v2 rescue my-vm --zone=us-central1-a")
             else:
                 lines.append(f"{message.capitalize()}")
         else:

--- a/gce_rescue_v2/core/auth.py
+++ b/gce_rescue_v2/core/auth.py
@@ -134,7 +134,7 @@ class AuthManager:
                 def _request_builder(http, *args, **kwargs):
                     """Inject User-Agent header for usage tracking."""
                     headers = kwargs.setdefault('headers', {})
-                    headers['user-agent'] = f'gce_rescue-{VERSION}'
+                    headers['user-agent'] = f'gce-rescue-{VERSION}'
                     auth_http = google_auth_httplib2.AuthorizedHttp(
                         self._credentials,
                         http=httplib2.Http()

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -55,6 +55,7 @@ class RescueConfig:
     vm_start_timeout: int = 300  # 5 minutes
     disk_create_timeout: int = 300  # 5 minutes
     operation_timeout: int = 600  # 10 minutes
+    startup_verification_timeout: int = 120  # 2 minutes for startup script completion
 
     # Logging settings
     log_level: str = 'INFO'

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0-beta.2'
+VERSION = '2.0.0-beta.3'
 
 # OS Types
 OS_TYPE_LINUX = 'linux'

--- a/gce_rescue_v2/core/error_messages.py
+++ b/gce_rescue_v2/core/error_messages.py
@@ -331,6 +331,31 @@ METADATA_SET_FAILED = ErrorSuggestion(
 )
 
 # =============================================================================
+# Startup Verification Errors
+# =============================================================================
+
+STARTUP_VERIFICATION_TIMEOUT = ErrorSuggestion(
+    message="Startup script did not complete within timeout period",
+    causes=[
+        "VM boot is very slow (Windows can take 5-10 minutes)",
+        "Startup script crashed or encountered errors",
+        "Disk failed to attach or mount",
+        "Serial console output is not being captured",
+    ],
+    suggestions=[
+        "Check serial console output for errors",
+        "Increase timeout with longer --startup-verification-timeout if needed",
+        "Try rescue operation again (VM may be slow on first boot)",
+        "Use --skip-startup-verification to bypass (not recommended)",
+    ],
+    commands=[
+        "gcloud compute instances get-serial-port-output {vm_name} --zone={zone}",
+        "gcloud compute instances describe {vm_name} --zone={zone}",
+        "Check /var/log/gce-rescue.log (Linux) or C:\\gce-rescue.log (Windows) via SSH/RDP",
+    ]
+)
+
+# =============================================================================
 # Helper function to get error suggestion based on error message
 # =============================================================================
 

--- a/gce_rescue_v2/core/error_messages.py
+++ b/gce_rescue_v2/core/error_messages.py
@@ -23,6 +23,8 @@ Provides user-friendly error messages with:
 
 from typing import Optional
 
+from ..utils.colors import error_prefix
+
 
 class ErrorSuggestion:
     """Container for error message with suggestions."""
@@ -37,7 +39,7 @@ class ErrorSuggestion:
     def format(self, vm_name: str = None, zone: str = None, project: str = None,
                disk_name: str = None) -> str:
         """Format the error with context-specific details."""
-        lines = [f"ERROR: {self.message}"]
+        lines = [f"{error_prefix()} {self.message}"]
 
         if self.causes:
             lines.append("")

--- a/gce_rescue_v2/main.py
+++ b/gce_rescue_v2/main.py
@@ -146,7 +146,11 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
             logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone} --project={project}")
         else:
             logger.info("1. Connect to the instance:")
-            logger.info(f"   $ gcloud compute ssh {vm_name} --zone={zone} --project={project}")
+            logger.info("   a. Using gcloud CLI (add --tunnel-through-iap if needed):")
+            logger.info(f"      $ gcloud compute ssh {vm_name} --zone={zone} --project={project}")
+            logger.info("   OR")
+            logger.info("   b. Using Google Cloud Console:")
+            logger.info(f"      https://ssh.cloud.google.com/v2/ssh/projects/{project}/zones/{zone}/instances/{vm_name}?authuser=0&hl=en_US&useAdminProxy=true")
             logger.info("")
             logger.info("2. Fix the issue (affected boot disk is mounted at /mnt/sysroot).")
             logger.info("")
@@ -287,7 +291,11 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
             logger.info(f"  $ gcloud compute reset-windows-password {vm_name} --zone={zone} --project={project}")
         else:
             logger.info("Connect to the instance:")
-            logger.info(f"  $ gcloud compute ssh {vm_name} --zone={zone} --project={project}")
+            logger.info("  a. Using gcloud CLI (add --tunnel-through-iap if needed):")
+            logger.info(f"     $ gcloud compute ssh {vm_name} --zone={zone} --project={project}")
+            logger.info("  OR")
+            logger.info("  b. Using Google Cloud Console:")
+            logger.info(f"     https://ssh.cloud.google.com/v2/ssh/projects/{project}/zones/{zone}/instances/{vm_name}?authuser=0&hl=en_US&useAdminProxy=true")
 
         logger.info("")
         return True

--- a/gce_rescue_v2/main.py
+++ b/gce_rescue_v2/main.py
@@ -5,13 +5,15 @@ Simple, clean entry points for rescue and restore operations.
 
 Usage:
     from gce_rescue_v2.main import rescue_vm, restore_vm
-    
+
     # Rescue a VM
     success = rescue_vm('my-vm', 'us-central1-a', project='my-project')
-    
+
     # Restore a VM
     success = restore_vm('my-vm', 'us-central1-a', project='my-project')
 """
+
+from datetime import datetime
 
 from .core.auth import AuthManager
 from .core.config import RescueConfig, RestoreConfig, OS_TYPE_WINDOWS
@@ -52,14 +54,18 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
         >>> rescue_vm('my-vm', 'us-central1-a', debug=True)
         True
     """
-    
-    # Setup logging
+
+    # Setup logging with auto-generated log file
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_file = f"{vm_name}-rescue-{timestamp}.log"
     logger = setup_logging(
         level='DEBUG' if debug else 'INFO',
+        log_file=log_file,
         debug=debug
     )
-    
+
     logger.debug(f"GCE Rescue V2 - Rescue")
+    logger.debug(f"Log file: {log_file}")
     logger.debug(f"VM: {vm_name}, Zone: {zone}" + (f", Project: {project}" if project else ""))
     
     try:
@@ -196,14 +202,18 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
         >>> restore_vm('my-vm', 'us-central1-a')
         True
     """
-    
-    # Setup logging
+
+    # Setup logging with auto-generated log file
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_file = f"{vm_name}-restore-{timestamp}.log"
     logger = setup_logging(
         level='DEBUG' if debug else 'INFO',
+        log_file=log_file,
         debug=debug
     )
-    
+
     logger.debug(f"GCE Rescue V2 - Restore")
+    logger.debug(f"Log file: {log_file}")
     logger.debug(f"VM: {vm_name}, Zone: {zone}" + (f", Project: {project}" if project else ""))
     
     try:

--- a/gce_rescue_v2/main.py
+++ b/gce_rescue_v2/main.py
@@ -15,7 +15,9 @@ Usage:
 
 from .core.auth import AuthManager
 from .core.config import RescueConfig, RestoreConfig, OS_TYPE_WINDOWS
+from .core.error_messages import get_error_suggestion
 from .utils.logger import setup_logging
+from .utils.colors import note_prefix
 from .orchestration import RescueOrchestrator, RestoreOrchestrator
 
 
@@ -95,10 +97,22 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
         logger.info(f"Rescue mode enabled for instance [{vm_name}].")
         logger.info("")
 
-        # Show verification timeout warning if applicable
+        # Show disk info
+        mount_path = "D:\\" if orchestrator.os_type == OS_TYPE_WINDOWS else "/mnt/sysroot"
+        logger.info(f"Affected disk mounted at: {mount_path}")
+        if orchestrator.snapshot_name:
+            logger.info(f"Backup snapshot: {orchestrator.snapshot_name}")
+        logger.info("")
+
+        # Show startup verification note if it didn't complete in time
         if not orchestrator.verification_succeeded:
-            logger.info("Note: Startup verification timed out. Check rescue logs:")
-            logger.info(f"  $ gcloud compute instances get-serial-port-output {vm_name} --zone={zone}")
+            wait_time = "1-2 minutes" if orchestrator.os_type == OS_TYPE_WINDOWS else "30 seconds"
+            log_file = "C:\\gce-rescue.log" if orchestrator.os_type == OS_TYPE_WINDOWS else "/var/log/gce-rescue.log"
+            logger.info(f"{note_prefix()} Disk mount is still in progress.")
+            logger.info(f"      Wait ~{wait_time} before connecting. If disk is not available, check:")
+            logger.info(f"      - Rescue log: {log_file}")
+            logger.info(f"      - Serial console (mount status{', credentials' if orchestrator.os_type == OS_TYPE_WINDOWS else ''}):")
+            logger.info(f"        $ gcloud compute instances get-serial-port-output {vm_name} --zone={zone} --project={project}")
             logger.info("")
 
         logger.info("Next Steps:")
@@ -118,27 +132,36 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
             logger.info("1. Connect via RDP:")
             logger.info(f"   IP: {ip_str}")
             logger.info(f"   User: rescue_admin")
-            logger.info(f"   Pass: {orchestrator.windows_rescue_password}")
+            logger.info(f"   Password: {orchestrator.windows_rescue_password}")
             logger.info("")
-            logger.info("2. Fix the issue (affected disk is mounted at D:\\).")
+            logger.info("2. Fix the issue (affected boot disk is mounted at D:\\).")
             logger.info("")
             logger.info("3. Restore original configuration:")
-            logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone}")
+            logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone} --project={project}")
         else:
             logger.info("1. Connect to the instance:")
-            logger.info(f"   $ gcloud compute ssh {vm_name} --zone={zone}")
+            logger.info(f"   $ gcloud compute ssh {vm_name} --zone={zone} --project={project}")
             logger.info("")
-            logger.info("2. Fix the issue (affected disk is mounted at /mnt/sysroot).")
+            logger.info("2. Fix the issue (affected boot disk is mounted at /mnt/sysroot).")
             logger.info("")
             logger.info("3. Restore original configuration:")
-            logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone}")
+            logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone} --project={project}")
 
+        logger.info("")
         return True
         
     except Exception as e:
-        logger.error(f"Unexpected error: {str(e)}")
+        error_msg = str(e)
+        suggestion = get_error_suggestion(error_msg)
+
+        if suggestion:
+            logger.error(suggestion.format(vm_name=vm_name, zone=zone, project=project))
+        else:
+            logger.error(f"Unexpected error: {error_msg}")
+
         if debug:
             logger.exception("Full traceback:")
+        logger.info("")
         return False
 
 
@@ -232,18 +255,45 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
         logger.info("")
         logger.info(f"Instance [{vm_name}] restored to normal operation.")
         logger.info("")
-        logger.info("Connect to the instance:")
         if os_type == OS_TYPE_WINDOWS:
-            logger.info(f"  $ gcloud compute reset-windows-password {vm_name} --zone={zone}")
-        else:
-            logger.info(f"  $ gcloud compute ssh {vm_name} --zone={zone}")
+            # Get external IP for RDP connection
+            external_ip = None
+            try:
+                for iface in vm.get('networkInterfaces', []):
+                    for access in iface.get('accessConfigs', []):
+                        if access.get('natIP'):
+                            external_ip = access.get('natIP')
+                            break
+            except Exception:
+                pass
 
+            logger.info("Connect via RDP using your original credentials:")
+            if external_ip:
+                logger.info(f"  IP: {external_ip}")
+            else:
+                logger.info(f"  $ gcloud compute instances describe {vm_name} --zone={zone} --project={project} --format=\"get(networkInterfaces[0].accessConfigs[0].natIP)\"")
+            logger.info("")
+            logger.info("Forgot password? Reset it:")
+            logger.info(f"  $ gcloud compute reset-windows-password {vm_name} --zone={zone} --project={project}")
+        else:
+            logger.info("Connect to the instance:")
+            logger.info(f"  $ gcloud compute ssh {vm_name} --zone={zone} --project={project}")
+
+        logger.info("")
         return True
-        
+
     except Exception as e:
-        logger.error(f"Unexpected error: {str(e)}")
+        error_msg = str(e)
+        suggestion = get_error_suggestion(error_msg)
+
+        if suggestion:
+            logger.error(suggestion.format(vm_name=vm_name, zone=zone, project=project))
+        else:
+            logger.error(f"Unexpected error: {error_msg}")
+
         if debug:
             logger.exception("Full traceback:")
+        logger.info("")
         return False
 
 

--- a/gce_rescue_v2/main.py
+++ b/gce_rescue_v2/main.py
@@ -57,14 +57,8 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
         debug=debug
     )
     
-    logger.info("=" * 60)
-    logger.info("GCE Rescue V2 - Rescue Mode")
-    logger.info("=" * 60)
-    logger.info(f"VM: {vm_name}")
-    logger.info(f"Zone: {zone}")
-    if project:
-        logger.info(f"Project: {project}")
-    logger.info("")
+    logger.debug(f"GCE Rescue V2 - Rescue")
+    logger.debug(f"VM: {vm_name}, Zone: {zone}" + (f", Project: {project}" if project else ""))
     
     try:
         # Initialize auth
@@ -87,26 +81,27 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
         )
         
         # Step 1: Validate
-        logger.info("")
         if not orchestrator.validate():
-            logger.error("")
             logger.error("Validation failed. Cannot proceed with rescue.")
             return False
-        
+
         # Step 2: Execute
-        logger.info("")
         if not orchestrator.execute():
-            logger.error("")
             logger.error("Rescue failed.")
             return False
-        
-        # Success! Show OS-appropriate instructions
+
+        # Success! Show output
         logger.info("")
-        logger.info("=" * 60)
-        logger.info("[OK] Rescue completed successfully!")
-        logger.info("=" * 60)
+        logger.info(f"Rescue mode enabled for instance [{vm_name}].")
         logger.info("")
-        logger.info("Your VM is now in rescue mode.")
+
+        # Show verification timeout warning if applicable
+        if not orchestrator.verification_succeeded:
+            logger.info("Note: Startup verification timed out. Check rescue logs:")
+            logger.info(f"  $ gcloud compute instances get-serial-port-output {vm_name} --zone={zone}")
+            logger.info("")
+
+        logger.info("Next Steps:")
 
         # Show OS-specific connection and mount instructions
         if orchestrator.os_type == OS_TYPE_WINDOWS:
@@ -119,43 +114,28 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
                         external_ip = access.get('natIP')
                         break
 
+            ip_str = external_ip if external_ip else "N/A"
+            logger.info("1. Connect via RDP:")
+            logger.info(f"   IP: {ip_str}")
+            logger.info(f"   User: rescue_admin")
+            logger.info(f"   Pass: {orchestrator.windows_rescue_password}")
             logger.info("")
-            logger.info("=" * 50)
-            logger.info("  Windows RDP Login Credentials")
-            logger.info("=" * 50)
-            if external_ip:
-                logger.info(f"  IP Address: {external_ip}")
-            logger.info(f"  Username:   rescue_admin")
-            logger.info(f"  Password:   {orchestrator.windows_rescue_password}")
-            logger.info("=" * 50)
+            logger.info("2. Fix the issue (affected disk is mounted at D:\\).")
             logger.info("")
-            logger.info("Note: Wait 2-3 minutes for Windows to fully boot before connecting.")
-            logger.info("")
-            logger.info("Affected disk mounted at: D:\\ (or next available drive letter)")
-            logger.info("")
-            logger.info("Check rescue logs inside VM:")
-            logger.info("  type C:\\gce-rescue.log")
-            logger.info("")
-            logger.info("Common Windows repair tasks:")
-            logger.info("  - Edit files: notepad D:\\path\\to\\file")
-            logger.info("  - Registry: Load hive from D:\\Windows\\System32\\config\\ in regedit")
-            logger.info("  - Boot repair: bcdboot D:\\Windows /s C:")
+            logger.info("3. Restore original configuration:")
+            logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone}")
         else:
-            logger.info(f"Connect via SSH: gcloud compute ssh {vm_name} --zone={zone}")
-            logger.info("Affected disk mounted at: /mnt/sysroot")
+            logger.info("1. Connect to the instance:")
+            logger.info(f"   $ gcloud compute ssh {vm_name} --zone={zone}")
             logger.info("")
-            logger.info("Check rescue logs inside VM:")
-            logger.info("  cat /var/log/gce-rescue.log")
-
-        logger.info("")
-        logger.info("When done, restore your VM:")
-        logger.info(f"  gce-rescue-v2 restore {vm_name} --zone={zone}")
-        logger.info("")
+            logger.info("2. Fix the issue (affected disk is mounted at /mnt/sysroot).")
+            logger.info("")
+            logger.info("3. Restore original configuration:")
+            logger.info(f"   $ gce-rescue-v2 restore {vm_name} --zone={zone}")
 
         return True
         
     except Exception as e:
-        logger.error("")
         logger.error(f"Unexpected error: {str(e)}")
         if debug:
             logger.exception("Full traceback:")
@@ -200,14 +180,8 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
         debug=debug
     )
     
-    logger.info("=" * 60)
-    logger.info("GCE Rescue V2 - Restore Mode")
-    logger.info("=" * 60)
-    logger.info(f"VM: {vm_name}")
-    logger.info(f"Zone: {zone}")
-    if project:
-        logger.info(f"Project: {project}")
-    logger.info("")
+    logger.debug(f"GCE Rescue V2 - Restore")
+    logger.debug(f"VM: {vm_name}, Zone: {zone}" + (f", Project: {project}" if project else ""))
     
     try:
         # Initialize auth
@@ -230,20 +204,16 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
         )
         
         # Step 1: Validate
-        logger.info("")
         if not orchestrator.validate():
-            logger.error("")
             logger.error("Validation failed. Cannot proceed with restore.")
             logger.error("Is the VM in rescue mode?")
             return False
-        
+
         # Step 2: Execute
-        logger.info("")
         if not orchestrator.execute():
-            logger.error("")
             logger.error("Restore failed.")
             return False
-        
+
         # Success! Show OS-appropriate instructions
         # Check metadata for OS type (stored during rescue)
         os_type = None
@@ -260,22 +230,17 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
             pass  # Default to Linux instructions if detection fails
 
         logger.info("")
-        logger.info("=" * 60)
-        logger.info("[OK] Restore completed successfully!")
-        logger.info("=" * 60)
+        logger.info(f"Instance [{vm_name}] restored to normal operation.")
         logger.info("")
-        logger.info("Your VM has been restored to normal operation.")
-
+        logger.info("Connect to the instance:")
         if os_type == OS_TYPE_WINDOWS:
-            logger.info(f"Connect via RDP: gcloud compute reset-windows-password {vm_name} --zone={zone}")
+            logger.info(f"  $ gcloud compute reset-windows-password {vm_name} --zone={zone}")
         else:
-            logger.info(f"Connect via SSH: gcloud compute ssh {vm_name} --zone={zone}")
-        logger.info("")
+            logger.info(f"  $ gcloud compute ssh {vm_name} --zone={zone}")
 
         return True
         
     except Exception as e:
-        logger.error("")
         logger.error(f"Unexpected error: {str(e)}")
         if debug:
             logger.exception("Full traceback:")

--- a/gce_rescue_v2/operations/__init__.py
+++ b/gce_rescue_v2/operations/__init__.py
@@ -40,6 +40,7 @@ from .detach_disk import DetachDiskOperation
 from .set_metadata import SetMetadataOperation
 from .delete_disk import DeleteDiskOperation
 from .create_snapshot import CreateSnapshotOperation
+from .verify_startup import VerifyStartupOperation
 
 __all__ = [
     # Base classes
@@ -55,4 +56,5 @@ __all__ = [
     'SetMetadataOperation',
     'DeleteDiskOperation',
     'CreateSnapshotOperation',
+    'VerifyStartupOperation',
 ]

--- a/gce_rescue_v2/operations/attach_disk.py
+++ b/gce_rescue_v2/operations/attach_disk.py
@@ -6,8 +6,13 @@ the disk using the provided rollback metadata.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, DISK_ATTACH_FAILED
+from ..core.config import VERSION
 
 
 class AttachDiskOperation(BaseOperation):
@@ -28,7 +33,7 @@ class AttachDiskOperation(BaseOperation):
         return "Attach Disk"
 
     def execute(self, vm_name: str, disk_name: str, boot: bool = False,
-                auto_delete: bool = False, read_only: bool = False) -> OperationResult:
+                auto_delete: bool = False, read_only: bool = False, tracking_label: str = None) -> OperationResult:
         """
         Attach a persistent disk to a VM instance.
 
@@ -38,6 +43,9 @@ class AttachDiskOperation(BaseOperation):
             boot (bool): Whether to mark the disk as a boot device.
             auto_delete (bool): Whether to auto-delete the disk with the VM.
             read_only (bool): Attach in read-only mode when True; read-write otherwise.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-disk-attach-rescue'
 
         Returns:
             OperationResult: Result containing success status, message, and
@@ -49,6 +57,8 @@ class AttachDiskOperation(BaseOperation):
 
         self._log_debug(f"Executing {self.name}: {disk_name} to {vm_name}")
         self._log_debug(f"  Boot: {boot}, AutoDelete: {auto_delete}, ReadOnly: {read_only}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Prepare attachment configuration
@@ -62,8 +72,10 @@ class AttachDiskOperation(BaseOperation):
 
             self._log_debug(f"Attaching with config: {attach_body}")
 
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
             # Attach the disk
-            operation = self.compute.instances().attachDisk(
+            operation = compute.instances().attachDisk(
                 project=self.project,
                 zone=self.zone,
                 instance=vm_name,
@@ -117,6 +129,43 @@ class AttachDiskOperation(BaseOperation):
                 message=f"Failed to attach disk: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-disk-attach-rescue'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/base.py
+++ b/gce_rescue_v2/operations/base.py
@@ -189,9 +189,9 @@ class BaseOperation(ABC):
         pass
 
     def _log_debug(self, message: str):
-        """Log debug message if logger available."""
+        """Log debug message with component prefix."""
         if self.logger:
-            self.logger.debug(message)
+            self.logger.debug(f"[{self.name}] {message}", stacklevel=2)
 
     def _log_info(self, message: str):
         """Log info message if logger available."""

--- a/gce_rescue_v2/operations/create_disk.py
+++ b/gce_rescue_v2/operations/create_disk.py
@@ -6,8 +6,13 @@ the disk that was created by this operation.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, DISK_CREATE_FAILED
+from ..core.config import VERSION
 
 
 class CreateDiskOperation(BaseOperation):
@@ -30,7 +35,7 @@ class CreateDiskOperation(BaseOperation):
     def execute(self, disk_name: str, size_gb: int = 10,
                 disk_type: str = 'pd-standard',
                 source_image: str = 'projects/debian-cloud/global/images/family/debian-12',
-                timeout: int = 300) -> OperationResult:
+                timeout: int = 300, tracking_label: str = None) -> OperationResult:
         """
         Create a new persistent disk from the specified image.
 
@@ -43,6 +48,9 @@ class CreateDiskOperation(BaseOperation):
                 (e.g., `projects/debian-cloud/global/images/family/debian-12`).
             timeout (int): Maximum seconds to wait for the disk to reach
                 status READY.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-disk-create-rescue'
 
         Returns:
             OperationResult: Result containing success flag, message, and
@@ -55,6 +63,8 @@ class CreateDiskOperation(BaseOperation):
         self._log_debug(f"Executing {self.name}: {disk_name}")
         self._log_debug(f"  Size: {size_gb}GB, Type: {disk_type}")
         self._log_debug(f"  Image: {source_image}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Prepare disk configuration
@@ -67,8 +77,10 @@ class CreateDiskOperation(BaseOperation):
 
             self._log_debug(f"Creating disk with config: {disk_body}")
 
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
             # Create the disk
-            self.compute.disks().insert(
+            compute.disks().insert(
                 project=self.project,
                 zone=self.zone,
                 body=disk_body
@@ -135,6 +147,43 @@ class CreateDiskOperation(BaseOperation):
                 message=f"Failed to create disk: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-disk-create-rescue'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/create_snapshot.py
+++ b/gce_rescue_v2/operations/create_snapshot.py
@@ -6,8 +6,13 @@ operations. Rollback removes only snapshots created by this operation.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, SNAPSHOT_CREATE_FAILED, SNAPSHOT_TIMEOUT
+from ..core.config import VERSION
 
 
 class CreateSnapshotOperation(BaseOperation):
@@ -28,7 +33,8 @@ class CreateSnapshotOperation(BaseOperation):
         return "Create Snapshot"
 
     def execute(self, disk_name: str, snapshot_name: str = None,
-                description: str = None, timeout: int = 600, wait: bool = True) -> OperationResult:
+                description: str = None, timeout: int = 600, wait: bool = True,
+                tracking_label: str = None) -> OperationResult:
         """
         Create a snapshot of the specified disk.
 
@@ -46,6 +52,9 @@ class CreateSnapshotOperation(BaseOperation):
                 Default is 600.
             wait (bool): Whether to wait for completion (synchronous). If
                 False, runs in async mode and returns immediately. Default True.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-disk-snapshot'
 
         Returns:
             OperationResult: Result object containing success flag, message,
@@ -68,6 +77,8 @@ class CreateSnapshotOperation(BaseOperation):
         self._log_debug(f"Executing {self.name}: {snapshot_name}")
         self._log_debug(f"  Disk: {disk_name}")
         self._log_debug(f"  Description: {description}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Create snapshot
@@ -78,7 +89,9 @@ class CreateSnapshotOperation(BaseOperation):
 
             self._log_debug(f"Creating snapshot with config: {body}")
 
-            self.compute.disks().createSnapshot(
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
+            compute.disks().createSnapshot(
                 project=self.project,
                 zone=self.zone,
                 disk=disk_name,
@@ -186,6 +199,43 @@ class CreateSnapshotOperation(BaseOperation):
                 message=f"Failed to create snapshot: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-disk-snapshot'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/delete_disk.py
+++ b/gce_rescue_v2/operations/delete_disk.py
@@ -6,8 +6,13 @@ irreversible and should only be used after completing the rescue workflow.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, DISK_DELETE_FAILED
+from ..core.config import VERSION
 
 
 class DeleteDiskOperation(BaseOperation):
@@ -26,12 +31,15 @@ class DeleteDiskOperation(BaseOperation):
         """
         return "Delete Disk"
 
-    def execute(self, disk_name: str) -> OperationResult:
+    def execute(self, disk_name: str, tracking_label: str = None) -> OperationResult:
         """
         Permanently delete a persistent disk.
 
         Args:
             disk_name (str): Name of the disk to delete.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'restore-disk-delete-rescue'
 
         Returns:
             OperationResult: Result with success status. `rollback_data` is
@@ -43,10 +51,14 @@ class DeleteDiskOperation(BaseOperation):
 
         self._log_debug(f"Executing {self.name}: {disk_name}")
         self._log_debug("WARNING: This operation cannot be rolled back!")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
             # Delete the disk
-            operation = self.compute.disks().delete(
+            operation = compute.disks().delete(
                 project=self.project,
                 zone=self.zone,
                 disk=disk_name
@@ -96,6 +108,43 @@ class DeleteDiskOperation(BaseOperation):
                 message=f"Failed to delete disk: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'restore-disk-delete-rescue'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/detach_disk.py
+++ b/gce_rescue_v2/operations/detach_disk.py
@@ -6,8 +6,13 @@ attaches the disk using the captured original configuration.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, DISK_DETACH_FAILED
+from ..core.config import VERSION
 
 
 class DetachDiskOperation(BaseOperation):
@@ -26,7 +31,7 @@ class DetachDiskOperation(BaseOperation):
         """
         return "Detach Disk"
 
-    def execute(self, vm_name: str, device_name: str) -> OperationResult:
+    def execute(self, vm_name: str, device_name: str, tracking_label: str = None) -> OperationResult:
         """
         Detach a disk from the specified VM instance.
 
@@ -34,6 +39,9 @@ class DetachDiskOperation(BaseOperation):
             vm_name (str): Name of the target VM instance.
             device_name (str): Device name of the disk to detach (e.g.,
                 the `deviceName` field from instance.disks[]).
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'restore-disk-detach-rescue'
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
@@ -44,6 +52,8 @@ class DetachDiskOperation(BaseOperation):
         """
 
         self._log_debug(f"Executing {self.name}: {device_name} from {vm_name}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Get current disk configuration for rollback
@@ -75,8 +85,10 @@ class DetachDiskOperation(BaseOperation):
 
             self._log_debug(f"Detaching disk: {disk_info}")
 
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
             # Detach the disk
-            operation = self.compute.instances().detachDisk(
+            operation = compute.instances().detachDisk(
                 project=self.project,
                 zone=self.zone,
                 instance=vm_name,
@@ -130,6 +142,43 @@ class DetachDiskOperation(BaseOperation):
                 message=f"Failed to detach disk: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'restore-disk-detach-rescue'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/set_metadata.py
+++ b/gce_rescue_v2/operations/set_metadata.py
@@ -50,7 +50,7 @@ class SetMetadataOperation(BaseOperation):
         """
         return "Set Metadata"
 
-    def execute(self, vm_name: str, metadata_items: list, preserve_existing: bool = True, operation_type: str = None) -> OperationResult:
+    def execute(self, vm_name: str, metadata_items: list, preserve_existing: bool = True, tracking_label: str = None) -> OperationResult:
         """
         Set metadata on the specified VM instance, preserving existing metadata.
 
@@ -65,8 +65,9 @@ class SetMetadataOperation(BaseOperation):
                 form {'key': str, 'value': str}.
             preserve_existing (bool): If True, merge with existing metadata
                 and backup conflicting keys. Default True.
-            operation_type (str): Operation type for tracking ('rescue' or 'restore').
-                Sets unique User-Agent for analytics.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-meta-set-rescue-keys'
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
@@ -75,8 +76,8 @@ class SetMetadataOperation(BaseOperation):
 
         self._log_debug(f"Executing {self.name} for {vm_name}")
         self._log_debug(f"  Setting {len(metadata_items)} metadata items (preserve_existing={preserve_existing})")
-        if operation_type:
-            self._log_debug(f"  Operation tracking: {operation_type}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Get current metadata for rollback
@@ -104,9 +105,9 @@ class SetMetadataOperation(BaseOperation):
                 'items': final_items
             }
 
-            # Use custom compute client with unique User-Agent if operation_type provided (for tracking)
-            if operation_type:
-                compute = self._create_tracked_client(operation_type)
+            # Use custom compute client with unique User-Agent if tracking_label provided (for tracking)
+            if tracking_label:
+                compute = self._create_tracked_client(tracking_label)
             else:
                 compute = self.compute
 
@@ -163,12 +164,13 @@ class SetMetadataOperation(BaseOperation):
                 error=error_detail
             )
 
-    def _create_tracked_client(self, operation_type: str):
+    def _create_tracked_client(self, tracking_label: str):
         """
         Create a compute client with unique User-Agent for usage tracking.
 
         Args:
-            operation_type: Operation type ('rescue' or 'restore')
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-meta-set-rescue-keys'
 
         Returns:
             Compute API client with custom User-Agent header
@@ -177,7 +179,8 @@ class SetMetadataOperation(BaseOperation):
         credentials = self.compute._http.credentials
 
         # Build unique User-Agent for tracking
-        user_agent = f'gce-rescue-{VERSION}-{operation_type}'
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
 
         def _request_builder(http, *args, **kwargs):
             """Inject custom User-Agent header."""

--- a/gce_rescue_v2/operations/set_metadata.py
+++ b/gce_rescue_v2/operations/set_metadata.py
@@ -6,8 +6,13 @@ by backing up conflicting keys with a prefix, and supports full restoration.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, METADATA_SET_FAILED
+from ..core.config import VERSION
 
 
 # Prefix used to backup original metadata keys that conflict with rescue keys
@@ -45,7 +50,7 @@ class SetMetadataOperation(BaseOperation):
         """
         return "Set Metadata"
 
-    def execute(self, vm_name: str, metadata_items: list, preserve_existing: bool = True) -> OperationResult:
+    def execute(self, vm_name: str, metadata_items: list, preserve_existing: bool = True, operation_type: str = None) -> OperationResult:
         """
         Set metadata on the specified VM instance, preserving existing metadata.
 
@@ -60,6 +65,8 @@ class SetMetadataOperation(BaseOperation):
                 form {'key': str, 'value': str}.
             preserve_existing (bool): If True, merge with existing metadata
                 and backup conflicting keys. Default True.
+            operation_type (str): Operation type for tracking ('rescue' or 'restore').
+                Sets unique User-Agent for analytics.
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
@@ -68,6 +75,8 @@ class SetMetadataOperation(BaseOperation):
 
         self._log_debug(f"Executing {self.name} for {vm_name}")
         self._log_debug(f"  Setting {len(metadata_items)} metadata items (preserve_existing={preserve_existing})")
+        if operation_type:
+            self._log_debug(f"  Operation tracking: {operation_type}")
 
         try:
             # Get current metadata for rollback
@@ -95,7 +104,13 @@ class SetMetadataOperation(BaseOperation):
                 'items': final_items
             }
 
-            operation = self.compute.instances().setMetadata(
+            # Use custom compute client with unique User-Agent if operation_type provided (for tracking)
+            if operation_type:
+                compute = self._create_tracked_client(operation_type)
+            else:
+                compute = self.compute
+
+            operation = compute.instances().setMetadata(
                 project=self.project,
                 zone=self.zone,
                 instance=vm_name,
@@ -147,6 +162,41 @@ class SetMetadataOperation(BaseOperation):
                 message=f"Failed to set metadata: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, operation_type: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            operation_type: Operation type ('rescue' or 'restore')
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        user_agent = f'gce-rescue/{VERSION} ({operation_type})'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def _merge_with_backup(self, original_items: list, new_items: list) -> list:
         """

--- a/gce_rescue_v2/operations/set_metadata.py
+++ b/gce_rescue_v2/operations/set_metadata.py
@@ -177,7 +177,7 @@ class SetMetadataOperation(BaseOperation):
         credentials = self.compute._http.credentials
 
         # Build unique User-Agent for tracking
-        user_agent = f'gce-rescue/{VERSION} ({operation_type})'
+        user_agent = f'gce-rescue-{VERSION}-{operation_type}'
 
         def _request_builder(http, *args, **kwargs):
             """Inject custom User-Agent header."""

--- a/gce_rescue_v2/operations/start_vm.py
+++ b/gce_rescue_v2/operations/start_vm.py
@@ -6,8 +6,13 @@ stops the VM only if it was previously stopped (TERMINATED) before execution.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, VM_START_TIMEOUT
+from ..core.config import VERSION
 
 
 class StartVMOperation(BaseOperation):
@@ -26,7 +31,7 @@ class StartVMOperation(BaseOperation):
         """
         return "Start VM"
 
-    def execute(self, vm_name: str, timeout: int = 300) -> OperationResult:
+    def execute(self, vm_name: str, timeout: int = 300, tracking_label: str = None) -> OperationResult:
         """
         Start the specified VM and wait until it is RUNNING.
 
@@ -34,6 +39,9 @@ class StartVMOperation(BaseOperation):
             vm_name (str): Name of the VM to start.
             timeout (int): Maximum seconds to wait for the VM to reach
                 RUNNING. Default is 300.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-vm-start'
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
@@ -44,6 +52,8 @@ class StartVMOperation(BaseOperation):
         """
 
         self._log_debug(f"Executing {self.name} for {vm_name}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Get current state
@@ -59,7 +69,9 @@ class StartVMOperation(BaseOperation):
             if original_status == 'TERMINATED':
                 self._log_debug("VM is TERMINATED, starting...")
 
-                self.compute.instances().start(
+                # Use tracked client if tracking_label provided
+                compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
+                compute.instances().start(
                     project=self.project,
                     zone=self.zone,
                     instance=vm_name
@@ -142,6 +154,43 @@ class StartVMOperation(BaseOperation):
                 message=f"Failed to start VM: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-vm-start'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/stop_vm.py
+++ b/gce_rescue_v2/operations/stop_vm.py
@@ -6,8 +6,13 @@ Rollback restarts the VM only if it was originally running prior to execution.
 """
 
 import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from .base import BaseOperation, OperationResult, extract_error_message
 from ..core.error_messages import get_error_suggestion, VM_STOP_TIMEOUT, VM_NOT_FOUND
+from ..core.config import VERSION
 
 
 class StopVMOperation(BaseOperation):
@@ -26,7 +31,7 @@ class StopVMOperation(BaseOperation):
         """
         return "Stop VM"
 
-    def execute(self, vm_name: str, timeout: int = 300, discard_local_ssd: bool = False) -> OperationResult:
+    def execute(self, vm_name: str, timeout: int = 300, discard_local_ssd: bool = False, tracking_label: str = None) -> OperationResult:
         """
         Stop the specified VM and wait until it is TERMINATED.
 
@@ -36,6 +41,9 @@ class StopVMOperation(BaseOperation):
                 TERMINATED. Default is 300.
             discard_local_ssd (bool): If True, allows stopping VMs with Local SSDs
                 attached (data on Local SSDs will be lost). Default is False.
+            tracking_label (str): Tracking label for usage analytics.
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-vm-stop'
 
         Returns:
             OperationResult: Result including `rollback_data` with `vm_name`
@@ -46,6 +54,8 @@ class StopVMOperation(BaseOperation):
         """
 
         self._log_debug(f"Executing {self.name} for {vm_name}")
+        if tracking_label:
+            self._log_debug(f"  Operation tracking: {tracking_label}")
 
         try:
             # Step 1: Get current VM state (for rollback)
@@ -75,7 +85,9 @@ class StopVMOperation(BaseOperation):
                     stop_params['discardLocalSsd'] = True
                     self._log_debug("Using discardLocalSsd=True for Local SSD VM")
 
-                self.compute.instances().stop(**stop_params).execute()
+                # Use tracked client if tracking_label provided
+                compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
+                compute.instances().stop(**stop_params).execute()
 
                 # Step 3: Wait for VM to stop
                 self._log_debug("Waiting for VM to stop...")
@@ -160,6 +172,43 @@ class StopVMOperation(BaseOperation):
                 message=f"Failed to stop VM: {error_msg}",
                 error=error_detail
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-vm-stop'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/operations/verify_startup.py
+++ b/gce_rescue_v2/operations/verify_startup.py
@@ -1,0 +1,165 @@
+"""
+Verify Startup Script operation.
+
+Polls VM serial console output for completion marker to verify
+startup script executed successfully.
+"""
+
+import time
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
+from .base import BaseOperation, OperationResult, extract_error_message
+from ..core.config import VERSION
+
+
+class VerifyStartupOperation(BaseOperation):
+    """
+    Operation that verifies startup script completion via serial console.
+
+    Polls instances().getSerialPortOutput() for completion marker.
+    Returns success only if marker found within timeout period.
+
+    No rollback needed - this is a read-only verification operation.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Verify Startup Script"
+
+    def execute(self, vm_name: str, completion_marker: str = "GCE-RESCUE-COMPLETE",
+                timeout: int = 120, tracking_label: str = None) -> OperationResult:
+        """
+        Verify startup script completion by polling serial console.
+
+        Args:
+            vm_name: VM instance name
+            completion_marker: String to search for in serial output
+            timeout: Maximum seconds to wait (default: 120)
+            tracking_label: Optional tracking label for analytics
+
+        Returns:
+            OperationResult with success=True if marker found, False if timeout
+        """
+
+        self._log_debug(f"Executing {self.name} for {vm_name}")
+        self._log_debug(f"  Looking for marker: {completion_marker}")
+        self._log_debug(f"  Timeout: {timeout}s")
+
+        start_time = time.time()
+        poll_interval = 5  # Poll every 5 seconds (consistent with V2 patterns)
+
+        try:
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
+
+            while True:
+                elapsed = time.time() - start_time
+
+                # Check timeout
+                if elapsed > timeout:
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message=f"Timeout waiting for startup script ({timeout}s)",
+                        error=f"Startup script did not complete within {timeout}s"
+                    )
+
+                # Poll serial console
+                try:
+                    result = compute.instances().getSerialPortOutput(
+                        project=self.project,
+                        zone=self.zone,
+                        instance=vm_name
+                    ).execute()
+
+                    contents = result.get('contents', '')
+
+                    # Check for completion marker
+                    if completion_marker in contents:
+                        duration = time.time() - start_time
+                        self._log_debug(f"Startup script completed in {duration:.1f}s")
+
+                        return OperationResult(
+                            operation_name=self.name,
+                            success=True,
+                            message=f"Startup script completed ({duration:.0f}s)",
+                            rollback_data=None  # No rollback needed for verification
+                        )
+
+                    # Log progress
+                    self._log_debug(f"  Waiting for startup script... ({elapsed:.0f}s/{timeout}s)")
+
+                except Exception as e:
+                    # Serial console might be temporarily unavailable
+                    self._log_debug(f"  Serial console check error (will retry): {str(e)}")
+
+                # Wait before next poll
+                time.sleep(poll_interval)
+
+        except Exception as e:
+            # Catch-all for unexpected errors
+            error_msg = extract_error_message(e)
+
+            # Check if serial console is disabled
+            if "Serial port output is not enabled" in error_msg or "403" in str(e):
+                # Return SUCCESS with warning - don't fail the operation
+                return OperationResult(
+                    operation_name=self.name,
+                    success=True,
+                    message="Completed (manual verification required - serial console disabled)",
+                    rollback_data=None
+                )
+
+            self._log_error(f"Unexpected error: {error_msg}")
+            return OperationResult(
+                operation_name=self.name,
+                success=False,
+                message=f"Verification failed: {error_msg}",
+                error=error_msg
+            )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-vm-verify-startup'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
+
+    def rollback(self, rollback_data: dict) -> bool:
+        """
+        No rollback needed for verification operation.
+        This is a read-only check.
+        """
+        return True

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -126,8 +126,9 @@ class RescueOrchestrator:
         import logging
         import threading
 
-        # Check if we're in debug mode
-        self._is_debug_mode = self.logger and self.logger.level <= logging.DEBUG
+        # Check if we're in debug mode (use console_level if available, fallback to logger.level)
+        console_level = getattr(self.logger, 'console_level', self.logger.level) if self.logger else logging.INFO
+        self._is_debug_mode = console_level <= logging.DEBUG
         self._progress_phases = []
         self._progress_lock = threading.Lock()
 

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -25,7 +25,8 @@ from ..operations import (
     AttachDiskOperation,
     SetMetadataOperation,
     StartVMOperation,
-    CreateSnapshotOperation
+    CreateSnapshotOperation,
+    VerifyStartupOperation
 )
 from .state import StateTracker
 from .rollback import RollbackHandler
@@ -102,15 +103,100 @@ class RescueOrchestrator:
         # Windows rescue credentials (generated for RDP access)
         self.windows_rescue_password = None
 
+        # Verification status (set after startup verification)
+        self.verification_succeeded = None
+
+        # Progress tracking for spinner with phases
+        self._spinner_thread = None
+        self._spinner_stop = False
+        self._is_debug_mode = False
+        self._progress_started = False
+        self._progress_phases = []
+        self._progress_lock = None
+
+    def _init_progress(self):
+        """Initialize spinner with phases display."""
+        import sys
+        import logging
+        import threading
+
+        # Check if we're in debug mode
+        self._is_debug_mode = self.logger and self.logger.level <= logging.DEBUG
+        self._progress_phases = []
+        self._progress_lock = threading.Lock()
+
+        if not self._is_debug_mode:
+            # Start spinner thread
+            self._spinner_stop = False
+            self._spinner_thread = threading.Thread(target=self._run_spinner, daemon=True)
+            self._spinner_thread.start()
+
+        self._progress_started = True
+
+    def _run_spinner(self):
+        """Run spinner animation with phases in background thread."""
+        import sys
+        import time
+
+        spinner_chars = ['|', '/', '-', '\\']
+        idx = 0
+
+        while not self._spinner_stop:
+            with self._progress_lock:
+                if self._progress_phases:
+                    # Show completed phases, then current phase with dots and spinner
+                    completed = self._progress_phases[:-1]
+                    current = self._progress_phases[-1]
+                    if completed:
+                        phases_str = " -> ".join(completed) + " -> " + current + ".." + spinner_chars[idx]
+                    else:
+                        phases_str = current + ".." + spinner_chars[idx]
+                else:
+                    phases_str = spinner_chars[idx]
+
+            line = f"\rRescuing {self.vm_name} [{phases_str}"
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            idx = (idx + 1) % len(spinner_chars)
+            time.sleep(0.1)
+
+    def _update_progress(self, phase: str):
+        """Add a new phase to the progress display."""
+        with self._progress_lock:
+            self._progress_phases.append(phase)
+        self._log_debug(f"Phase: {phase}")
+
+    def _finish_progress(self, success: bool = True):
+        """Finish spinner display with final status."""
+        import sys
+
+        if not self._progress_started:
+            return
+
+        # Stop spinner thread
+        self._spinner_stop = True
+        if self._spinner_thread:
+            self._spinner_thread.join(timeout=0.5)
+
+        if not self._is_debug_mode:
+            with self._progress_lock:
+                phases_str = " -> ".join(self._progress_phases)
+
+            if success:
+                sys.stdout.write(f"\rRescuing {self.vm_name} [{phases_str}] done.\n")
+            else:
+                sys.stdout.write(f"\rRescuing {self.vm_name} [{phases_str}] FAILED.\n")
+            sys.stdout.flush()
+
     def _log_info(self, message: str):
         """Log info message."""
         if self.logger:
             self.logger.info(message)
 
     def _log_debug(self, message: str):
-        """Log debug message."""
+        """Log debug message with component prefix."""
         if self.logger:
-            self.logger.debug(message)
+            self.logger.debug(f"[Rescue] {message}", stacklevel=2)
 
     def _log_error(self, message: str):
         """Log error message."""
@@ -131,7 +217,9 @@ class RescueOrchestrator:
             True if all validations passed
         """
 
-        self._log_info("Pre-flight Validation:")
+        # Initialize progress and start with validation phase
+        self._init_progress()
+        self._update_progress("validating")
         self._log_debug("Creating validation runner")
 
         runner = ValidationRunner()
@@ -146,8 +234,7 @@ class RescueOrchestrator:
         results = runner.run_all(self.logger)
 
         if not results.all_passed():
-            self._log_error("")
-            self._log_error("Pre-flight validation failed!")
+            self._finish_progress(False)
             results.print_failures()
             return False
 
@@ -172,8 +259,7 @@ class RescueOrchestrator:
             True if rescue succeeded, False if failed
         """
 
-        self._log_info("")
-        self._log_info("Executing Rescue:")
+        self._log_debug(f"Rescuing instance '{self.vm_name}'...")
         self._log_debug(f"Config: {self.config}")
 
         try:
@@ -196,32 +282,34 @@ class RescueOrchestrator:
 
             # Build operations map for rollback (in execution order)
             self.operations_map = {
-                "Stop VM": stop_vm,                       # Step 1
-                "Detach Boot Disk": detach_boot,          # Step 2
-                "Create Snapshot": create_snapshot,       # Step 3
-                "Create Rescue Disk": create_disk,        # Step 4
-                "Attach Rescue Disk": attach_rescue,      # Step 5
-                "Set Metadata": set_metadata,             # Step 6
-                "Start VM": start_vm,                     # Step 7
-                "Attach Original Disk": attach_original   # Step 9
+                "Stop VM": stop_vm,
+                "Detach Boot Disk": detach_boot,
+                "Create Snapshot": create_snapshot,
+                "Create Rescue Disk": create_disk,
+                "Attach Rescue Disk": attach_rescue,
+                "Set Metadata": set_metadata,
+                "Start VM": start_vm,
+                "Attach Original Disk": attach_original
             }
 
             # Step 1: Stop VM
-            self._log_info("  Stopping VM...")
+            self._update_progress("stopping")
+            self._log_debug(f"Stopping instance {self.vm_name}...")
             result = stop_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_stop_timeout,
-                discard_local_ssd=self.config.force,  # Allow stopping VMs with Local SSDs if --force
+                discard_local_ssd=self.config.force,
                 tracking_label='rescue-vm-stop'
             )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
-            # Step 2: Detach boot disk (EARLY - enables snapshot immediately)
-            self._log_info("  Detaching boot disk...")
+            # Step 2: Detach boot disk
+            self._update_progress("creating rescue disk")
+            self._log_debug("Detaching boot disk...")
             result = detach_boot.execute(
                 vm_name=self.vm_name,
                 device_name=self.original_device_name,
@@ -229,57 +317,43 @@ class RescueOrchestrator:
             )
             self.state_tracker.add_operation("Detach Boot Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
-            # Step 3: Create safety snapshot (immediately after detach)
-            # Track snapshot name for later wait
+            # Step 3: Create safety snapshot
             pending_snapshot_name = None
             if self.config.create_snapshot:
-                if self.config.async_snapshot:
-                    self._log_info("  Creating safety snapshot (async - will wait before attaching disk)...")
-                else:
-                    self._log_info("  Creating safety snapshot...")
-                    self._log_info("    (This takes 2-5 minutes but ensures data safety)")
-
+                self._log_debug("Creating snapshot...")
                 result = create_snapshot.execute(
                     disk_name=self.original_disk_name,
-                    snapshot_name=None,  # Auto-generate
+                    snapshot_name=None,
                     description=f"Pre-rescue safety snapshot of {self.vm_name}",
                     timeout=self.config.snapshot_timeout,
-                    wait=not self.config.async_snapshot,  # Don't wait if async mode
+                    wait=not self.config.async_snapshot,
                     tracking_label='rescue-disk-snapshot'
                 )
                 self.state_tracker.add_operation("Create Snapshot", result.success, result.message, result.rollback_data)
 
                 if not result.success:
-                    self._log_error("  Failed to create safety snapshot")
                     if self.config.require_snapshot:
-                        self._log_error("  Snapshot required but failed. Aborting.")
+                        self._finish_progress(False)
                         self._rollback()
                         return False
-                    else:
-                        self._log_error("  Continuing without snapshot (risky!)")
                 else:
                     pending_snapshot_name = result.rollback_data.get('snapshot_name')
-                    self._log_info(f"  [OK] {result.message}")
-                    if not self.config.async_snapshot:
-                        self._log_info(f"    Snapshot: {pending_snapshot_name}")
 
-            # Step 4: Create rescue disk (runs while snapshot progresses in background)
-            # Select rescue image based on OS type
+            # Step 4: Create rescue disk
             if self.os_type == OS_TYPE_WINDOWS:
                 rescue_image_project = self.config.windows_rescue_image_project
                 rescue_image_family = self.config.windows_rescue_image_family
                 rescue_disk_size = self.config.windows_rescue_disk_size_gb
-                self._log_info(f"  Creating Windows rescue disk ({rescue_disk_size}GB)...")
             else:
                 rescue_image_project = self.config.rescue_image_project
                 rescue_image_family = self.config.rescue_image_family
                 rescue_disk_size = self.config.rescue_disk_size_gb
-                self._log_info(f"  Creating Linux rescue disk ({rescue_disk_size}GB)...")
 
+            self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB)...")
             result = create_disk.execute(
                 disk_name=rescue_disk_name,
                 size_gb=rescue_disk_size,
@@ -290,12 +364,12 @@ class RescueOrchestrator:
             )
             self.state_tracker.add_operation("Create Rescue Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 5: Attach rescue disk as boot
-            self._log_info("  Attaching rescue disk as boot...")
+            self._log_debug("Attaching rescue disk as boot...")
             result = attach_rescue.execute(
                 vm_name=self.vm_name,
                 disk_name=rescue_disk_name,
@@ -304,15 +378,14 @@ class RescueOrchestrator:
             )
             self.state_tracker.add_operation("Attach Rescue Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 6: Set rescue metadata
-            self._log_info("  Setting rescue metadata...")
+            self._log_debug("Setting rescue metadata...")
             startup_script = self._generate_startup_script()
 
-            # Use appropriate startup script key based on OS type
             if self.os_type == OS_TYPE_WINDOWS:
                 script_key = 'windows-startup-script-ps1'
             else:
@@ -331,12 +404,13 @@ class RescueOrchestrator:
             )
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 7: Start VM in rescue mode
-            self._log_info("  Starting VM in rescue mode...")
+            self._update_progress("starting")
+            self._log_debug(f"Starting instance {self.vm_name}...")
             result = start_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_start_timeout,
@@ -344,26 +418,38 @@ class RescueOrchestrator:
             )
             self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
-            # Step 8: Wait for snapshot completion (if async mode)
+            # Step 8: Verify startup script completion
+            self._update_progress("verifying")
+            self._log_debug("Verifying startup script...")
+            verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
+            result = verify_startup.execute(
+                vm_name=self.vm_name,
+                timeout=self.config.startup_verification_timeout,
+                tracking_label='rescue-vm-verify-startup'
+            )
+            self.verification_succeeded = result.success
+            # Don't fail on verification timeout - continue
+
+            # Wait for snapshot completion (if async mode) - not a numbered step
             if pending_snapshot_name and self.config.async_snapshot:
-                self._log_info("  Waiting for snapshot to complete...")
+                self._log_debug("Waiting for async snapshot to complete...")
                 snapshot_start_time = time.time()
                 snapshot_timeout = self.config.snapshot_timeout
 
                 while True:
                     elapsed = time.time() - snapshot_start_time
                     if elapsed > snapshot_timeout:
-                        self._log_error(f"  Snapshot timeout after {snapshot_timeout}s")
+                        self._log_debug(f"Snapshot timeout after {snapshot_timeout}s")
                         if self.config.require_snapshot:
-                            self._log_error("  Snapshot required but timed out. Aborting.")
+                            self._log_error("Snapshot required but timed out. Aborting.")
                             self._rollback()
                             return False
                         else:
-                            self._log_error("  Continuing without verified snapshot (risky!)")
+                            self._log_debug("Continuing without verified snapshot.")
                             break
 
                     try:
@@ -375,24 +461,24 @@ class RescueOrchestrator:
                         status = snapshot.get('status', 'UNKNOWN')
 
                         if status == 'READY':
-                            self._log_info(f"  [OK] Snapshot ready: {pending_snapshot_name}")
+                            self._log_debug(f"Snapshot ready: {pending_snapshot_name}")
                             break
                         elif status == 'FAILED':
-                            self._log_error(f"  Snapshot failed: {pending_snapshot_name}")
+                            self._log_debug(f"Snapshot failed: {pending_snapshot_name}")
                             if self.config.require_snapshot:
                                 self._rollback()
                                 return False
                             break
                         else:
                             # Still creating, show progress
-                            self._log_debug(f"    Snapshot status: {status} ({elapsed:.0f}s)")
+                            self._log_debug(f"Snapshot status: {status} ({elapsed:.0f}s)")
                     except Exception as e:
-                        self._log_debug(f"    Checking snapshot... ({elapsed:.0f}s)")
+                        self._log_debug(f"Checking snapshot... ({elapsed:.0f}s)")
 
                     time.sleep(5)
 
             # Step 9: Re-attach original disk as secondary
-            self._log_info("  Attaching affected disk as secondary...")
+            self._log_debug("Attaching affected disk as secondary...")
             time.sleep(5)  # Brief wait for VM stability
             result = attach_original.execute(
                 vm_name=self.vm_name,
@@ -402,14 +488,16 @@ class RescueOrchestrator:
             )
             self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Success!
+            self._finish_progress(True)
             return True
 
         except Exception as e:
+            self._finish_progress(False)
             self._log_error(f"Unexpected error during rescue: {str(e)}")
             self._rollback()
             return False
@@ -424,7 +512,7 @@ class RescueOrchestrator:
 
         # Detect OS type
         self.os_type = detect_os_type(self.vm_info)
-        self._log_info(f"  Detected OS: {get_os_display_name(self.os_type)}")
+        self._log_debug(f"Detected OS: {get_os_display_name(self.os_type)}")
 
         for disk in self.vm_info.get('disks', []):
             if disk.get('boot'):

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -136,10 +136,10 @@ class RescueOrchestrator:
 
         runner = ValidationRunner()
 
-        # Add validators
+        # Add validators with tracking labels
         runner.add(CredentialsValidator(self.compute, self.project, self.zone))
-        runner.add(IAMPermissionsValidator(self.compute, self.project, self.zone, self.vm_name))
-        vm_validator = VMStateValidator(self.compute, self.project, self.zone, self.vm_name)
+        runner.add(IAMPermissionsValidator(self.compute, self.project, self.zone, self.vm_name, tracking_label='rescue-val-iam'))
+        vm_validator = VMStateValidator(self.compute, self.project, self.zone, self.vm_name, tracking_label='rescue-val-vm-state')
         runner.add(vm_validator)
 
         # Run validations

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -211,7 +211,8 @@ class RescueOrchestrator:
             result = stop_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_stop_timeout,
-                discard_local_ssd=self.config.force  # Allow stopping VMs with Local SSDs if --force
+                discard_local_ssd=self.config.force,  # Allow stopping VMs with Local SSDs if --force
+                tracking_label='rescue-vm-stop'
             )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:
@@ -221,7 +222,11 @@ class RescueOrchestrator:
 
             # Step 2: Detach boot disk (EARLY - enables snapshot immediately)
             self._log_info("  Detaching boot disk...")
-            result = detach_boot.execute(vm_name=self.vm_name, device_name=self.original_device_name)
+            result = detach_boot.execute(
+                vm_name=self.vm_name,
+                device_name=self.original_device_name,
+                tracking_label='rescue-disk-detach-orig'
+            )
             self.state_tracker.add_operation("Detach Boot Disk", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -243,7 +248,8 @@ class RescueOrchestrator:
                     snapshot_name=None,  # Auto-generate
                     description=f"Pre-rescue safety snapshot of {self.vm_name}",
                     timeout=self.config.snapshot_timeout,
-                    wait=not self.config.async_snapshot  # Don't wait if async mode
+                    wait=not self.config.async_snapshot,  # Don't wait if async mode
+                    tracking_label='rescue-disk-snapshot'
                 )
                 self.state_tracker.add_operation("Create Snapshot", result.success, result.message, result.rollback_data)
 
@@ -279,7 +285,8 @@ class RescueOrchestrator:
                 size_gb=rescue_disk_size,
                 disk_type=self.config.rescue_disk_type,
                 source_image=f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}',
-                timeout=self.config.disk_create_timeout
+                timeout=self.config.disk_create_timeout,
+                tracking_label='rescue-disk-create-rescue'
             )
             self.state_tracker.add_operation("Create Rescue Disk", result.success, result.message, result.rollback_data)
             if not result.success:
@@ -289,7 +296,12 @@ class RescueOrchestrator:
 
             # Step 5: Attach rescue disk as boot
             self._log_info("  Attaching rescue disk as boot...")
-            result = attach_rescue.execute(vm_name=self.vm_name, disk_name=rescue_disk_name, boot=True)
+            result = attach_rescue.execute(
+                vm_name=self.vm_name,
+                disk_name=rescue_disk_name,
+                boot=True,
+                tracking_label='rescue-disk-attach-rescue'
+            )
             self.state_tracker.add_operation("Attach Rescue Disk", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -315,7 +327,7 @@ class RescueOrchestrator:
             result = set_metadata.execute(
                 vm_name=self.vm_name,
                 metadata_items=metadata_items,
-                operation_type='rescue'  # For usage tracking
+                tracking_label='rescue-meta-set-rescue-keys'
             )
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
@@ -325,7 +337,11 @@ class RescueOrchestrator:
 
             # Step 7: Start VM in rescue mode
             self._log_info("  Starting VM in rescue mode...")
-            result = start_vm.execute(vm_name=self.vm_name, timeout=self.config.vm_start_timeout)
+            result = start_vm.execute(
+                vm_name=self.vm_name,
+                timeout=self.config.vm_start_timeout,
+                tracking_label='rescue-vm-start'
+            )
             self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -378,7 +394,12 @@ class RescueOrchestrator:
             # Step 9: Re-attach original disk as secondary
             self._log_info("  Attaching affected disk as secondary...")
             time.sleep(5)  # Brief wait for VM stability
-            result = attach_original.execute(vm_name=self.vm_name, disk_name=self.original_disk_name, boot=False)
+            result = attach_original.execute(
+                vm_name=self.vm_name,
+                disk_name=self.original_disk_name,
+                boot=False,
+                tracking_label='rescue-disk-attach-orig'
+            )
             self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -312,7 +312,11 @@ class RescueOrchestrator:
                 {'key': 'rescue-original-disk', 'value': self.original_disk_name},
                 {'key': 'rescue-os-type', 'value': self.os_type}
             ]
-            result = set_metadata.execute(vm_name=self.vm_name, metadata_items=metadata_items)
+            result = set_metadata.execute(
+                vm_name=self.vm_name,
+                metadata_items=metadata_items,
+                operation_type='rescue'  # For usage tracking
+            )
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -119,6 +119,7 @@ class RescueOrchestrator:
         self._progress_started = False
         self._progress_phases = []
         self._progress_lock = None
+        self._total_steps = 5  # Stopping, Snapshotting, Creating rescue disk, Starting, Attaching
 
     def _init_progress(self):
         """Initialize spinner with phases display."""
@@ -153,6 +154,7 @@ class RescueOrchestrator:
 
         while not self._spinner_stop:
             with self._progress_lock:
+                current_step = len(self._progress_phases)
                 if self._progress_phases:
                     # Show completed phases, then current phase with dots and spinner
                     completed = self._progress_phases[:-1]
@@ -164,7 +166,7 @@ class RescueOrchestrator:
                 else:
                     phases_str = spinner_chars[idx]
 
-            line = f"\r [{phases_str}"
+            line = f"\r ({current_step}/{self._total_steps}) [{phases_str}"
             sys.stdout.write(line)
             sys.stdout.flush()
             idx = (idx + 1) % len(spinner_chars)
@@ -191,11 +193,12 @@ class RescueOrchestrator:
         if not self._is_debug_mode:
             with self._progress_lock:
                 phases_str = " -> ".join(self._progress_phases)
+                current_step = len(self._progress_phases)
 
             if success:
-                sys.stdout.write(f"\r [{phases_str}] done.\n")
+                sys.stdout.write(f"\r ({self._total_steps}/{self._total_steps}) [{phases_str}] done.\n")
             else:
-                sys.stdout.write(f"\r [{phases_str}] FAILED.\n")
+                sys.stdout.write(f"\r ({current_step}/{self._total_steps}) [{phases_str}] FAILED.\n")
             sys.stdout.flush()
 
     def _log_info(self, message: str):

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -106,6 +106,12 @@ class RescueOrchestrator:
         # Verification status (set after startup verification)
         self.verification_succeeded = None
 
+        # Snapshot name (set if snapshot created successfully)
+        self.snapshot_name = None
+
+        # Rescue disk name (set during execution)
+        self.rescue_disk_name = None
+
         # Progress tracking for spinner with phases
         self._spinner_thread = None
         self._spinner_stop = False
@@ -126,6 +132,9 @@ class RescueOrchestrator:
         self._progress_lock = threading.Lock()
 
         if not self._is_debug_mode:
+            # Print header line
+            sys.stdout.write(f"Rescuing instance [{self.vm_name}]:\n")
+            sys.stdout.flush()
             # Start spinner thread
             self._spinner_stop = False
             self._spinner_thread = threading.Thread(target=self._run_spinner, daemon=True)
@@ -154,7 +163,7 @@ class RescueOrchestrator:
                 else:
                     phases_str = spinner_chars[idx]
 
-            line = f"\rRescuing {self.vm_name} [{phases_str}"
+            line = f"\r [{phases_str}"
             sys.stdout.write(line)
             sys.stdout.flush()
             idx = (idx + 1) % len(spinner_chars)
@@ -183,9 +192,9 @@ class RescueOrchestrator:
                 phases_str = " -> ".join(self._progress_phases)
 
             if success:
-                sys.stdout.write(f"\rRescuing {self.vm_name} [{phases_str}] done.\n")
+                sys.stdout.write(f"\r [{phases_str}] done.\n")
             else:
-                sys.stdout.write(f"\rRescuing {self.vm_name} [{phases_str}] FAILED.\n")
+                sys.stdout.write(f"\r [{phases_str}] FAILED.\n")
             sys.stdout.flush()
 
     def _log_info(self, message: str):
@@ -217,9 +226,6 @@ class RescueOrchestrator:
             True if all validations passed
         """
 
-        # Initialize progress and start with validation phase
-        self._init_progress()
-        self._update_progress("validating")
         self._log_debug("Creating validation runner")
 
         runner = ValidationRunner()
@@ -234,7 +240,6 @@ class RescueOrchestrator:
         results = runner.run_all(self.logger)
 
         if not results.all_passed():
-            self._finish_progress(False)
             results.print_failures()
             return False
 
@@ -262,9 +267,13 @@ class RescueOrchestrator:
         self._log_debug(f"Rescuing instance '{self.vm_name}'...")
         self._log_debug(f"Config: {self.config}")
 
+        # Initialize progress display
+        self._init_progress()
+
         try:
             # Generate rescue disk name
             rescue_disk_name = f"rescue-disk-{int(time.time())}"
+            self.rescue_disk_name = rescue_disk_name  # Store for output
             self._log_debug(f"Rescue disk name: {rescue_disk_name}")
 
             # Get original disk info
@@ -293,7 +302,7 @@ class RescueOrchestrator:
             }
 
             # Step 1: Stop VM
-            self._update_progress("stopping")
+            self._update_progress("Stopping")
             self._log_debug(f"Stopping instance {self.vm_name}...")
             result = stop_vm.execute(
                 vm_name=self.vm_name,
@@ -308,7 +317,6 @@ class RescueOrchestrator:
                 return False
 
             # Step 2: Detach boot disk
-            self._update_progress("creating rescue disk")
             self._log_debug("Detaching boot disk...")
             result = detach_boot.execute(
                 vm_name=self.vm_name,
@@ -324,6 +332,7 @@ class RescueOrchestrator:
             # Step 3: Create safety snapshot
             pending_snapshot_name = None
             if self.config.create_snapshot:
+                self._update_progress("Snapshotting")
                 self._log_debug("Creating snapshot...")
                 result = create_snapshot.execute(
                     disk_name=self.original_disk_name,
@@ -342,8 +351,10 @@ class RescueOrchestrator:
                         return False
                 else:
                     pending_snapshot_name = result.rollback_data.get('snapshot_name')
+                    self.snapshot_name = pending_snapshot_name  # Store for output
 
             # Step 4: Create rescue disk
+            self._update_progress("Creating rescue disk")
             if self.os_type == OS_TYPE_WINDOWS:
                 rescue_image_project = self.config.windows_rescue_image_project
                 rescue_image_family = self.config.windows_rescue_image_family
@@ -409,7 +420,7 @@ class RescueOrchestrator:
                 return False
 
             # Step 7: Start VM in rescue mode
-            self._update_progress("starting")
+            self._update_progress("Starting")
             self._log_debug(f"Starting instance {self.vm_name}...")
             result = start_vm.execute(
                 vm_name=self.vm_name,
@@ -421,18 +432,6 @@ class RescueOrchestrator:
                 self._finish_progress(False)
                 self._rollback()
                 return False
-
-            # Step 8: Verify startup script completion
-            self._update_progress("verifying")
-            self._log_debug("Verifying startup script...")
-            verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
-            result = verify_startup.execute(
-                vm_name=self.vm_name,
-                timeout=self.config.startup_verification_timeout,
-                tracking_label='rescue-vm-verify-startup'
-            )
-            self.verification_succeeded = result.success
-            # Don't fail on verification timeout - continue
 
             # Wait for snapshot completion (if async mode) - not a numbered step
             if pending_snapshot_name and self.config.async_snapshot:
@@ -477,8 +476,8 @@ class RescueOrchestrator:
 
                     time.sleep(5)
 
-            # Step 9: Re-attach original disk as secondary
-            self._log_debug("Attaching affected disk as secondary...")
+            # Step 8: Re-attach original disk as secondary
+            self._log_debug("Attaching original boot disk as secondary...")
             time.sleep(5)  # Brief wait for VM stability
             result = attach_original.execute(
                 vm_name=self.vm_name,
@@ -491,6 +490,18 @@ class RescueOrchestrator:
                 self._finish_progress(False)
                 self._rollback()
                 return False
+
+            # Step 9: Verify startup script completion (disk mounting)
+            self._update_progress("Attaching affected disk")
+            self._log_debug("Verifying startup script...")
+            verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
+            result = verify_startup.execute(
+                vm_name=self.vm_name,
+                timeout=self.config.startup_verification_timeout,
+                tracking_label='rescue-vm-verify-startup'
+            )
+            self.verification_succeeded = result.success
+            # Don't fail on verification timeout - continue
 
             # Success!
             self._finish_progress(True)

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -92,15 +92,97 @@ class RestoreOrchestrator:
         self.original_disk_name = None
         self.original_device_name = None
 
+        # Progress tracking for spinner with phases
+        self._spinner_thread = None
+        self._spinner_stop = False
+        self._is_debug_mode = False
+        self._progress_started = False
+        self._progress_phases = []
+        self._progress_lock = None
+
+    def _init_progress(self):
+        """Initialize spinner with phases display."""
+        import sys
+        import logging
+        import threading
+
+        # Check if we're in debug mode
+        self._is_debug_mode = self.logger and self.logger.level <= logging.DEBUG
+        self._progress_phases = []
+        self._progress_lock = threading.Lock()
+
+        if not self._is_debug_mode:
+            # Start spinner thread
+            self._spinner_stop = False
+            self._spinner_thread = threading.Thread(target=self._run_spinner, daemon=True)
+            self._spinner_thread.start()
+
+        self._progress_started = True
+
+    def _run_spinner(self):
+        """Run spinner animation with phases in background thread."""
+        import sys
+        import time
+
+        spinner_chars = ['|', '/', '-', '\\']
+        idx = 0
+
+        while not self._spinner_stop:
+            with self._progress_lock:
+                if self._progress_phases:
+                    # Show completed phases, then current phase with dots and spinner
+                    completed = self._progress_phases[:-1]
+                    current = self._progress_phases[-1]
+                    if completed:
+                        phases_str = " -> ".join(completed) + " -> " + current + ".." + spinner_chars[idx]
+                    else:
+                        phases_str = current + ".." + spinner_chars[idx]
+                else:
+                    phases_str = spinner_chars[idx]
+
+            line = f"\rRestoring {self.vm_name} [{phases_str}"
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            idx = (idx + 1) % len(spinner_chars)
+            time.sleep(0.1)
+
+    def _update_progress(self, phase: str):
+        """Add a new phase to the progress display."""
+        with self._progress_lock:
+            self._progress_phases.append(phase)
+        self._log_debug(f"Phase: {phase}")
+
+    def _finish_progress(self, success: bool = True):
+        """Finish spinner display with final status."""
+        import sys
+
+        if not self._progress_started:
+            return
+
+        # Stop spinner thread
+        self._spinner_stop = True
+        if self._spinner_thread:
+            self._spinner_thread.join(timeout=0.5)
+
+        if not self._is_debug_mode:
+            with self._progress_lock:
+                phases_str = " -> ".join(self._progress_phases)
+
+            if success:
+                sys.stdout.write(f"\rRestoring {self.vm_name} [{phases_str}] done.\n")
+            else:
+                sys.stdout.write(f"\rRestoring {self.vm_name} [{phases_str}] FAILED.\n")
+            sys.stdout.flush()
+
     def _log_info(self, message: str):
         """Log info message."""
         if self.logger:
             self.logger.info(message)
 
     def _log_debug(self, message: str):
-        """Log debug message."""
+        """Log debug message with component prefix."""
         if self.logger:
-            self.logger.debug(message)
+            self.logger.debug(f"[Restore] {message}", stacklevel=2)
 
     def _log_error(self, message: str):
         """Log error message."""
@@ -120,7 +202,9 @@ class RestoreOrchestrator:
             True if all validations passed
         """
 
-        self._log_info("Pre-flight Validation:")
+        # Initialize progress and start with validation phase
+        self._init_progress()
+        self._update_progress("validating")
 
         runner = ValidationRunner()
 
@@ -133,11 +217,11 @@ class RestoreOrchestrator:
         results = runner.run_all(self.logger)
 
         if not results.all_passed():
-            self._log_error("")
-            self._log_error("Pre-flight validation failed!")
+            self._finish_progress(False)
             results.print_failures()
             return False
 
+        self._log_debug("All validations passed")
         return True
 
     def execute(self) -> bool:
@@ -148,11 +232,10 @@ class RestoreOrchestrator:
             True if restore succeeded
         """
 
-        self._log_info("")
-        self._log_info("Executing Restore:")
+        self._log_debug(f"Restoring instance '{self.vm_name}'...")
 
         try:
-            # Get disk info
+            # Get disk info (before progress display)
             self._get_disk_info()
 
             # Check snapshot status (warn if failed or missing)
@@ -179,6 +262,8 @@ class RestoreOrchestrator:
             }
 
             # Step 1: Stop VM
+            self._update_progress("stopping")
+            self._log_debug(f"Stopping instance {self.vm_name}...")
             # Auto-detect Local SSDs and handle automatically
             # (user already acknowledged data loss during rescue)
             has_local_ssd = any(
@@ -187,7 +272,6 @@ class RestoreOrchestrator:
                     project=self.project, zone=self.zone, instance=self.vm_name
                 ).execute().get('disks', [])
             )
-            self._log_info("  Stopping VM...")
             result = stop_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_stop_timeout,
@@ -196,12 +280,13 @@ class RestoreOrchestrator:
             )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 2: Detach rescue disk
-            self._log_info("  Detaching rescue disk...")
+            self._update_progress("restoring boot disk")
+            self._log_debug("Detaching rescue disk...")
             result = detach_rescue.execute(
                 vm_name=self.vm_name,
                 device_name=self.rescue_device_name,
@@ -209,12 +294,12 @@ class RestoreOrchestrator:
             )
             self.state_tracker.add_operation("Detach Rescue Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 3: Detach original disk
-            self._log_info("  Detaching affected disk...")
+            self._log_debug("Detaching affected disk...")
             result = detach_original.execute(
                 vm_name=self.vm_name,
                 device_name=self.original_device_name,
@@ -222,12 +307,12 @@ class RestoreOrchestrator:
             )
             self.state_tracker.add_operation("Detach Original Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 4: Re-attach original disk as boot
-            self._log_info("  Re-attaching affected disk as boot...")
+            self._log_debug("Attaching boot disk...")
             result = attach_original.execute(
                 vm_name=self.vm_name,
                 disk_name=self.original_disk_name,
@@ -236,12 +321,12 @@ class RestoreOrchestrator:
             )
             self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 5: Remove rescue metadata and restore backed up keys
-            self._log_info("  Restoring original metadata...")
+            self._log_debug("Removing rescue metadata...")
             clean_metadata = self._get_clean_metadata()
             # Use preserve_existing=False to REPLACE metadata (not merge)
             # because clean_metadata already contains the correct final state
@@ -253,12 +338,13 @@ class RestoreOrchestrator:
             )
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 6: Start VM
-            self._log_info("  Starting VM...")
+            self._update_progress("starting")
+            self._log_debug(f"Starting instance {self.vm_name}...")
             result = start_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_start_timeout,
@@ -266,27 +352,27 @@ class RestoreOrchestrator:
             )
             self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data)
             if not result.success:
+                self._finish_progress(False)
                 self._rollback()
                 return False
-            self._log_info(f"  [OK] {result.message}")
 
             # Step 7: Delete rescue disk (only if config allows)
             if self.config.delete_rescue_disk:
-                self._log_info(f"  Deleting rescue disk...")
+                self._log_debug("Deleting rescue disk...")
                 result = delete_rescue.execute(
                     disk_name=self.rescue_disk_name,
                     tracking_label='restore-disk-delete-rescue'
                 )
                 # Note: Don't add to state tracker (can't rollback deletion)
-                if result.success:
-                    self._log_info(f"  [OK] {result.message}")
-                else:
-                    self._log_error(f"  [X] Failed to delete rescue disk: {result.error}")
-                    self._log_error("  You can delete it manually later")
+                if not result.success:
+                    self._log_debug("Rescue disk deletion failed (can delete manually)")
 
+            # Success!
+            self._finish_progress(True)
             return True
 
         except Exception as e:
+            self._finish_progress(False)
             self._log_error(f"Unexpected error during restore: {str(e)}")
             self._rollback()
             return False
@@ -444,7 +530,7 @@ class RestoreOrchestrator:
             status = most_recent.get('status', 'UNKNOWN')
 
             if status == 'READY':
-                self._log_info(f"  Safety snapshot verified: {snapshot_name}")
+                self._log_debug(f"Safety snapshot verified: {snapshot_name}")
             elif status == 'CREATING':
                 self._log_info("")
                 self._log_info("  " + "=" * 56)

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -231,7 +231,12 @@ class RestoreOrchestrator:
             clean_metadata = self._get_clean_metadata()
             # Use preserve_existing=False to REPLACE metadata (not merge)
             # because clean_metadata already contains the correct final state
-            result = set_metadata.execute(vm_name=self.vm_name, metadata_items=clean_metadata, preserve_existing=False)
+            result = set_metadata.execute(
+                vm_name=self.vm_name,
+                metadata_items=clean_metadata,
+                preserve_existing=False,
+                operation_type='restore'  # For usage tracking
+            )
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -191,7 +191,8 @@ class RestoreOrchestrator:
             result = stop_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_stop_timeout,
-                discard_local_ssd=has_local_ssd  # Auto-handle Local SSDs during restore
+                discard_local_ssd=has_local_ssd,  # Auto-handle Local SSDs during restore
+                tracking_label='restore-vm-stop'
             )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:
@@ -201,7 +202,11 @@ class RestoreOrchestrator:
 
             # Step 2: Detach rescue disk
             self._log_info("  Detaching rescue disk...")
-            result = detach_rescue.execute(vm_name=self.vm_name, device_name=self.rescue_device_name)
+            result = detach_rescue.execute(
+                vm_name=self.vm_name,
+                device_name=self.rescue_device_name,
+                tracking_label='restore-disk-detach-rescue'
+            )
             self.state_tracker.add_operation("Detach Rescue Disk", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -210,7 +215,11 @@ class RestoreOrchestrator:
 
             # Step 3: Detach original disk
             self._log_info("  Detaching affected disk...")
-            result = detach_original.execute(vm_name=self.vm_name, device_name=self.original_device_name)
+            result = detach_original.execute(
+                vm_name=self.vm_name,
+                device_name=self.original_device_name,
+                tracking_label='restore-disk-detach-orig'
+            )
             self.state_tracker.add_operation("Detach Original Disk", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -219,7 +228,12 @@ class RestoreOrchestrator:
 
             # Step 4: Re-attach original disk as boot
             self._log_info("  Re-attaching affected disk as boot...")
-            result = attach_original.execute(vm_name=self.vm_name, disk_name=self.original_disk_name, boot=True)
+            result = attach_original.execute(
+                vm_name=self.vm_name,
+                disk_name=self.original_disk_name,
+                boot=True,
+                tracking_label='restore-disk-attach-orig'
+            )
             self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -235,7 +249,7 @@ class RestoreOrchestrator:
                 vm_name=self.vm_name,
                 metadata_items=clean_metadata,
                 preserve_existing=False,
-                operation_type='restore'  # For usage tracking
+                tracking_label='restore-meta-restore-orig'
             )
             self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
             if not result.success:
@@ -245,7 +259,11 @@ class RestoreOrchestrator:
 
             # Step 6: Start VM
             self._log_info("  Starting VM...")
-            result = start_vm.execute(vm_name=self.vm_name, timeout=self.config.vm_start_timeout)
+            result = start_vm.execute(
+                vm_name=self.vm_name,
+                timeout=self.config.vm_start_timeout,
+                tracking_label='restore-vm-start'
+            )
             self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data)
             if not result.success:
                 self._rollback()
@@ -255,7 +273,10 @@ class RestoreOrchestrator:
             # Step 7: Delete rescue disk (only if config allows)
             if self.config.delete_rescue_disk:
                 self._log_info(f"  Deleting rescue disk...")
-                result = delete_rescue.execute(disk_name=self.rescue_disk_name)
+                result = delete_rescue.execute(
+                    disk_name=self.rescue_disk_name,
+                    tracking_label='restore-disk-delete-rescue'
+                )
                 # Note: Don't add to state tracker (can't rollback deletion)
                 if result.success:
                     self._log_info(f"  [OK] {result.message}")

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -112,6 +112,9 @@ class RestoreOrchestrator:
         self._progress_lock = threading.Lock()
 
         if not self._is_debug_mode:
+            # Print header line
+            sys.stdout.write(f"Restoring instance [{self.vm_name}]:\n")
+            sys.stdout.flush()
             # Start spinner thread
             self._spinner_stop = False
             self._spinner_thread = threading.Thread(target=self._run_spinner, daemon=True)
@@ -140,7 +143,7 @@ class RestoreOrchestrator:
                 else:
                     phases_str = spinner_chars[idx]
 
-            line = f"\rRestoring {self.vm_name} [{phases_str}"
+            line = f"\r [{phases_str}"
             sys.stdout.write(line)
             sys.stdout.flush()
             idx = (idx + 1) % len(spinner_chars)
@@ -169,9 +172,9 @@ class RestoreOrchestrator:
                 phases_str = " -> ".join(self._progress_phases)
 
             if success:
-                sys.stdout.write(f"\rRestoring {self.vm_name} [{phases_str}] done.\n")
+                sys.stdout.write(f"\r [{phases_str}] done.\n")
             else:
-                sys.stdout.write(f"\rRestoring {self.vm_name} [{phases_str}] FAILED.\n")
+                sys.stdout.write(f"\r [{phases_str}] FAILED.\n")
             sys.stdout.flush()
 
     def _log_info(self, message: str):
@@ -202,10 +205,6 @@ class RestoreOrchestrator:
             True if all validations passed
         """
 
-        # Initialize progress and start with validation phase
-        self._init_progress()
-        self._update_progress("validating")
-
         runner = ValidationRunner()
 
         # Add validators with tracking labels
@@ -217,7 +216,6 @@ class RestoreOrchestrator:
         results = runner.run_all(self.logger)
 
         if not results.all_passed():
-            self._finish_progress(False)
             results.print_failures()
             return False
 
@@ -233,6 +231,9 @@ class RestoreOrchestrator:
         """
 
         self._log_debug(f"Restoring instance '{self.vm_name}'...")
+
+        # Initialize progress display
+        self._init_progress()
 
         try:
             # Get disk info (before progress display)
@@ -262,7 +263,7 @@ class RestoreOrchestrator:
             }
 
             # Step 1: Stop VM
-            self._update_progress("stopping")
+            self._update_progress("Stopping")
             self._log_debug(f"Stopping instance {self.vm_name}...")
             # Auto-detect Local SSDs and handle automatically
             # (user already acknowledged data loss during rescue)
@@ -285,7 +286,7 @@ class RestoreOrchestrator:
                 return False
 
             # Step 2: Detach rescue disk
-            self._update_progress("restoring boot disk")
+            self._update_progress("Restoring affected disk")
             self._log_debug("Detaching rescue disk...")
             result = detach_rescue.execute(
                 vm_name=self.vm_name,
@@ -299,7 +300,7 @@ class RestoreOrchestrator:
                 return False
 
             # Step 3: Detach original disk
-            self._log_debug("Detaching affected disk...")
+            self._log_debug("Detaching original boot disk...")
             result = detach_original.execute(
                 vm_name=self.vm_name,
                 device_name=self.original_device_name,
@@ -343,7 +344,7 @@ class RestoreOrchestrator:
                 return False
 
             # Step 6: Start VM
-            self._update_progress("starting")
+            self._update_progress("Starting")
             self._log_debug(f"Starting instance {self.vm_name}...")
             result = start_vm.execute(
                 vm_name=self.vm_name,

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -124,10 +124,10 @@ class RestoreOrchestrator:
 
         runner = ValidationRunner()
 
-        # Add validators
+        # Add validators with tracking labels
         runner.add(CredentialsValidator(self.compute, self.project, self.zone))
-        runner.add(IAMPermissionsValidator(self.compute, self.project, self.zone, self.vm_name))
-        runner.add(VMRestoreStateValidator(self.compute, self.project, self.zone, self.vm_name))
+        runner.add(IAMPermissionsValidator(self.compute, self.project, self.zone, self.vm_name, tracking_label='restore-val-iam'))
+        runner.add(VMRestoreStateValidator(self.compute, self.project, self.zone, self.vm_name, tracking_label='restore-val-vm-state'))
 
         # Run validations
         results = runner.run_all(self.logger)

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -99,6 +99,7 @@ class RestoreOrchestrator:
         self._progress_started = False
         self._progress_phases = []
         self._progress_lock = None
+        self._total_steps = 3  # Stopping, Restoring affected disk, Starting
 
     def _init_progress(self):
         """Initialize spinner with phases display."""
@@ -133,6 +134,7 @@ class RestoreOrchestrator:
 
         while not self._spinner_stop:
             with self._progress_lock:
+                current_step = len(self._progress_phases)
                 if self._progress_phases:
                     # Show completed phases, then current phase with dots and spinner
                     completed = self._progress_phases[:-1]
@@ -144,7 +146,7 @@ class RestoreOrchestrator:
                 else:
                     phases_str = spinner_chars[idx]
 
-            line = f"\r [{phases_str}"
+            line = f"\r ({current_step}/{self._total_steps}) [{phases_str}"
             sys.stdout.write(line)
             sys.stdout.flush()
             idx = (idx + 1) % len(spinner_chars)
@@ -171,11 +173,12 @@ class RestoreOrchestrator:
         if not self._is_debug_mode:
             with self._progress_lock:
                 phases_str = " -> ".join(self._progress_phases)
+                current_step = len(self._progress_phases)
 
             if success:
-                sys.stdout.write(f"\r [{phases_str}] done.\n")
+                sys.stdout.write(f"\r ({self._total_steps}/{self._total_steps}) [{phases_str}] done.\n")
             else:
-                sys.stdout.write(f"\r [{phases_str}] FAILED.\n")
+                sys.stdout.write(f"\r ({current_step}/{self._total_steps}) [{phases_str}] FAILED.\n")
             sys.stdout.flush()
 
     def _log_info(self, message: str):

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -179,11 +179,19 @@ class RestoreOrchestrator:
             }
 
             # Step 1: Stop VM
+            # Auto-detect Local SSDs and handle automatically
+            # (user already acknowledged data loss during rescue)
+            has_local_ssd = any(
+                disk.get('type') == 'SCRATCH'
+                for disk in self.compute.instances().get(
+                    project=self.project, zone=self.zone, instance=self.vm_name
+                ).execute().get('disks', [])
+            )
             self._log_info("  Stopping VM...")
             result = stop_vm.execute(
                 vm_name=self.vm_name,
                 timeout=self.config.vm_stop_timeout,
-                discard_local_ssd=self.config.force  # Allow stopping VMs with Local SSDs if --force
+                discard_local_ssd=has_local_ssd  # Auto-handle Local SSDs during restore
             )
             self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
             if not result.success:

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -106,8 +106,9 @@ class RestoreOrchestrator:
         import logging
         import threading
 
-        # Check if we're in debug mode
-        self._is_debug_mode = self.logger and self.logger.level <= logging.DEBUG
+        # Check if we're in debug mode (use console_level if available, fallback to logger.level)
+        console_level = getattr(self.logger, 'console_level', self.logger.level) if self.logger else logging.INFO
+        self._is_debug_mode = console_level <= logging.DEBUG
         self._progress_phases = []
         self._progress_lock = threading.Lock()
 

--- a/gce_rescue_v2/orchestration/rollback.py
+++ b/gce_rescue_v2/orchestration/rollback.py
@@ -72,9 +72,9 @@ class RollbackHandler:
             self.logger.error(message)
 
     def _log_debug(self, message: str):
-        """Log debug message."""
+        """Log debug message with component prefix."""
         if self.logger:
-            self.logger.debug(message)
+            self.logger.debug(f"[Rollback] {message}", stacklevel=2)
 
     def _should_skip_rollback(self, op_name: str) -> bool:
         """

--- a/gce_rescue_v2/startup_scripts/rescue_mount.sh
+++ b/gce_rescue_v2/startup_scripts/rescue_mount.sh
@@ -131,6 +131,10 @@ if [ -n "$disk_p" ]; then
     log "=== GCE Rescue Auto-Mount Complete ==="
     echo "SUCCESS" > "$STATUS_FILE"
 
+    # Output completion marker to serial console (for orchestrator verification)
+    echo "GCE-RESCUE-COMPLETE" >&2
+    log "=== Startup script completed successfully ==="
+
 else
     log "ERROR: No supported filesystem found!"
     log "Supported: ext3, ext4, xfs, ntfs"

--- a/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
+++ b/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
@@ -80,9 +80,9 @@ while ($attempt -lt $maxAttempts) {
     $attempt++
 
     # Get all disks except the boot disk (Disk 0)
-    $disks = Get-Disk | Where-Object { $_.Number -ne 0 }
+    $disks = @(Get-Disk | Where-Object { $_.Number -ne 0 })
 
-    if ($disks) {
+    if ($disks.Count -gt 0) {
         Write-Log "Found $($disks.Count) additional disk(s)"
         $diskFound = $true
         break
@@ -118,9 +118,9 @@ foreach ($disk in $disks) {
         }
 
         # Get partitions
-        $partitions = Get-Partition -DiskNumber $disk.Number | Where-Object { $_.Type -ne 'Reserved' -and $_.Size -gt 1GB }
+        $partitions = @(Get-Partition -DiskNumber $disk.Number | Where-Object { $_.Type -ne 'Reserved' -and $_.Size -gt 1GB })
 
-        if ($partitions) {
+        if ($partitions.Count -gt 0) {
             Write-Log "  Found $($partitions.Count) partition(s)"
 
             foreach ($partition in $partitions) {
@@ -184,6 +184,13 @@ Write-Log "=== Startup script completed successfully ==="
 Write-Log ""
 Write-Log "=== GCE Rescue Ready ==="
 Write-Log "Connect via RDP and access your affected disk at the mounted drive letter(s)"
+Write-Log ""
+Write-Log "=========================================="
+Write-Log "RDP CONNECTION CREDENTIALS"
+Write-Log "=========================================="
+Write-Log "Username: $rescueUser"
+Write-Log "Password: $rescuePassword"
+Write-Log "=========================================="
 Write-Log ""
 Write-Log "Common repair tasks:"
 Write-Log "  - Edit files: notepad D:\Windows\System32\config\SOFTWARE"

--- a/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
+++ b/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
@@ -175,6 +175,12 @@ foreach ($drive in $mountedDrives) {
     Write-Log "  $($drive.DriveLetter): - $($drive.FileSystemLabel) - $($drive.SizeGB) GB ($($drive.FileSystem))"
 }
 
+# Output completion marker to serial console FIRST (for orchestrator verification)
+# This must happen before any operations that might fail (like desktop file creation)
+Write-Log ""
+Write-Log "GCE-RESCUE-COMPLETE"
+Write-Log "=== Startup script completed successfully ==="
+
 Write-Log ""
 Write-Log "=== GCE Rescue Ready ==="
 Write-Log "Connect via RDP and access your affected disk at the mounted drive letter(s)"
@@ -185,9 +191,13 @@ Write-Log "  - Registry: Load hive from D:\Windows\System32\config\ in regedit"
 Write-Log "  - Boot repair: bcdboot D:\Windows /s C:"
 Write-Log ""
 
-# Create desktop shortcut with instructions
-$desktopPath = [Environment]::GetFolderPath("Desktop")
-$shortcutContent = @"
+# Create desktop shortcut with instructions (optional - may fail if running as SYSTEM)
+try {
+    $desktopPath = [Environment]::GetFolderPath("CommonDesktopDirectory")
+    if (-not $desktopPath) {
+        $desktopPath = "C:\Users\Public\Desktop"
+    }
+    $shortcutContent = @"
 GCE Rescue Mode - Instructions
 ==============================
 
@@ -212,5 +222,9 @@ When done, run restore command from your local machine:
   python -m gce_rescue_v2.cli restore VM_NAME --zone ZONE
 "@
 
-$shortcutContent | Out-File -FilePath "$desktopPath\GCE-Rescue-Instructions.txt" -Encoding UTF8
-Write-Log "Instructions saved to Desktop"
+    $shortcutContent | Out-File -FilePath "$desktopPath\GCE-Rescue-Instructions.txt" -Encoding UTF8
+    Write-Log "Instructions saved to Desktop: $desktopPath\GCE-Rescue-Instructions.txt"
+} catch {
+    Write-Log "WARNING: Could not create desktop instructions file: $_"
+    Write-Log "This is non-critical - rescue mode is still operational"
+}

--- a/gce_rescue_v2/tests/test_integration.py
+++ b/gce_rescue_v2/tests/test_integration.py
@@ -27,6 +27,7 @@ def test_full_rescue_restore_cycle(monkeypatch):
             # Required attributes for main.py success message
             self.os_type = 'linux'
             self.windows_rescue_password = None
+            self.verification_succeeded = True
 
         def validate(self):
             state["calls"].append("rescue-validate")

--- a/gce_rescue_v2/tests/test_integration.py
+++ b/gce_rescue_v2/tests/test_integration.py
@@ -28,6 +28,9 @@ def test_full_rescue_restore_cycle(monkeypatch):
             self.os_type = 'linux'
             self.windows_rescue_password = None
             self.verification_succeeded = True
+            self.snapshot_name = 'pre-rescue-test-disk-1234567890'
+            self.original_disk_name = 'test-boot-disk'
+            self.rescue_disk_name = 'rescue-disk-1234567890'
 
         def validate(self):
             state["calls"].append("rescue-validate")

--- a/gce_rescue_v2/tests/test_verify_startup.py
+++ b/gce_rescue_v2/tests/test_verify_startup.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for VerifyStartupOperation.
+
+Tests:
+- test_marker_found_immediately: Marker found on first poll
+- test_marker_found_after_delay: Marker found after several polls
+- test_timeout_marker_not_found: Returns failure after timeout
+- test_serial_console_disabled: Handles 403 error gracefully
+- test_empty_serial_output: Handles empty contents field
+- test_tracking_label_used: Verifies tracking label in User-Agent
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from gce_rescue_v2.operations.verify_startup import VerifyStartupOperation
+
+
+class TestVerifyStartupOperation:
+
+    def setup_method(self):
+        """Setup test fixtures."""
+        self.mock_compute = Mock()
+        self.project = "test-project"
+        self.zone = "us-central1-a"
+        self.logger = Mock()
+
+        self.operation = VerifyStartupOperation(
+            self.mock_compute,
+            self.project,
+            self.zone,
+            self.logger
+        )
+
+    def test_marker_found_immediately(self):
+        """Test marker found on first poll."""
+        # Arrange
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'Boot messages...\nGCE-RESCUE-COMPLETE\nMore output...'
+        }
+
+        # Act
+        result = self.operation.execute(vm_name='test-vm', timeout=10)
+
+        # Assert
+        assert result.success is True
+        assert "Startup script completed" in result.message
+        assert result.rollback_data is None  # Verification doesn't need rollback
+
+    def test_marker_found_after_delay(self):
+        """Test marker found after several polls."""
+        # Arrange
+        call_count = [0]
+
+        def mock_execute():
+            call_count[0] += 1
+            if call_count[0] < 3:
+                return {'contents': 'Booting...\nStarting services...'}
+            else:
+                return {'contents': 'Booting...\nStarting services...\nGCE-RESCUE-COMPLETE'}
+
+        self.mock_compute.instances().getSerialPortOutput().execute.side_effect = mock_execute
+
+        # Act
+        with patch('time.sleep'):  # Speed up test by mocking sleep
+            result = self.operation.execute(vm_name='test-vm', timeout=30)
+
+        # Assert
+        assert result.success is True
+        assert call_count[0] == 3  # Called 3 times before finding marker
+        assert "Startup script completed" in result.message
+
+    def test_timeout_marker_not_found(self):
+        """Test timeout when marker is not found."""
+        # Arrange
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'Boot messages without completion marker'
+        }
+
+        # Act
+        with patch('time.sleep'):  # Speed up test
+            with patch('time.time', side_effect=[0, 5, 10, 15, 20, 121]):  # Simulate timeout
+                result = self.operation.execute(vm_name='test-vm', timeout=120)
+
+        # Assert
+        assert result.success is False
+        assert "Timeout waiting for startup script" in result.message
+        assert "did not complete within" in result.error
+
+    def test_serial_console_disabled(self):
+        """Test handling when serial console is disabled (403 error)."""
+        # Arrange
+        from googleapiclient.errors import HttpError
+        resp = Mock(status=403, reason="Forbidden")
+        error = HttpError(resp, b'{"error": {"message": "Serial port output is not enabled"}}')
+
+        # Make _create_tracked_client raise the 403 error
+        # This will be caught by the outer try-except which checks for 403
+        with patch.object(self.operation, '_create_tracked_client') as mock_create:
+            mock_create.side_effect = error
+
+            # Act
+            result = self.operation.execute(vm_name='test-vm', timeout=10, tracking_label='test')
+
+        # Assert - should return SUCCESS with warning (not failure)
+        assert result.success is True
+        assert "manual verification required" in result.message.lower()
+        assert "serial console disabled" in result.message.lower()
+
+    def test_empty_serial_output(self):
+        """Test handling empty serial output."""
+        # Arrange
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': ''
+        }
+
+        # Act
+        with patch('time.sleep'):
+            with patch('time.time', side_effect=[0, 5, 121]):  # Quick timeout
+                result = self.operation.execute(vm_name='test-vm', timeout=120)
+
+        # Assert
+        assert result.success is False
+        assert "Timeout" in result.message
+
+    def test_tracking_label_used(self):
+        """Test that tracking label creates custom User-Agent."""
+        # Arrange
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'GCE-RESCUE-COMPLETE'
+        }
+
+        # Mock _create_tracked_client to verify it's called
+        mock_tracked_client = Mock()
+        mock_tracked_client.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'GCE-RESCUE-COMPLETE'
+        }
+
+        with patch.object(self.operation, '_create_tracked_client', return_value=mock_tracked_client) as mock_create:
+            # Act
+            result = self.operation.execute(
+                vm_name='test-vm',
+                tracking_label='test-tracking-label',
+                timeout=10
+            )
+
+            # Assert
+            assert result.success is True
+            mock_create.assert_called_once_with('test-tracking-label')
+            # Verify tracked client was used (called at least once)
+            assert mock_tracked_client.instances().getSerialPortOutput.call_count >= 1
+
+    def test_rollback_returns_true(self):
+        """Test rollback always returns True (no-op for verification)."""
+        # Act
+        result = self.operation.rollback({})
+
+        # Assert
+        assert result is True
+
+    def test_custom_completion_marker(self):
+        """Test using custom completion marker."""
+        # Arrange
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'Boot messages...\nCUSTOM-MARKER-HERE\nMore output...'
+        }
+
+        # Act
+        result = self.operation.execute(
+            vm_name='test-vm',
+            completion_marker='CUSTOM-MARKER-HERE',
+            timeout=10
+        )
+
+        # Assert
+        assert result.success is True
+
+    def test_serial_output_missing_contents_field(self):
+        """Test handling when serial output response doesn't have contents field."""
+        # Arrange
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {}
+
+        # Act
+        with patch('time.sleep'):
+            with patch('time.time', side_effect=[0, 5, 121]):
+                result = self.operation.execute(vm_name='test-vm', timeout=120)
+
+        # Assert
+        assert result.success is False
+        assert "Timeout" in result.message

--- a/gce_rescue_v2/utils/colors.py
+++ b/gce_rescue_v2/utils/colors.py
@@ -1,0 +1,57 @@
+"""
+Color and terminal utilities for CLI output.
+
+Provides simple ANSI color support with TTY detection.
+Colors are automatically disabled when output is piped.
+"""
+
+import sys
+
+# ANSI color codes
+RED = '\033[91m'
+YELLOW = '\033[93m'
+RESET = '\033[0m'
+
+
+def _is_tty() -> bool:
+    """Check if stdout is a terminal (not piped)."""
+    return hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+
+
+def red(text: str) -> str:
+    """Return text in red if TTY, otherwise plain text."""
+    if _is_tty():
+        return f"{RED}{text}{RESET}"
+    return text
+
+
+def yellow(text: str) -> str:
+    """Return text in yellow if TTY, otherwise plain text."""
+    if _is_tty():
+        return f"{YELLOW}{text}{RESET}"
+    return text
+
+
+def error_prefix() -> str:
+    """Return colored 'ERROR:' prefix."""
+    return red("ERROR:")
+
+
+def warning_prefix() -> str:
+    """Return colored 'WARNING:' prefix."""
+    return yellow("WARNING:")
+
+
+def note_prefix() -> str:
+    """Return colored 'Note:' prefix."""
+    return yellow("Note:")
+
+
+def clear_lines(num_lines: int) -> None:
+    """Clear the specified number of lines above cursor."""
+    if _is_tty() and num_lines > 0:
+        # Move cursor up and clear each line
+        for _ in range(num_lines):
+            sys.stdout.write('\033[A')  # Move up
+            sys.stdout.write('\033[2K')  # Clear line
+        sys.stdout.flush()

--- a/gce_rescue_v2/utils/logger.py
+++ b/gce_rescue_v2/utils/logger.py
@@ -91,7 +91,12 @@ def setup_logging(level='INFO', log_file=None, debug=False):
 
     # Create logger
     logger = logging.getLogger('gce_rescue')
-    logger.setLevel(numeric_level)
+    # Logger level must be DEBUG to allow debug messages to file handler
+    # But we track the console level separately for UI decisions
+    logger.setLevel(logging.DEBUG)
+
+    # Store console level as attribute for UI components to check
+    logger.console_level = numeric_level
 
     # Remove existing handlers (in case setup_logging called multiple times)
     logger.handlers.clear()
@@ -128,11 +133,12 @@ def setup_logging(level='INFO', log_file=None, debug=False):
     if log_file:
         # Create log directory if it doesn't exist
         log_path = Path(log_file)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
+        if log_path.parent != Path('.'):
+            log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Create file handler
+        # Create file handler - always DEBUG level for full troubleshooting
         file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(numeric_level)
+        file_handler.setLevel(logging.DEBUG)
 
         # File format includes more details
         file_format = logging.Formatter(

--- a/gce_rescue_v2/utils/logger.py
+++ b/gce_rescue_v2/utils/logger.py
@@ -100,11 +100,13 @@ def setup_logging(level='INFO', log_file=None, debug=False):
 
     # Create formatter based on debug mode
     if debug:
-        # Debug mode: Include timestamp with milliseconds, level, function, line number
-        # Format: [2025-11-02 10:30:45.123] DEBUG [stop_vm:45]: API call: instances.stop(...)
+        # Debug mode: gcloud-style format (no timestamps) with function:line for developers
+        # Format: DEBUG: [funcName:line] [Component] message
+        # - No timestamps (gcloud style - timing goes to Cloud Logging)
+        # - funcName:line shows WHERE in code (for debugging)
+        # - Component context in message shows WHAT component (e.g., [Rescue], [Stop VM])
         console_format = logging.Formatter(
-            '[%(asctime)s] %(levelname)s [%(funcName)s:%(lineno)d]: %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S'
+            '%(levelname)s: [%(funcName)s:%(lineno)d] %(message)s'
         )
     else:
         # Normal mode: Clean format, just timestamp and message

--- a/gce_rescue_v2/utils/logger.py
+++ b/gce_rescue_v2/utils/logger.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import Any, Dict
 
+from .colors import error_prefix
+
 
 class CleanFormatter(logging.Formatter):
     """
@@ -39,9 +41,9 @@ class CleanFormatter(logging.Formatter):
         elif record.levelno == logging.WARNING:
             return f"[!]  WARNING: {record.getMessage()}"
 
-        # ERROR: Show with prefix
+        # ERROR: Show with prefix (red)
         elif record.levelno == logging.ERROR:
-            return f"[X] ERROR: {record.getMessage()}"
+            return f"{error_prefix()} {record.getMessage()}"
 
         # CRITICAL: Show with prefix and emphasis
         elif record.levelno == logging.CRITICAL:

--- a/gce_rescue_v2/validators/base.py
+++ b/gce_rescue_v2/validators/base.py
@@ -248,7 +248,7 @@ class ValidationRunner:
         for validator in self.validators:
             # Log what we're checking (DEBUG level)
             if logger:
-                logger.debug(f"Running validator: {validator.name}")
+                logger.debug(f"[Validator] Running: {validator.name}")
 
             # Run the validator
             result = validator.validate()
@@ -256,16 +256,16 @@ class ValidationRunner:
             # Log result (DEBUG level)
             if logger:
                 status = "PASS" if result.passed else "FAIL"
-                logger.debug(f"  {status}: {result.message}")
+                logger.debug(f"[Validator]   {status}: {result.message}")
 
             # Add to results
             results.add(result)
 
-            # Print result for user (INFO level)
+            # Print result for user (DEBUG level for individual validators)
             if logger:
                 if result.passed:
-                    logger.info(f"  [OK] {result.validator_name}")
+                    logger.debug(f"[Validator]   {result.validator_name}...done.")
                 else:
-                    logger.info(f"  [FAIL] {result.validator_name}")
+                    logger.info(f"  {result.validator_name}...FAILED.")
 
         return results

--- a/gce_rescue_v2/validators/base.py
+++ b/gce_rescue_v2/validators/base.py
@@ -84,11 +84,38 @@ class ValidationResults:
         print()
         for result in failures:
             print(f"  [X] {result.validator_name}")
-            print(f"    {result.message}")
+            print(f"      {result.message}")
 
-            # Print fix suggestions if available
-            if result.details and 'fix' in result.details:
-                print(f"    Fix: {result.details['fix']}")
+            # Special handling for IAM permission failures
+            if result.details and 'missing' in result.details:
+                missing = result.details['missing']
+                if missing:
+                    print()
+                    print("      Missing permissions:")
+                    for perm in missing:
+                        print(f"        - {perm}")
+
+                # Show required roles
+                if 'required_roles' in result.details:
+                    print()
+                    print("      Required roles (grant one of these):")
+                    for role in result.details['required_roles']:
+                        print(f"        - {role}")
+
+                # Show how to grant
+                print()
+                print("      To grant access, run:")
+                print("        $ gcloud projects add-iam-policy-binding PROJECT_ID \\")
+                print("            --member=\"user:YOUR_EMAIL\" \\")
+                print("            --role=\"roles/compute.instanceAdmin.v1\"")
+                print()
+                print("      To check your current account:")
+                print("        $ gcloud auth list")
+
+            # Print general fix suggestions for other errors
+            elif result.details and 'fix' in result.details:
+                print(f"      Fix: {result.details['fix']}")
+
             print()
 
 

--- a/gce_rescue_v2/validators/base.py
+++ b/gce_rescue_v2/validators/base.py
@@ -10,6 +10,11 @@ Pattern: Create a new validator by inheriting from BaseValidator
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
+from ..core.config import VERSION
 
 
 @dataclass
@@ -119,7 +124,7 @@ class BaseValidator(ABC):
                     )
     """
 
-    def __init__(self, compute, project: str, zone: str, vm_name: str = None):
+    def __init__(self, compute, project: str, zone: str, vm_name: str = None, tracking_label: str = None):
         """
         Initialize validator.
 
@@ -128,11 +133,52 @@ class BaseValidator(ABC):
             project: GCP project ID
             zone: GCP zone (e.g., 'us-central1-a')
             vm_name: Name of the VM to validate (optional for some validators)
+            tracking_label: Optional tracking label for usage analytics
+                Format: '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-val-iam'
         """
         self.compute = compute
         self.project = project
         self.zone = zone
         self.vm_name = vm_name
+        self.tracking_label = tracking_label
+
+    def _create_tracked_client(self, tracking_label: str):
+        """
+        Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label in format '{operation_type}-{action_group}-{action_detail}'
+                Example: 'rescue-val-iam'
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        # Get credentials from the base compute client
+        credentials = self.compute._http.credentials
+
+        # Build unique User-Agent for tracking
+        # Format: gce-rescue-{VERSION}-{tracking_label}
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            """Inject custom User-Agent header."""
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials,
+                http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        # Create compute client with custom request builder
+        return discovery.build(
+            'compute',
+            'v1',
+            credentials=credentials,
+            cache_discovery=False,
+            requestBuilder=_request_builder
+        )
 
     @abstractmethod
     def validate(self) -> ValidationResult:

--- a/gce_rescue_v2/validators/iam_permissions.py
+++ b/gce_rescue_v2/validators/iam_permissions.py
@@ -100,7 +100,9 @@ class IAMPermissionsValidator(BaseValidator):
                 'permissions': self.INSTANCE_PERMISSIONS
             }
 
-            result = self.compute.instances().testIamPermissions(
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(self.tracking_label) if self.tracking_label else self.compute
+            result = compute.instances().testIamPermissions(
                 project=self.project,
                 zone=self.zone,
                 resource=self.vm_name,

--- a/gce_rescue_v2/validators/vm_state.py
+++ b/gce_rescue_v2/validators/vm_state.py
@@ -64,8 +64,10 @@ class VMStateValidator(BaseValidator):
             )
 
         try:
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(self.tracking_label) if self.tracking_label else self.compute
             # Try to get VM
-            vm = self.compute.instances().get(
+            vm = compute.instances().get(
                 project=self.project,
                 zone=self.zone,
                 instance=self.vm_name
@@ -222,8 +224,10 @@ class VMRestoreStateValidator(BaseValidator):
             )
 
         try:
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(self.tracking_label) if self.tracking_label else self.compute
             # Get VM
-            vm = self.compute.instances().get(
+            vm = compute.instances().get(
                 project=self.project,
                 zone=self.zone,
                 instance=self.vm_name


### PR DESCRIPTION
## Summary

This PR brings V2 to beta.3 with significant CLI UX improvements, better progress visibility, and safety features.

## What's New in Beta.3

### Added

- **Serial Console Verification**: Polls serial console for `GCE-RESCUE-COMPLETE` marker
  - 120 second timeout with warning (doesn't fail)
  - Confirms startup script actually ran successfully

- **Progress Spinner**: Visual progress indicator during operations
  - Shows current phase with step count (e.g., `(3/5) [Stopping -> ...]`)
  - Clean single-line updates

- **Browser SSH Option**: Added browser-based SSH connection option
  - Shows both gcloud CLI and Cloud Console SSH URL
  - Includes IAP tunnel hint for private VMs

- **Safer Confirmation Default**: Changed default from Yes to No (`y/N`)
  - Prevents accidental confirmations
  - Explicit 'y' required to proceed

- **Usage Tracking**: User-Agent headers for internal metrics
  - Tracks rescue/restore lifecycle phases
  - Hierarchical labels (rescue/validate, rescue/execute, etc.)

- **Auto Debug Log**: Automatic log file creation on errors
  - Saved to temp directory with timestamp
  - Includes full debug output for troubleshooting

- **Improved CLI Output**: gcloud-style formatting
  - Color-coded status (green OK, red FAIL, yellow WARN)
  - Better error messages with permission guidance
  - Clear next steps after rescue/restore

### Fixed

- SCRATCH disk handling in restore orchestration
- User-Agent format consistency (hyphen not underscore)
- Local SSD warning clarified: "data lost" instead of "disk deleted"

## Files Changed

| File | Change |
|------|--------|
| `CHANGELOG.md` | Added beta.2 and beta.3 entries |
| `cli.py` | Safer confirmation default, clearer Local SSD warning |
| `main.py` | Browser SSH option for rescue and restore |
| `orchestration/rescue.py` | Progress spinner with step count |
| `orchestration/restore.py` | Progress spinner with step count |
| `README.md` | Updated examples to match actual CLI output |

## Test Plan

- [x] All 106 tests pass
- [x] Manual test rescue with confirmation prompt (y/N)
- [x] Manual test restore with browser SSH output
- [x] Verify progress spinner shows step count