### PR TITLE
feat: Add session recovery for interrupted rescue/restore operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.4] - 2026-01-20
+
+### Added
+
+- **Session Recovery**: Resume or rollback interrupted rescue/restore operations
+  - Checkpoint stored in VM metadata (`gce-rescue-checkpoint`)
+  - Detects incomplete operations on next run
+  - Interactive prompt: Continue, Rollback, or Abort
+  - Idempotent operations handle partial state gracefully
+  - Progress resumes from where it left off (e.g., `(3/5)` not `(0/5)`)
+  - Log file persists across session recovery
+
+- **Transitional State Handling**: Graceful handling of VM states
+  - Handles STAGING, PROVISIONING, STOPPING states during resume
+  - Waits for stable state before proceeding
+
+- **Private Network VM Support**: Better UX for VMs without external IP
+  - Shows internal IP when no external IP exists
+  - Provides IAP tunnel command for RDP access
+
+### Fixed
+
+- Windows rescue password now preserved across session recovery
+- Completed checkpoints auto-cleared to prevent stale state errors
+
 ## [2.0.0-beta.3] - 2025-01-14
 
 ### Added

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -21,6 +21,7 @@ from typing import Optional, Dict, Any
 from .core.config import RescueConfig, RestoreConfig, VERSION
 from .main import rescue_vm, restore_vm
 from .utils.colors import error_prefix, warning_prefix, clear_lines
+from .orchestration.checkpoint import CheckpointManager, CheckpointData
 
 
 class OutputFormatter:
@@ -622,6 +623,200 @@ def _validate_vm_for_restore(compute, project: str, zone: str, vm_name: str) -> 
         return (False, None, _parse_api_error(e, vm_name, zone, project))
 
 
+def _prompt_incomplete_operation(checkpoint: CheckpointData, operation_type: str) -> str:
+    """
+    Prompt user about incomplete operation (interactive mode only).
+
+    Args:
+        checkpoint: Checkpoint data from incomplete operation
+        operation_type: 'rescue' or 'restore'
+
+    Returns:
+        'continue', 'rollback', or 'abort'
+    """
+    # Get next step name for continue option
+    next_step = checkpoint.current_step + 1
+    step_names = {
+        1: "Stop VM", 2: "Detach Boot Disk", 3: "Create Snapshot",
+        4: "Create Rescue Disk", 5: "Attach Rescue Disk", 6: "Set Metadata",
+        7: "Start VM", 8: "Attach Original Disk", 9: "Verify Startup"
+    }
+    next_step_name = step_names.get(next_step, f"Step {next_step}")
+    last_step_name = checkpoint.get_last_completed_operation() or "None"
+
+    # Track lines for clearing after continue
+    lines_printed = 0
+
+    print(f"\n{warning_prefix()} An incomplete {operation_type} operation was detected for this instance.")
+    lines_printed += 2  # includes leading newline
+    print("")
+    lines_printed += 1
+    print(f"  Started:    {checkpoint.started_at[:19].replace('T', ' ')} ({checkpoint.get_age_display()})")
+    lines_printed += 1
+    print(f"  Progress:   {checkpoint.current_step} of {checkpoint.total_steps} steps completed")
+    lines_printed += 1
+    print(f"  Last step:  {last_step_name}")
+    lines_printed += 1
+    print("")
+    lines_printed += 1
+    print("What would you like to do?")
+    lines_printed += 1
+    print(f"  [1] Continue  Resume from \"{next_step_name}\"")
+    lines_printed += 1
+    print("  [2] Rollback  Undo completed steps and restore original state")
+    lines_printed += 1
+    print("  [3] Abort     Do nothing and exit")
+    lines_printed += 1
+    print("")
+    lines_printed += 1
+
+    while True:
+        try:
+            response = input("Enter your choice (1/2/3): ").strip()
+            lines_printed += 1  # input line
+            if response == '1':
+                # Clear the warning message when continuing
+                clear_lines(lines_printed)
+                return 'continue'
+            elif response == '2':
+                return 'rollback'
+            elif response == '3':
+                return 'abort'
+            else:
+                print("Please enter 1, 2, or 3.")
+                lines_printed += 1
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            return 'abort'
+
+
+def _handle_restore_checkpoint_rollback(compute, project: str, zone: str, vm_name: str,
+                                        checkpoint: CheckpointData, logger=None) -> bool:
+    """
+    Rollback restore operation to return to rescue mode.
+
+    Args:
+        compute: GCP compute client
+        project: GCP project ID
+        zone: GCP zone
+        vm_name: VM name
+        checkpoint: Checkpoint data
+        logger: Optional logger
+
+    Returns:
+        True if rollback succeeded
+    """
+    from .orchestration.rollback import RollbackHandler
+    from .orchestration.state import StateTracker
+    from .operations import (
+        StopVMOperation, DetachDiskOperation, AttachDiskOperation,
+        SetMetadataOperation, StartVMOperation
+    )
+
+    print(f"\nRolling back to rescue mode for instance [{vm_name}]:")
+
+    # Create operations map for restore operations
+    operations_map = {
+        "Stop VM": StopVMOperation(compute, project, zone, logger),
+        "Detach Rescue Disk": DetachDiskOperation(compute, project, zone, logger),
+        "Detach Original Disk": DetachDiskOperation(compute, project, zone, logger),
+        "Attach Original Disk": AttachDiskOperation(compute, project, zone, logger),
+        "Set Metadata": SetMetadataOperation(compute, project, zone, logger),
+        "Start VM": StartVMOperation(compute, project, zone, logger),
+    }
+
+    # Build state tracker from checkpoint
+    state_tracker = StateTracker()
+    for op in checkpoint.completed_operations:
+        state_tracker.add_operation(
+            operation_name=op.name,
+            success=True,
+            message="Completed in previous session",
+            rollback_data=op.rollback_data,
+            step_number=op.step
+        )
+
+    # Perform rollback
+    handler = RollbackHandler(logger)
+    success = handler.rollback(state_tracker, operations_map)
+
+    # Clear checkpoint after rollback
+    checkpoint_mgr = CheckpointManager(compute, project, zone, vm_name, logger)
+    checkpoint_mgr.clear_checkpoint()
+
+    if success:
+        print(f"\nInstance [{vm_name}] is back in rescue mode.")
+    else:
+        print(f"\n{error_prefix()} Rollback completed with errors. Manual intervention may be required.")
+
+    return success
+
+
+def _handle_checkpoint_rollback(compute, project: str, zone: str, vm_name: str,
+                                checkpoint: CheckpointData, logger=None) -> bool:
+    """
+    Rollback from checkpoint.
+
+    Args:
+        compute: GCP compute client
+        project: GCP project ID
+        zone: GCP zone
+        vm_name: VM name
+        checkpoint: Checkpoint data
+        logger: Optional logger
+
+    Returns:
+        True if rollback succeeded
+    """
+    from .orchestration.rollback import RollbackHandler
+    from .orchestration.state import StateTracker, OperationState
+    from .operations import (
+        StopVMOperation, DetachDiskOperation, AttachDiskOperation,
+        SetMetadataOperation, StartVMOperation, DeleteDiskOperation,
+        CreateSnapshotOperation, CreateDiskOperation
+    )
+
+    print(f"\nRolling back instance [{vm_name}]:")
+
+    # Create operations map
+    operations_map = {
+        "Stop VM": StopVMOperation(compute, project, zone, logger),
+        "Detach Boot Disk": DetachDiskOperation(compute, project, zone, logger),
+        "Create Snapshot": CreateSnapshotOperation(compute, project, zone, logger),
+        "Create Rescue Disk": CreateDiskOperation(compute, project, zone, logger),
+        "Attach Rescue Disk": AttachDiskOperation(compute, project, zone, logger),
+        "Set Metadata": SetMetadataOperation(compute, project, zone, logger),
+        "Start VM": StartVMOperation(compute, project, zone, logger),
+        "Attach Original Disk": AttachDiskOperation(compute, project, zone, logger),
+    }
+
+    # Build state tracker from checkpoint
+    state_tracker = StateTracker()
+    for op in checkpoint.completed_operations:
+        state_tracker.add_operation(
+            operation_name=op.name,
+            success=True,
+            message="Completed in previous session",
+            rollback_data=op.rollback_data,
+            step_number=op.step
+        )
+
+    # Perform rollback
+    handler = RollbackHandler(logger)
+    success = handler.rollback(state_tracker, operations_map)
+
+    # Clear checkpoint after rollback
+    checkpoint_mgr = CheckpointManager(compute, project, zone, vm_name, logger)
+    checkpoint_mgr.clear_checkpoint()
+
+    if success:
+        print(f"\nInstance [{vm_name}] has been restored to its original state.")
+    else:
+        print(f"\n{error_prefix()} Rollback completed with errors. Manual intervention may be required.")
+
+    return success
+
+
 def handle_rescue(args: argparse.Namespace) -> int:
     """Handle rescue command."""
     from .core.auth import AuthManager
@@ -647,30 +842,54 @@ def handle_rescue(args: argparse.Namespace) -> int:
         print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
         return 1
 
-    # Validate VM exists and state BEFORE confirmation
-    valid, vm_info, error_msg = _validate_vm_exists(compute, project, args.zone, args.instance_name)
-    if not valid:
-        print(f"{error_prefix()} {error_msg}", file=sys.stderr)
-        return 1
-
-    # Check for Local SSDs using validated VM info
-    local_ssds = _check_local_ssds(vm_info)
-    has_local_ssd = len(local_ssds) > 0
-
-    # In quiet mode with Local SSDs, require --force
-    if args.quiet and has_local_ssd and not args.force:
-        print(f"{error_prefix()} VM has Local SSDs attached.", file=sys.stderr)
-        print("", file=sys.stderr)
-        print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("WARNING: Stopping this VM will PERMANENTLY LOSE all data on Local SSDs!", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
-        print(f"  gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --quiet --force", file=sys.stderr)
-        return 1
-
-    # Interactive confirmation (unless --quiet)
+    # Check for incomplete operation (interactive mode only)
+    checkpoint = None
+    resuming = False
     if not args.quiet:
+        checkpoint_mgr = CheckpointManager(compute, project, args.zone, args.instance_name)
+        checkpoint = checkpoint_mgr.detect_incomplete(operation_type='rescue')
+
+        if checkpoint:
+            action = _prompt_incomplete_operation(checkpoint, 'rescue')
+
+            if action == 'abort':
+                return 0
+            elif action == 'rollback':
+                success = _handle_checkpoint_rollback(
+                    compute, project, args.zone, args.instance_name, checkpoint
+                )
+                return 0 if success else 1
+            # action == 'continue': proceed with resume
+            # Skip normal validation and confirmation when resuming
+            vm_info = None
+            has_local_ssd = False
+            resuming = True
+
+    if not resuming:
+        # Validate VM exists and state BEFORE confirmation
+        valid, vm_info, error_msg = _validate_vm_exists(compute, project, args.zone, args.instance_name)
+        if not valid:
+            print(f"{error_prefix()} {error_msg}", file=sys.stderr)
+            return 1
+
+        # Check for Local SSDs using validated VM info
+        local_ssds = _check_local_ssds(vm_info)
+        has_local_ssd = len(local_ssds) > 0
+
+        # In quiet mode with Local SSDs, require --force
+        if args.quiet and has_local_ssd and not args.force:
+            print(f"{error_prefix()} VM has Local SSDs attached.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("WARNING: Stopping this VM will PERMANENTLY LOSE all data on Local SSDs!", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
+            print(f"  gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --quiet --force", file=sys.stderr)
+            return 1
+
+    # Interactive confirmation (unless --quiet or resuming)
+    if not args.quiet and not resuming:
         # Count lines for clearing after confirmation
         lines_printed = 0
 
@@ -715,12 +934,16 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
     # Execute
     debug = args.verbosity == 'debug'
+    # Use log_file from checkpoint if resuming (continues logging to same file)
+    log_file = checkpoint.context.get('log_file') if checkpoint else None
     success = rescue_vm(
         vm_name=args.instance_name,
         zone=args.zone,
         project=project,
         config=config,
-        debug=debug
+        debug=debug,
+        resume_checkpoint=checkpoint if checkpoint else None,
+        log_file=log_file
     )
 
     # Format output
@@ -763,14 +986,37 @@ def handle_restore(args: argparse.Namespace) -> int:
         print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
         return 1
 
-    # Validate VM exists and is in rescue mode BEFORE confirmation
-    valid, vm_info, error_msg = _validate_vm_for_restore(compute, project, args.zone, args.instance_name)
-    if not valid:
-        print(f"{error_prefix()} {error_msg}", file=sys.stderr)
-        return 1
-
-    # Interactive confirmation (unless --quiet)
+    # Check for incomplete restore operation (interactive mode only)
+    checkpoint = None
+    resuming = False
     if not args.quiet:
+        checkpoint_mgr = CheckpointManager(compute, project, args.zone, args.instance_name)
+        checkpoint = checkpoint_mgr.detect_incomplete(operation_type='restore')
+
+        if checkpoint:
+            action = _prompt_incomplete_operation(checkpoint, 'restore')
+
+            if action == 'abort':
+                return 0
+            elif action == 'rollback':
+                # For restore rollback, we go back to rescue mode
+                success = _handle_restore_checkpoint_rollback(
+                    compute, project, args.zone, args.instance_name, checkpoint
+                )
+                return 0 if success else 1
+            # action == 'continue': proceed with resume
+            # Skip normal validation and confirmation when resuming
+            resuming = True
+
+    if not resuming:
+        # Validate VM exists and is in rescue mode BEFORE confirmation
+        valid, vm_info, error_msg = _validate_vm_for_restore(compute, project, args.zone, args.instance_name)
+        if not valid:
+            print(f"{error_prefix()} {error_msg}", file=sys.stderr)
+            return 1
+
+    # Interactive confirmation (unless --quiet or resuming)
+    if not args.quiet and not resuming:
         # Count lines for clearing after confirmation
         lines_printed = 0
 
@@ -805,12 +1051,16 @@ def handle_restore(args: argparse.Namespace) -> int:
 
     # Execute
     debug = args.verbosity == 'debug'
+    # Use log_file from checkpoint if resuming (continues logging to same file)
+    log_file = checkpoint.context.get('log_file') if checkpoint else None
     success = restore_vm(
         vm_name=args.instance_name,
         zone=args.zone,
         project=project,
         config=config,
-        debug=debug
+        debug=debug,
+        resume_checkpoint=checkpoint if checkpoint else None,
+        log_file=log_file
     )
 
     # Format output

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0-beta.3'
+VERSION = '2.0.0-beta.4'
 
 # OS Types
 OS_TYPE_LINUX = 'linux'

--- a/gce_rescue_v2/main.py
+++ b/gce_rescue_v2/main.py
@@ -24,10 +24,11 @@ from .orchestration import RescueOrchestrator, RestoreOrchestrator
 
 
 def rescue_vm(vm_name: str, zone: str, project: str = None,
-              config: RescueConfig = None, debug: bool = False) -> bool:
+              config: RescueConfig = None, debug: bool = False,
+              resume_checkpoint=None, log_file: str = None) -> bool:
     """
     Rescue a VM (enter rescue mode).
-    
+
     This will:
     1. Validate credentials and permissions
     2. Stop the VM
@@ -37,33 +38,38 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
     6. Set rescue metadata and startup script
     7. Start VM in rescue mode
     8. Re-attach original disk as secondary
-    
+
     On failure, automatically rolls back to original state.
-    
+    Supports resuming from interrupted operations via resume_checkpoint.
+
     Args:
         vm_name: Name of VM to rescue
         zone: GCP zone (e.g., 'us-central1-a')
         project: GCP project ID (optional, uses default if not provided)
         config: Optional RescueConfig for advanced settings
         debug: Enable debug logging (default: False)
-    
+        resume_checkpoint: Optional checkpoint data to resume from
+
     Returns:
         True if rescue succeeded, False if failed
-    
+
     Example:
         >>> rescue_vm('my-vm', 'us-central1-a', debug=True)
         True
     """
 
-    # Setup logging with auto-generated log file
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_file = f"{vm_name}-rescue-{timestamp}.log"
+    # Setup logging - use provided log_file (resume) or generate new one
+    if not log_file:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_file = f"{vm_name}-rescue-{timestamp}.log"
     logger = setup_logging(
         level='DEBUG' if debug else 'INFO',
         log_file=log_file,
         debug=debug
     )
 
+    if resume_checkpoint:
+        logger.debug(f"=== Session Resumed ===")
     logger.debug(f"GCE Rescue V2 - Rescue")
     logger.debug(f"Log file: {log_file}")
     logger.debug(f"VM: {vm_name}, Zone: {zone}" + (f", Project: {project}" if project else ""))
@@ -85,11 +91,17 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
             zone=zone,
             vm_name=vm_name,
             config=config,
-            logger=logger
+            logger=logger,
+            log_file=log_file
         )
-        
-        # Step 1: Validate
-        if not orchestrator.validate():
+
+        # Set resume state if resuming from checkpoint
+        if resume_checkpoint:
+            orchestrator.set_resume_state(resume_checkpoint)
+            logger.debug(f"Resuming from step {resume_checkpoint.current_step + 1}")
+
+        # Step 1: Validate (skip if resuming - already validated)
+        if not resume_checkpoint and not orchestrator.validate():
             logger.error("Validation failed. Cannot proceed with rescue.")
             return False
 
@@ -125,18 +137,24 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
 
         # Show OS-specific connection and mount instructions
         if orchestrator.os_type == OS_TYPE_WINDOWS:
-            # Get external IP for RDP connection
+            # Get external/internal IP for RDP connection
             vm = compute.instances().get(project=project, zone=zone, instance=vm_name).execute()
             external_ip = None
+            internal_ip = None
             for iface in vm.get('networkInterfaces', []):
+                if not internal_ip:
+                    internal_ip = iface.get('networkIP')
                 for access in iface.get('accessConfigs', []):
                     if access.get('natIP'):
                         external_ip = access.get('natIP')
                         break
 
-            ip_str = external_ip if external_ip else "N/A"
             logger.info("1. Connect via RDP:")
-            logger.info(f"   IP: {ip_str}")
+            if external_ip:
+                logger.info(f"   IP: {external_ip}")
+            else:
+                logger.info(f"   IP: {internal_ip} (internal - use IAP tunnel)")
+                logger.info(f"   Tunnel: gcloud compute start-iap-tunnel {vm_name} 3389 --local-host-port=localhost:3389 --zone={zone} --project={project}")
             logger.info(f"   User: rescue_admin")
             logger.info(f"   Password: {orchestrator.windows_rescue_password}")
             logger.info("")
@@ -176,10 +194,11 @@ def rescue_vm(vm_name: str, zone: str, project: str = None,
 
 
 def restore_vm(vm_name: str, zone: str, project: str = None,
-               config: RestoreConfig = None, debug: bool = False) -> bool:
+               config: RestoreConfig = None, debug: bool = False,
+               resume_checkpoint=None, log_file: str = None) -> bool:
     """
     Restore a VM (exit rescue mode).
-    
+
     This will:
     1. Validate VM is in rescue mode
     2. Stop the VM
@@ -189,33 +208,38 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
     6. Remove rescue metadata
     7. Start VM normally
     8. Delete rescue disk (if configured)
-    
+
     On failure, automatically rolls back to rescue mode.
-    
+    Supports resuming from interrupted operations via resume_checkpoint.
+
     Args:
         vm_name: Name of VM to restore
         zone: GCP zone (e.g., 'us-central1-a')
         project: GCP project ID (optional, uses default if not provided)
         config: Optional RestoreConfig for advanced settings
         debug: Enable debug logging (default: False)
-    
+        resume_checkpoint: Optional checkpoint data to resume from
+
     Returns:
         True if restore succeeded, False if failed
-    
+
     Example:
         >>> restore_vm('my-vm', 'us-central1-a')
         True
     """
 
-    # Setup logging with auto-generated log file
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_file = f"{vm_name}-restore-{timestamp}.log"
+    # Setup logging - use provided log_file (resume) or generate new one
+    if not log_file:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_file = f"{vm_name}-restore-{timestamp}.log"
     logger = setup_logging(
         level='DEBUG' if debug else 'INFO',
         log_file=log_file,
         debug=debug
     )
 
+    if resume_checkpoint:
+        logger.debug(f"=== Session Resumed ===")
     logger.debug(f"GCE Rescue V2 - Restore")
     logger.debug(f"Log file: {log_file}")
     logger.debug(f"VM: {vm_name}, Zone: {zone}" + (f", Project: {project}" if project else ""))
@@ -237,11 +261,17 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
             zone=zone,
             vm_name=vm_name,
             config=config,
-            logger=logger
+            logger=logger,
+            log_file=log_file
         )
-        
-        # Step 1: Validate
-        if not orchestrator.validate():
+
+        # Set resume state if resuming from checkpoint
+        if resume_checkpoint:
+            orchestrator.set_resume_state(resume_checkpoint)
+            logger.debug(f"Resuming from step {resume_checkpoint.current_step + 1}")
+
+        # Step 1: Validate (skip if resuming - already validated)
+        if not resume_checkpoint and not orchestrator.validate():
             logger.error("Validation failed. Cannot proceed with restore.")
             logger.error("Is the VM in rescue mode?")
             return False
@@ -270,10 +300,13 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
         logger.info(f"Instance [{vm_name}] restored to normal operation.")
         logger.info("")
         if os_type == OS_TYPE_WINDOWS:
-            # Get external IP for RDP connection
+            # Get external/internal IP for RDP connection
             external_ip = None
+            internal_ip = None
             try:
                 for iface in vm.get('networkInterfaces', []):
+                    if not internal_ip:
+                        internal_ip = iface.get('networkIP')
                     for access in iface.get('accessConfigs', []):
                         if access.get('natIP'):
                             external_ip = access.get('natIP')
@@ -284,8 +317,11 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
             logger.info("Connect via RDP using your original credentials:")
             if external_ip:
                 logger.info(f"  IP: {external_ip}")
+            elif internal_ip:
+                logger.info(f"  IP: {internal_ip} (internal - use IAP tunnel)")
+                logger.info(f"  Tunnel: gcloud compute start-iap-tunnel {vm_name} 3389 --local-host-port=localhost:3389 --zone={zone} --project={project}")
             else:
-                logger.info(f"  $ gcloud compute instances describe {vm_name} --zone={zone} --project={project} --format=\"get(networkInterfaces[0].accessConfigs[0].natIP)\"")
+                logger.info(f"  $ gcloud compute instances describe {vm_name} --zone={zone} --project={project} --format=\"get(networkInterfaces[0].networkIP)\"")
             logger.info("")
             logger.info("Forgot password? Reset it:")
             logger.info(f"  $ gcloud compute reset-windows-password {vm_name} --zone={zone} --project={project}")

--- a/gce_rescue_v2/operations/set_metadata.py
+++ b/gce_rescue_v2/operations/set_metadata.py
@@ -18,6 +18,9 @@ from ..core.config import VERSION
 # Prefix used to backup original metadata keys that conflict with rescue keys
 RESCUE_BACKUP_PREFIX = 'rescue-backup-'
 
+# Key used to store checkpoint data for resumable operations
+CHECKPOINT_KEY = 'gce-rescue-checkpoint'
+
 # Keys that rescue mode needs to set (may conflict with existing metadata)
 RESCUE_CONFLICT_KEYS = [
     'startup-script',
@@ -31,6 +34,7 @@ RESCUE_METADATA_KEYS = [
     'rescue-os-type',
     'startup-script',
     'windows-startup-script-ps1',
+    CHECKPOINT_KEY,  # Clean up checkpoint on restore
 ]
 
 

--- a/gce_rescue_v2/operations/start_vm.py
+++ b/gce_rescue_v2/operations/start_vm.py
@@ -128,6 +128,101 @@ class StartVMOperation(BaseOperation):
                     }
                 )
 
+            elif original_status in ('STAGING', 'PROVISIONING'):
+                # VM is already starting up, just wait for it
+                self._log_debug(f"VM is {original_status}, waiting for RUNNING...")
+                start_time = time.time()
+
+                def get_status():
+                    vm = self.compute.instances().get(
+                        project=self.project,
+                        zone=self.zone,
+                        instance=vm_name
+                    ).execute()
+                    return vm['status']
+
+                if not self._wait_for_status(get_status, 'RUNNING', timeout):
+                    error_detail = VM_START_TIMEOUT.format(
+                        vm_name=vm_name,
+                        zone=self.zone,
+                        project=self.project
+                    )
+                    self._log_error(error_detail)
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message=f"Timeout waiting for VM to reach RUNNING (>{timeout}s)",
+                        error=error_detail
+                    )
+
+                duration = time.time() - start_time
+                self._log_debug(f"VM reached RUNNING in {duration:.2f}s")
+
+                return OperationResult(
+                    operation_name=self.name,
+                    success=True,
+                    message=f"VM started ({duration:.0f}s)",
+                    rollback_data={
+                        'vm_name': vm_name,
+                        'original_status': 'TERMINATED'  # Treat as if it was terminated
+                    }
+                )
+
+            elif original_status == 'STOPPING':
+                # VM is stopping, wait for TERMINATED then start
+                self._log_debug("VM is STOPPING, waiting for TERMINATED...")
+
+                def get_status():
+                    vm = self.compute.instances().get(
+                        project=self.project,
+                        zone=self.zone,
+                        instance=vm_name
+                    ).execute()
+                    return vm['status']
+
+                if not self._wait_for_status(get_status, 'TERMINATED', timeout // 2):
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message="Timeout waiting for VM to stop",
+                        error="VM stuck in STOPPING state"
+                    )
+
+                # Now start it
+                self._log_debug("VM stopped, now starting...")
+                compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
+                compute.instances().start(
+                    project=self.project,
+                    zone=self.zone,
+                    instance=vm_name
+                ).execute()
+
+                start_time = time.time()
+                if not self._wait_for_status(get_status, 'RUNNING', timeout // 2):
+                    error_detail = VM_START_TIMEOUT.format(
+                        vm_name=vm_name,
+                        zone=self.zone,
+                        project=self.project
+                    )
+                    self._log_error(error_detail)
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message=f"Timeout waiting for VM to start (>{timeout}s)",
+                        error=error_detail
+                    )
+
+                duration = time.time() - start_time
+                return OperationResult(
+                    operation_name=self.name,
+                    success=True,
+                    message=f"VM started ({duration:.0f}s)",
+                    rollback_data={
+                        'vm_name': vm_name,
+                        'original_status': 'TERMINATED'
+                    }
+                )
+
             else:
                 return OperationResult(
                     operation_name=self.name,

--- a/gce_rescue_v2/orchestration/checkpoint.py
+++ b/gce_rescue_v2/orchestration/checkpoint.py
@@ -1,0 +1,529 @@
+"""
+GCE Rescue - Checkpoint Manager
+
+Manages operation checkpoints for resumable rescue/restore operations.
+Checkpoints are stored in VM metadata to enable recovery from interrupted sessions.
+"""
+
+import json
+import uuid
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Optional, List, Dict, Any, Tuple
+
+# Metadata key for checkpoint data
+CHECKPOINT_KEY = 'gce-rescue-checkpoint'
+
+# Schema version for future compatibility
+CHECKPOINT_VERSION = 1
+
+
+@dataclass
+class CompletedOperation:
+    """Record of a completed operation with rollback data."""
+    name: str
+    step: int
+    rollback_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            'name': self.name,
+            'step': self.step,
+            'rollback_data': self.rollback_data
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'CompletedOperation':
+        """Create from dictionary."""
+        return cls(
+            name=data['name'],
+            step=data['step'],
+            rollback_data=data.get('rollback_data', {})
+        )
+
+
+@dataclass
+class CheckpointData:
+    """
+    Complete checkpoint state for a rescue/restore operation.
+
+    This captures everything needed to resume or rollback an interrupted operation.
+    """
+    version: int
+    operation: str  # 'rescue' or 'restore'
+    session_id: str
+    started_at: str
+    updated_at: str
+    current_step: int
+    total_steps: int
+    completed_operations: List[CompletedOperation]
+    context: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            'version': self.version,
+            'operation': self.operation,
+            'session_id': self.session_id,
+            'started_at': self.started_at,
+            'updated_at': self.updated_at,
+            'current_step': self.current_step,
+            'total_steps': self.total_steps,
+            'completed_operations': [op.to_dict() for op in self.completed_operations],
+            'context': self.context
+        }
+
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'CheckpointData':
+        """Create from dictionary."""
+        return cls(
+            version=data.get('version', 1),
+            operation=data['operation'],
+            session_id=data['session_id'],
+            started_at=data['started_at'],
+            updated_at=data['updated_at'],
+            current_step=data['current_step'],
+            total_steps=data['total_steps'],
+            completed_operations=[
+                CompletedOperation.from_dict(op)
+                for op in data.get('completed_operations', [])
+            ],
+            context=data.get('context', {})
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> 'CheckpointData':
+        """Create from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+
+    def get_last_completed_operation(self) -> Optional[str]:
+        """Get the name of the last completed operation."""
+        if self.completed_operations:
+            return self.completed_operations[-1].name
+        return None
+
+    def get_next_step_number(self) -> int:
+        """Get the next step number to execute (1-indexed)."""
+        return self.current_step + 1
+
+    def get_age_seconds(self) -> float:
+        """Get the age of this checkpoint in seconds."""
+        started = datetime.fromisoformat(self.started_at.replace('Z', '+00:00'))
+        now = datetime.now(timezone.utc)
+        return (now - started).total_seconds()
+
+    def get_age_display(self) -> str:
+        """Get human-readable age string."""
+        seconds = self.get_age_seconds()
+        if seconds < 60:
+            return f"{int(seconds)} seconds ago"
+        minutes = int(seconds / 60)
+        if minutes < 60:
+            return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+        hours = int(minutes / 60)
+        if hours < 24:
+            return f"{hours} hour{'s' if hours != 1 else ''} ago"
+        days = int(hours / 24)
+        return f"{days} day{'s' if days != 1 else ''} ago"
+
+
+class CheckpointManager:
+    """
+    Manages checkpoint persistence for resumable operations.
+
+    Checkpoints are stored in VM metadata under the key 'gce-rescue-checkpoint'.
+    This allows recovery from interrupted sessions by detecting incomplete
+    operations when the same command is run again.
+
+    Example:
+        mgr = CheckpointManager(compute, project, zone, vm_name, logger)
+
+        # Start tracking a new rescue operation
+        session_id = mgr.create_checkpoint('rescue', total_steps=9, context={...})
+
+        # After each successful operation
+        mgr.update_checkpoint(step=1, operation_name='Stop VM', rollback_data={...})
+
+        # On successful completion
+        mgr.clear_checkpoint()
+
+        # To check for incomplete operation
+        checkpoint = mgr.load_checkpoint()
+        if checkpoint:
+            # Incomplete operation found - prompt user
+            pass
+    """
+
+    # Maximum retries for metadata operations
+    MAX_RETRIES = 3
+    RETRY_DELAY = 2
+
+    # Stale threshold in hours (checkpoints older than this get auto-prompted)
+    STALE_THRESHOLD_HOURS = 1.0
+
+    def __init__(self, compute, project: str, zone: str, vm_name: str, logger=None):
+        """
+        Initialize checkpoint manager.
+
+        Args:
+            compute: GCP compute client
+            project: GCP project ID
+            zone: GCP zone
+            vm_name: Name of VM being operated on
+            logger: Optional logger for debug output
+        """
+        self.compute = compute
+        self.project = project
+        self.zone = zone
+        self.vm_name = vm_name
+        self.logger = logger
+        self._current_session_id: Optional[str] = None
+
+    def _log_debug(self, message: str):
+        """Log debug message with component prefix."""
+        if self.logger:
+            self.logger.debug(f"[Checkpoint] {message}", stacklevel=2)
+
+    def _log_info(self, message: str):
+        """Log info message."""
+        if self.logger:
+            self.logger.info(message)
+
+    def _log_error(self, message: str):
+        """Log error message."""
+        if self.logger:
+            self.logger.error(message)
+
+    def _get_vm_metadata(self) -> Tuple[Dict[str, str], str]:
+        """
+        Get current VM metadata as dict and fingerprint.
+
+        Returns:
+            Tuple of (metadata_dict, fingerprint)
+        """
+        vm = self.compute.instances().get(
+            project=self.project,
+            zone=self.zone,
+            instance=self.vm_name
+        ).execute()
+
+        metadata = vm.get('metadata', {})
+        fingerprint = metadata.get('fingerprint', '')
+        items = metadata.get('items', [])
+
+        metadata_dict = {item['key']: item['value'] for item in items}
+        return metadata_dict, fingerprint
+
+    def _set_vm_metadata(self, metadata_dict: Dict[str, str], fingerprint: str) -> bool:
+        """
+        Set VM metadata with retry logic.
+
+        Args:
+            metadata_dict: Metadata as key-value dict
+            fingerprint: Metadata fingerprint for optimistic locking
+
+        Returns:
+            True if successful, False otherwise
+        """
+        import time
+
+        items = [{'key': k, 'value': v} for k, v in metadata_dict.items()]
+        body = {
+            'fingerprint': fingerprint,
+            'items': items
+        }
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                operation = self.compute.instances().setMetadata(
+                    project=self.project,
+                    zone=self.zone,
+                    instance=self.vm_name,
+                    body=body
+                ).execute()
+
+                # Wait for operation to complete
+                if self._wait_for_operation(operation):
+                    return True
+
+            except Exception as e:
+                self._log_debug(f"Metadata set attempt {attempt + 1} failed: {e}")
+
+                # Refresh fingerprint on conflict
+                if 'fingerprint' in str(e).lower() or 'precondition' in str(e).lower():
+                    try:
+                        _, fingerprint = self._get_vm_metadata()
+                        body['fingerprint'] = fingerprint
+                    except Exception:
+                        pass
+
+                if attempt < self.MAX_RETRIES - 1:
+                    time.sleep(self.RETRY_DELAY)
+
+        return False
+
+    def _wait_for_operation(self, operation: dict, timeout: int = 60) -> bool:
+        """Wait for a GCP operation to complete."""
+        import time
+
+        operation_name = operation.get('name')
+        if not operation_name:
+            return True
+
+        start_time = time.time()
+        while True:
+            if time.time() - start_time > timeout:
+                return False
+
+            try:
+                result = self.compute.zoneOperations().get(
+                    project=self.project,
+                    zone=self.zone,
+                    operation=operation_name
+                ).execute()
+
+                if result.get('status') == 'DONE':
+                    return 'error' not in result
+
+            except Exception:
+                pass
+
+            time.sleep(1)
+
+    def create_checkpoint(self, operation_type: str, total_steps: int,
+                         context: Dict[str, Any]) -> str:
+        """
+        Create initial checkpoint for a new operation.
+
+        Args:
+            operation_type: 'rescue' or 'restore'
+            total_steps: Total number of steps in the operation
+            context: Operation context (vm_name, original_disk, etc.)
+
+        Returns:
+            Session ID for this operation
+        """
+        session_id = str(uuid.uuid4())[:8]
+        self._current_session_id = session_id
+
+        now = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+        checkpoint = CheckpointData(
+            version=CHECKPOINT_VERSION,
+            operation=operation_type,
+            session_id=session_id,
+            started_at=now,
+            updated_at=now,
+            current_step=0,
+            total_steps=total_steps,
+            completed_operations=[],
+            context=context
+        )
+
+        self._log_debug(f"Creating checkpoint: session={session_id}, operation={operation_type}")
+
+        # Get current metadata and add checkpoint
+        metadata_dict, fingerprint = self._get_vm_metadata()
+        metadata_dict[CHECKPOINT_KEY] = checkpoint.to_json()
+
+        if not self._set_vm_metadata(metadata_dict, fingerprint):
+            self._log_error("Warning: Failed to save initial checkpoint to metadata")
+
+        return session_id
+
+    def update_checkpoint(self, step: int, operation_name: str,
+                         rollback_data: Dict[str, Any] = None,
+                         context_updates: Dict[str, Any] = None) -> bool:
+        """
+        Update checkpoint after a successful operation step.
+
+        Args:
+            step: Step number that just completed (1-indexed)
+            operation_name: Name of the completed operation
+            rollback_data: Data needed to rollback this operation
+            context_updates: Optional context updates
+
+        Returns:
+            True if checkpoint was saved successfully
+        """
+        self._log_debug(f"Updating checkpoint: step={step}, operation={operation_name}")
+
+        # Load current checkpoint
+        checkpoint = self.load_checkpoint()
+        if not checkpoint:
+            self._log_error("Warning: No checkpoint found to update")
+            return False
+
+        # Verify session ID matches
+        if checkpoint.session_id != self._current_session_id:
+            self._log_error(f"Warning: Session ID mismatch: {checkpoint.session_id} vs {self._current_session_id}")
+
+        # Add completed operation
+        completed_op = CompletedOperation(
+            name=operation_name,
+            step=step,
+            rollback_data=rollback_data or {}
+        )
+        checkpoint.completed_operations.append(completed_op)
+        checkpoint.current_step = step
+        checkpoint.updated_at = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+        # Update context if provided
+        if context_updates:
+            checkpoint.context.update(context_updates)
+
+        # Save updated checkpoint
+        metadata_dict, fingerprint = self._get_vm_metadata()
+        metadata_dict[CHECKPOINT_KEY] = checkpoint.to_json()
+
+        if not self._set_vm_metadata(metadata_dict, fingerprint):
+            self._log_error("Warning: Failed to save checkpoint update to metadata")
+            return False
+
+        return True
+
+    def load_checkpoint(self) -> Optional[CheckpointData]:
+        """
+        Load checkpoint from VM metadata.
+
+        Returns:
+            CheckpointData if checkpoint exists, None otherwise
+        """
+        try:
+            metadata_dict, _ = self._get_vm_metadata()
+            checkpoint_json = metadata_dict.get(CHECKPOINT_KEY)
+
+            if not checkpoint_json:
+                return None
+
+            return CheckpointData.from_json(checkpoint_json)
+
+        except json.JSONDecodeError as e:
+            self._log_error(f"Warning: Corrupted checkpoint data: {e}")
+            return None
+        except Exception as e:
+            self._log_debug(f"Error loading checkpoint: {e}")
+            return None
+
+    def clear_checkpoint(self) -> bool:
+        """
+        Clear checkpoint from VM metadata (on successful completion).
+
+        Returns:
+            True if cleared successfully
+        """
+        self._log_debug("Clearing checkpoint")
+
+        try:
+            metadata_dict, fingerprint = self._get_vm_metadata()
+
+            if CHECKPOINT_KEY in metadata_dict:
+                del metadata_dict[CHECKPOINT_KEY]
+                return self._set_vm_metadata(metadata_dict, fingerprint)
+
+            return True
+
+        except Exception as e:
+            self._log_error(f"Warning: Failed to clear checkpoint: {e}")
+            return False
+
+    def detect_incomplete(self, operation_type: str = None) -> Optional[CheckpointData]:
+        """
+        Detect if there's an incomplete operation for this VM.
+
+        Args:
+            operation_type: Optional filter for specific operation type ('rescue' or 'restore')
+
+        Returns:
+            CheckpointData if incomplete operation found, None otherwise
+        """
+        checkpoint = self.load_checkpoint()
+
+        if not checkpoint:
+            return None
+
+        # Filter by operation type if specified
+        if operation_type and checkpoint.operation != operation_type:
+            return None
+
+        # Check if operation is incomplete (not all steps done)
+        if checkpoint.current_step < checkpoint.total_steps:
+            self._log_debug(
+                f"Incomplete operation detected: {checkpoint.operation} "
+                f"({checkpoint.current_step}/{checkpoint.total_steps} steps)"
+            )
+            return checkpoint
+
+        # Checkpoint exists but operation is complete - auto-clear stale checkpoint
+        # This handles the case where Ctrl+C happened after last step but before cleanup
+        self._log_debug(
+            f"Found completed checkpoint ({checkpoint.current_step}/{checkpoint.total_steps}), "
+            "auto-clearing stale checkpoint"
+        )
+        self.clear_checkpoint()
+        return None
+
+    def is_stale(self, checkpoint: CheckpointData) -> bool:
+        """
+        Check if a checkpoint is stale (older than threshold).
+
+        Stale checkpoints may indicate abandoned operations and can be
+        safely prompted without requiring --force.
+
+        Args:
+            checkpoint: Checkpoint to check
+
+        Returns:
+            True if checkpoint is stale
+        """
+        age_hours = checkpoint.get_age_seconds() / 3600
+        return age_hours > self.STALE_THRESHOLD_HOURS
+
+    def is_concurrent(self, checkpoint: CheckpointData) -> bool:
+        """
+        Check if checkpoint appears to be from a concurrent/active session.
+
+        A checkpoint is considered potentially concurrent if:
+        - It's recent (not stale)
+        - Session ID doesn't match current session
+
+        Args:
+            checkpoint: Checkpoint to check
+
+        Returns:
+            True if checkpoint may be from concurrent session
+        """
+        if self.is_stale(checkpoint):
+            return False
+
+        if self._current_session_id and checkpoint.session_id == self._current_session_id:
+            return False
+
+        return True
+
+    def set_session_id(self, session_id: str):
+        """
+        Set the current session ID (for resuming operations).
+
+        Args:
+            session_id: Session ID to adopt
+        """
+        self._current_session_id = session_id
+
+    def get_rollback_operations(self, checkpoint: CheckpointData) -> List[CompletedOperation]:
+        """
+        Get completed operations in reverse order for rollback.
+
+        Args:
+            checkpoint: Checkpoint containing completed operations
+
+        Returns:
+            List of CompletedOperation in reverse order
+        """
+        return list(reversed(checkpoint.completed_operations))

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -30,6 +30,7 @@ from ..operations import (
 )
 from .state import StateTracker
 from .rollback import RollbackHandler
+from .checkpoint import CheckpointManager, CheckpointData
 
 
 class RescueOrchestrator:
@@ -68,7 +69,7 @@ class RescueOrchestrator:
     """
 
     def __init__(self, compute, project: str, zone: str, vm_name: str,
-                 config: RescueConfig = None, logger=None):
+                 config: RescueConfig = None, logger=None, log_file: str = None):
         """
         Initialize rescue orchestrator.
 
@@ -79,6 +80,7 @@ class RescueOrchestrator:
             vm_name: Name of VM to rescue
             config: Optional rescue configuration
             logger: Optional logger
+            log_file: Log file path (for checkpoint persistence)
         """
         self.compute = compute
         self.project = project
@@ -86,6 +88,7 @@ class RescueOrchestrator:
         self.vm_name = vm_name
         self.config = config or RescueConfig()
         self.logger = logger
+        self.log_file = log_file
 
         # State tracking
         self.state_tracker = StateTracker()
@@ -121,6 +124,15 @@ class RescueOrchestrator:
         self._progress_lock = None
         self._total_steps = 5  # Stopping, Snapshotting, Creating rescue disk, Starting, Attaching
 
+        # Checkpoint manager for resumable operations
+        self.checkpoint_manager = CheckpointManager(
+            compute, project, zone, vm_name, logger
+        )
+
+        # Resume state (set when resuming from checkpoint)
+        self._resume_from_step = 0  # 0 = fresh start, >0 = resume from this step
+        self._resumed_context = None  # Context from checkpoint
+
     def _init_progress(self):
         """Initialize spinner with phases display."""
         import sys
@@ -132,6 +144,22 @@ class RescueOrchestrator:
         self._is_debug_mode = console_level <= logging.DEBUG
         self._progress_phases = []
         self._progress_lock = threading.Lock()
+
+        # If resuming, initialize phases from completed steps
+        if self._resume_from_step > 0:
+            # Map step numbers to phases (phases are added at these steps)
+            # Step 1: Stopping, Step 3: Snapshotting, Step 4: Creating rescue disk,
+            # Step 7: Starting, Step 9: Attaching affected disk
+            step_to_phase = {
+                1: "Stopping",
+                3: "Snapshotting",
+                4: "Creating rescue disk",
+                7: "Starting",
+                9: "Attaching affected disk"
+            }
+            for step in sorted(step_to_phase.keys()):
+                if step <= self._resume_from_step:
+                    self._progress_phases.append(step_to_phase[step])
 
         if not self._is_debug_mode:
             # Print header line
@@ -216,6 +244,83 @@ class RescueOrchestrator:
         if self.logger:
             self.logger.error(message)
 
+    def set_resume_state(self, checkpoint: CheckpointData):
+        """
+        Set resume state from a checkpoint.
+
+        Call this before execute() to resume from an interrupted operation.
+
+        Args:
+            checkpoint: Checkpoint data from previous interrupted operation
+        """
+        self._resume_from_step = checkpoint.current_step
+        self._resumed_context = checkpoint.context
+        self.checkpoint_manager.set_session_id(checkpoint.session_id)
+
+        # Restore context from checkpoint
+        if self._resumed_context:
+            self.original_disk_name = self._resumed_context.get('original_disk_name')
+            self.original_device_name = self._resumed_context.get('original_device_name')
+            self.rescue_disk_name = self._resumed_context.get('rescue_disk_name')
+            self.os_type = self._resumed_context.get('os_type')
+
+        self._log_debug(f"Resume state set: continuing from step {self._resume_from_step + 1}")
+
+    def _should_skip_step(self, step: int) -> bool:
+        """Check if a step should be skipped (already completed in previous session)."""
+        return step <= self._resume_from_step
+
+    def _is_disk_attached(self, disk_name: str) -> bool:
+        """Check if a disk is already attached to the VM."""
+        try:
+            vm = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=self.vm_name
+            ).execute()
+            for disk in vm.get('disks', []):
+                if disk.get('source', '').endswith(f'/disks/{disk_name}'):
+                    return True
+            return False
+        except Exception:
+            return False
+
+    def _disk_exists(self, disk_name: str) -> bool:
+        """Check if a disk exists."""
+        try:
+            self.compute.disks().get(
+                project=self.project,
+                zone=self.zone,
+                disk=disk_name
+            ).execute()
+            return True
+        except Exception:
+            return False
+
+    def _get_vm_status(self) -> str:
+        """Get current VM status."""
+        try:
+            vm = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=self.vm_name
+            ).execute()
+            return vm.get('status', 'UNKNOWN')
+        except Exception:
+            return 'UNKNOWN'
+
+    def _get_checkpoint_context(self) -> dict:
+        """Get context dict for checkpoint."""
+        return {
+            'vm_name': self.vm_name,
+            'zone': self.zone,
+            'original_disk_name': self.original_disk_name,
+            'original_device_name': self.original_device_name,
+            'rescue_disk_name': self.rescue_disk_name,
+            'os_type': self.os_type,
+            'log_file': self.log_file
+        }
+
     def validate(self) -> bool:
         """
         Run pre-flight validation.
@@ -274,14 +379,29 @@ class RescueOrchestrator:
         # Initialize progress display
         self._init_progress()
 
+        # Total internal steps for checkpoint tracking
+        total_checkpoint_steps = 9  # Stop, Detach, Snapshot, CreateDisk, AttachRescue, SetMeta, Start, AttachOrig, Verify
+
         try:
-            # Generate rescue disk name
-            rescue_disk_name = f"rescue-disk-{int(time.time())}"
-            self.rescue_disk_name = rescue_disk_name  # Store for output
+            # Get original disk info if not resuming (or if not already set)
+            if not self._resume_from_step or not self.original_disk_name:
+                self._get_original_disk_info()
+
+            # Generate rescue disk name if not resuming
+            if not self._resume_from_step or not self.rescue_disk_name:
+                rescue_disk_name = f"rescue-disk-{int(time.time())}"
+                self.rescue_disk_name = rescue_disk_name
+            else:
+                rescue_disk_name = self.rescue_disk_name
             self._log_debug(f"Rescue disk name: {rescue_disk_name}")
 
-            # Get original disk info
-            self._get_original_disk_info()
+            # Create initial checkpoint if not resuming
+            if not self._resume_from_step:
+                self.checkpoint_manager.create_checkpoint(
+                    operation_type='rescue',
+                    total_steps=total_checkpoint_steps,
+                    context=self._get_checkpoint_context()
+                )
 
             # Create operations (in execution order)
             stop_vm = StopVMOperation(self.compute, self.project, self.zone, self.logger)
@@ -306,36 +426,53 @@ class RescueOrchestrator:
             }
 
             # Step 1: Stop VM
-            self._update_progress("Stopping")
-            self._log_debug(f"Stopping instance {self.vm_name}...")
-            result = stop_vm.execute(
-                vm_name=self.vm_name,
-                timeout=self.config.vm_stop_timeout,
-                discard_local_ssd=self.config.force,
-                tracking_label='rescue-vm-stop'
-            )
-            self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(1):
+                self._update_progress("Stopping")
+                self._log_debug(f"Stopping instance {self.vm_name}...")
+                result = stop_vm.execute(
+                    vm_name=self.vm_name,
+                    timeout=self.config.vm_stop_timeout,
+                    discard_local_ssd=self.config.force,
+                    tracking_label='rescue-vm-stop'
+                )
+                self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data, step_number=1)
+                if not result.success:
+                    self._finish_progress(False)
+                    self._rollback()
+                    return False
+                # Update checkpoint after successful step
+                self.checkpoint_manager.update_checkpoint(
+                    step=1, operation_name="Stop VM",
+                    rollback_data=result.rollback_data,
+                    context_updates=self._get_checkpoint_context()
+                )
+            else:
+                self._log_debug("Skipping Step 1 (Stop VM) - already completed")
 
             # Step 2: Detach boot disk
-            self._log_debug("Detaching boot disk...")
-            result = detach_boot.execute(
-                vm_name=self.vm_name,
-                device_name=self.original_device_name,
-                tracking_label='rescue-disk-detach-orig'
-            )
-            self.state_tracker.add_operation("Detach Boot Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(2):
+                self._log_debug("Detaching boot disk...")
+                result = detach_boot.execute(
+                    vm_name=self.vm_name,
+                    device_name=self.original_device_name,
+                    tracking_label='rescue-disk-detach-orig'
+                )
+                self.state_tracker.add_operation("Detach Boot Disk", result.success, result.message, result.rollback_data, step_number=2)
+                if not result.success:
+                    self._finish_progress(False)
+                    self._rollback()
+                    return False
+                # Update checkpoint
+                self.checkpoint_manager.update_checkpoint(
+                    step=2, operation_name="Detach Boot Disk",
+                    rollback_data=result.rollback_data
+                )
+            else:
+                self._log_debug("Skipping Step 2 (Detach Boot Disk) - already completed")
 
             # Step 3: Create safety snapshot
             pending_snapshot_name = None
-            if self.config.create_snapshot:
+            if self.config.create_snapshot and not self._should_skip_step(3):
                 self._update_progress("Snapshotting")
                 self._log_debug("Creating snapshot...")
                 result = create_snapshot.execute(
@@ -346,7 +483,7 @@ class RescueOrchestrator:
                     wait=not self.config.async_snapshot,
                     tracking_label='rescue-disk-snapshot'
                 )
-                self.state_tracker.add_operation("Create Snapshot", result.success, result.message, result.rollback_data)
+                self.state_tracker.add_operation("Create Snapshot", result.success, result.message, result.rollback_data, step_number=3)
 
                 if not result.success:
                     if self.config.require_snapshot:
@@ -356,86 +493,167 @@ class RescueOrchestrator:
                 else:
                     pending_snapshot_name = result.rollback_data.get('snapshot_name')
                     self.snapshot_name = pending_snapshot_name  # Store for output
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=3, operation_name="Create Snapshot",
+                        rollback_data=result.rollback_data,
+                        context_updates={'snapshot_name': pending_snapshot_name}
+                    )
+            elif self._should_skip_step(3):
+                self._log_debug("Skipping Step 3 (Create Snapshot) - already completed")
+                # Restore snapshot name from context if resuming
+                if self._resumed_context:
+                    pending_snapshot_name = self._resumed_context.get('snapshot_name')
+                    self.snapshot_name = pending_snapshot_name
 
             # Step 4: Create rescue disk
-            self._update_progress("Creating rescue disk")
-            if self.os_type == OS_TYPE_WINDOWS:
-                rescue_image_project = self.config.windows_rescue_image_project
-                rescue_image_family = self.config.windows_rescue_image_family
-                rescue_disk_size = self.config.windows_rescue_disk_size_gb
-            else:
-                rescue_image_project = self.config.rescue_image_project
-                rescue_image_family = self.config.rescue_image_family
-                rescue_disk_size = self.config.rescue_disk_size_gb
+            if not self._should_skip_step(4):
+                self._update_progress("Creating rescue disk")
+                # Idempotency check: skip if rescue disk already exists
+                if self._disk_exists(rescue_disk_name):
+                    self._log_debug("Skipping Step 4 (Create Rescue Disk) - disk already exists")
+                    # Update checkpoint to record this step as done
+                    self.checkpoint_manager.update_checkpoint(
+                        step=4, operation_name="Create Rescue Disk",
+                        rollback_data={'disk_name': rescue_disk_name},
+                        context_updates={'rescue_disk_name': rescue_disk_name}
+                    )
+                else:
+                    if self.os_type == OS_TYPE_WINDOWS:
+                        rescue_image_project = self.config.windows_rescue_image_project
+                        rescue_image_family = self.config.windows_rescue_image_family
+                        rescue_disk_size = self.config.windows_rescue_disk_size_gb
+                    else:
+                        rescue_image_project = self.config.rescue_image_project
+                        rescue_image_family = self.config.rescue_image_family
+                        rescue_disk_size = self.config.rescue_disk_size_gb
 
-            self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB)...")
-            result = create_disk.execute(
-                disk_name=rescue_disk_name,
-                size_gb=rescue_disk_size,
-                disk_type=self.config.rescue_disk_type,
-                source_image=f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}',
-                timeout=self.config.disk_create_timeout,
-                tracking_label='rescue-disk-create-rescue'
-            )
-            self.state_tracker.add_operation("Create Rescue Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+                    self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB)...")
+                    result = create_disk.execute(
+                        disk_name=rescue_disk_name,
+                        size_gb=rescue_disk_size,
+                        disk_type=self.config.rescue_disk_type,
+                        source_image=f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}',
+                        timeout=self.config.disk_create_timeout,
+                        tracking_label='rescue-disk-create-rescue'
+                    )
+                    self.state_tracker.add_operation("Create Rescue Disk", result.success, result.message, result.rollback_data, step_number=4)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=4, operation_name="Create Rescue Disk",
+                        rollback_data=result.rollback_data,
+                        context_updates={'rescue_disk_name': rescue_disk_name}
+                    )
+            else:
+                self._log_debug("Skipping Step 4 (Create Rescue Disk) - already completed")
 
             # Step 5: Attach rescue disk as boot
-            self._log_debug("Attaching rescue disk as boot...")
-            result = attach_rescue.execute(
-                vm_name=self.vm_name,
-                disk_name=rescue_disk_name,
-                boot=True,
-                tracking_label='rescue-disk-attach-rescue'
-            )
-            self.state_tracker.add_operation("Attach Rescue Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(5):
+                # Idempotency check: skip if rescue disk already attached
+                if self._is_disk_attached(rescue_disk_name):
+                    self._log_debug("Skipping Step 5 (Attach Rescue Disk) - disk already attached")
+                    # Update checkpoint to record this step as done
+                    self.checkpoint_manager.update_checkpoint(
+                        step=5, operation_name="Attach Rescue Disk",
+                        rollback_data={'vm_name': self.vm_name, 'disk_name': rescue_disk_name}
+                    )
+                else:
+                    self._log_debug("Attaching rescue disk as boot...")
+                    result = attach_rescue.execute(
+                        vm_name=self.vm_name,
+                        disk_name=rescue_disk_name,
+                        boot=True,
+                        tracking_label='rescue-disk-attach-rescue'
+                    )
+                    self.state_tracker.add_operation("Attach Rescue Disk", result.success, result.message, result.rollback_data, step_number=5)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=5, operation_name="Attach Rescue Disk",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 5 (Attach Rescue Disk) - already completed")
 
             # Step 6: Set rescue metadata
-            self._log_debug("Setting rescue metadata...")
-            startup_script = self._generate_startup_script()
+            if not self._should_skip_step(6):
+                self._log_debug("Setting rescue metadata...")
+                startup_script = self._generate_startup_script()
 
-            if self.os_type == OS_TYPE_WINDOWS:
-                script_key = 'windows-startup-script-ps1'
+                if self.os_type == OS_TYPE_WINDOWS:
+                    script_key = 'windows-startup-script-ps1'
+                else:
+                    script_key = 'startup-script'
+
+                metadata_items = [
+                    {'key': script_key, 'value': startup_script},
+                    {'key': 'rescue-mode', 'value': str(int(time.time()))},
+                    {'key': 'rescue-original-disk', 'value': self.original_disk_name},
+                    {'key': 'rescue-os-type', 'value': self.os_type}
+                ]
+                result = set_metadata.execute(
+                    vm_name=self.vm_name,
+                    metadata_items=metadata_items,
+                    tracking_label='rescue-meta-set-rescue-keys'
+                )
+                self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data, step_number=6)
+                if not result.success:
+                    self._finish_progress(False)
+                    self._rollback()
+                    return False
+                # Update checkpoint - include Windows password if set
+                context_updates = {}
+                if self.os_type == OS_TYPE_WINDOWS and self.windows_rescue_password:
+                    context_updates['windows_rescue_password'] = self.windows_rescue_password
+                self.checkpoint_manager.update_checkpoint(
+                    step=6, operation_name="Set Metadata",
+                    rollback_data=result.rollback_data,
+                    context_updates=context_updates if context_updates else None
+                )
             else:
-                script_key = 'startup-script'
-
-            metadata_items = [
-                {'key': script_key, 'value': startup_script},
-                {'key': 'rescue-mode', 'value': str(int(time.time()))},
-                {'key': 'rescue-original-disk', 'value': self.original_disk_name},
-                {'key': 'rescue-os-type', 'value': self.os_type}
-            ]
-            result = set_metadata.execute(
-                vm_name=self.vm_name,
-                metadata_items=metadata_items,
-                tracking_label='rescue-meta-set-rescue-keys'
-            )
-            self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+                self._log_debug("Skipping Step 6 (Set Metadata) - already completed")
+                # Restore Windows password from checkpoint context if resuming
+                if self._resumed_context and self.os_type == OS_TYPE_WINDOWS:
+                    self.windows_rescue_password = self._resumed_context.get('windows_rescue_password')
 
             # Step 7: Start VM in rescue mode
-            self._update_progress("Starting")
-            self._log_debug(f"Starting instance {self.vm_name}...")
-            result = start_vm.execute(
-                vm_name=self.vm_name,
-                timeout=self.config.vm_start_timeout,
-                tracking_label='rescue-vm-start'
-            )
-            self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(7):
+                self._update_progress("Starting")
+                # Idempotency check: skip if VM is already running
+                vm_status = self._get_vm_status()
+                if vm_status == 'RUNNING':
+                    self._log_debug("Skipping Step 7 (Start VM) - VM already running")
+                    # Update checkpoint to record this step as done
+                    self.checkpoint_manager.update_checkpoint(
+                        step=7, operation_name="Start VM",
+                        rollback_data={'vm_name': self.vm_name, 'original_status': 'TERMINATED'}
+                    )
+                else:
+                    self._log_debug(f"Starting instance {self.vm_name}...")
+                    result = start_vm.execute(
+                        vm_name=self.vm_name,
+                        timeout=self.config.vm_start_timeout,
+                        tracking_label='rescue-vm-start'
+                    )
+                    self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data, step_number=7)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=7, operation_name="Start VM",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 7 (Start VM) - already completed")
 
             # Wait for snapshot completion (if async mode) - not a numbered step
             if pending_snapshot_name and self.config.async_snapshot:
@@ -481,33 +699,60 @@ class RescueOrchestrator:
                     time.sleep(5)
 
             # Step 8: Re-attach original disk as secondary
-            self._log_debug("Attaching original boot disk as secondary...")
-            time.sleep(5)  # Brief wait for VM stability
-            result = attach_original.execute(
-                vm_name=self.vm_name,
-                disk_name=self.original_disk_name,
-                boot=False,
-                tracking_label='rescue-disk-attach-orig'
-            )
-            self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(8):
+                # Idempotency check: skip if original disk already attached
+                if self._is_disk_attached(self.original_disk_name):
+                    self._log_debug("Skipping Step 8 (Attach Original Disk) - disk already attached")
+                    # Update checkpoint to record this step as done
+                    self.checkpoint_manager.update_checkpoint(
+                        step=8, operation_name="Attach Original Disk",
+                        rollback_data={'vm_name': self.vm_name, 'disk_name': self.original_disk_name}
+                    )
+                else:
+                    self._log_debug("Attaching original boot disk as secondary...")
+                    time.sleep(5)  # Brief wait for VM stability
+                    result = attach_original.execute(
+                        vm_name=self.vm_name,
+                        disk_name=self.original_disk_name,
+                        boot=False,
+                        tracking_label='rescue-disk-attach-orig'
+                    )
+                    self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data, step_number=8)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=8, operation_name="Attach Original Disk",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 8 (Attach Original Disk) - already completed")
 
             # Step 9: Verify startup script completion (disk mounting)
-            self._update_progress("Attaching affected disk")
-            self._log_debug("Verifying startup script...")
-            verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
-            result = verify_startup.execute(
-                vm_name=self.vm_name,
-                timeout=self.config.startup_verification_timeout,
-                tracking_label='rescue-vm-verify-startup'
-            )
-            self.verification_succeeded = result.success
-            # Don't fail on verification timeout - continue
+            if not self._should_skip_step(9):
+                self._update_progress("Attaching affected disk")
+                self._log_debug("Verifying startup script...")
+                verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
+                result = verify_startup.execute(
+                    vm_name=self.vm_name,
+                    timeout=self.config.startup_verification_timeout,
+                    tracking_label='rescue-vm-verify-startup'
+                )
+                self.verification_succeeded = result.success
+                # Don't fail on verification timeout - continue
+                # Update checkpoint (final step)
+                self.checkpoint_manager.update_checkpoint(
+                    step=9, operation_name="Verify Startup",
+                    rollback_data={}
+                )
+            else:
+                self._log_debug("Skipping Step 9 (Verify Startup) - already completed")
+                self.verification_succeeded = True  # Assume success if resuming past this step
 
-            # Success!
+            # Success! Clear checkpoint
+            self.checkpoint_manager.clear_checkpoint()
             self._finish_progress(True)
             return True
 

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -30,6 +30,7 @@ from ..operations import (
 )
 from .state import StateTracker
 from .rollback import RollbackHandler
+from .checkpoint import CheckpointManager, CheckpointData
 
 
 class RestoreOrchestrator:
@@ -62,7 +63,7 @@ class RestoreOrchestrator:
     """
 
     def __init__(self, compute, project: str, zone: str, vm_name: str,
-                 config: RestoreConfig = None, logger=None):
+                 config: RestoreConfig = None, logger=None, log_file: str = None):
         """
         Initialize restore orchestrator.
 
@@ -73,6 +74,7 @@ class RestoreOrchestrator:
             vm_name: Name of VM to restore
             config: Optional restore configuration
             logger: Optional logger
+            log_file: Log file path (for checkpoint persistence)
         """
         self.compute = compute
         self.project = project
@@ -80,6 +82,7 @@ class RestoreOrchestrator:
         self.vm_name = vm_name
         self.config = config or RestoreConfig()
         self.logger = logger
+        self.log_file = log_file
 
         # State tracking
         self.state_tracker = StateTracker()
@@ -101,6 +104,15 @@ class RestoreOrchestrator:
         self._progress_lock = None
         self._total_steps = 3  # Stopping, Restoring affected disk, Starting
 
+        # Checkpoint manager for resumable operations
+        self.checkpoint_manager = CheckpointManager(
+            compute, project, zone, vm_name, logger
+        )
+
+        # Resume state (set when resuming from checkpoint)
+        self._resume_from_step = 0  # 0 = fresh start, >0 = resume from this step
+        self._resumed_context = None  # Context from checkpoint
+
     def _init_progress(self):
         """Initialize spinner with phases display."""
         import sys
@@ -112,6 +124,19 @@ class RestoreOrchestrator:
         self._is_debug_mode = console_level <= logging.DEBUG
         self._progress_phases = []
         self._progress_lock = threading.Lock()
+
+        # If resuming, initialize phases from completed steps
+        if self._resume_from_step > 0:
+            # Map step numbers to phases (phases are added at these steps)
+            # Step 1: Stopping, Step 2: Restoring affected disk, Step 6: Starting
+            step_to_phase = {
+                1: "Stopping",
+                2: "Restoring affected disk",
+                6: "Starting"
+            }
+            for step in sorted(step_to_phase.keys()):
+                if step <= self._resume_from_step:
+                    self._progress_phases.append(step_to_phase[step])
 
         if not self._is_debug_mode:
             # Print header line
@@ -196,6 +221,98 @@ class RestoreOrchestrator:
         if self.logger:
             self.logger.error(message)
 
+    def set_resume_state(self, checkpoint: CheckpointData):
+        """
+        Set resume state from a checkpoint.
+
+        Call this before execute() to resume from an interrupted operation.
+
+        Args:
+            checkpoint: Checkpoint data from previous interrupted operation
+        """
+        self._resume_from_step = checkpoint.current_step
+        self._resumed_context = checkpoint.context
+        self.checkpoint_manager.set_session_id(checkpoint.session_id)
+
+        # Restore context from checkpoint
+        if self._resumed_context:
+            self.rescue_disk_name = self._resumed_context.get('rescue_disk_name')
+            self.rescue_device_name = self._resumed_context.get('rescue_device_name')
+            self.original_disk_name = self._resumed_context.get('original_disk_name')
+            self.original_device_name = self._resumed_context.get('original_device_name')
+
+        self._log_debug(f"Resume state set: continuing from step {self._resume_from_step + 1}")
+
+    def _should_skip_step(self, step: int) -> bool:
+        """Check if a step should be skipped (already completed in previous session)."""
+        return step <= self._resume_from_step
+
+    def _is_disk_attached(self, disk_name: str) -> bool:
+        """Check if a disk is attached to the VM."""
+        try:
+            vm = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=self.vm_name
+            ).execute()
+            for disk in vm.get('disks', []):
+                if disk.get('source', '').endswith(f'/disks/{disk_name}'):
+                    return True
+            return False
+        except Exception:
+            return False
+
+    def _is_disk_boot(self, disk_name: str) -> bool:
+        """Check if a disk is attached as boot disk."""
+        try:
+            vm = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=self.vm_name
+            ).execute()
+            for disk in vm.get('disks', []):
+                if disk.get('source', '').endswith(f'/disks/{disk_name}') and disk.get('boot'):
+                    return True
+            return False
+        except Exception:
+            return False
+
+    def _disk_exists(self, disk_name: str) -> bool:
+        """Check if a disk exists."""
+        try:
+            self.compute.disks().get(
+                project=self.project,
+                zone=self.zone,
+                disk=disk_name
+            ).execute()
+            return True
+        except Exception:
+            return False
+
+    def _get_vm_status(self) -> str:
+        """Get current VM status."""
+        try:
+            vm = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=self.vm_name
+            ).execute()
+            return vm.get('status', 'UNKNOWN')
+        except Exception:
+            return 'UNKNOWN'
+
+    def _get_checkpoint_context(self) -> dict:
+        """Get context dict for checkpoint."""
+        return {
+            'vm_name': self.vm_name,
+            'zone': self.zone,
+            'rescue_disk_name': self.rescue_disk_name,
+            'rescue_device_name': self.rescue_device_name,
+            'original_disk_name': self.original_disk_name,
+            'original_device_name': self.original_device_name,
+            'log_file': self.log_file
+        }
+
     def validate(self) -> bool:
         """
         Run pre-flight validation.
@@ -239,12 +356,25 @@ class RestoreOrchestrator:
         # Initialize progress display
         self._init_progress()
 
+        # Total internal steps for checkpoint tracking
+        total_checkpoint_steps = 7  # Stop, DetachRescue, DetachOrig, AttachOrig, SetMeta, Start, DeleteRescue
+
         try:
-            # Get disk info (before progress display)
-            self._get_disk_info()
+            # Get disk info (before progress display) if not resuming
+            if not self._resume_from_step or not self.rescue_disk_name:
+                self._get_disk_info()
 
             # Check snapshot status (warn if failed or missing)
-            self._check_snapshot_status()
+            if not self._resume_from_step:
+                self._check_snapshot_status()
+
+            # Create initial checkpoint if not resuming
+            if not self._resume_from_step:
+                self.checkpoint_manager.create_checkpoint(
+                    operation_type='restore',
+                    total_steps=total_checkpoint_steps,
+                    context=self._get_checkpoint_context()
+                )
 
             # Create operations
             stop_vm = StopVMOperation(self.compute, self.project, self.zone, self.logger)
@@ -267,112 +397,203 @@ class RestoreOrchestrator:
             }
 
             # Step 1: Stop VM
-            self._update_progress("Stopping")
-            self._log_debug(f"Stopping instance {self.vm_name}...")
-            # Auto-detect Local SSDs and handle automatically
-            # (user already acknowledged data loss during rescue)
-            has_local_ssd = any(
-                disk.get('type') == 'SCRATCH'
-                for disk in self.compute.instances().get(
-                    project=self.project, zone=self.zone, instance=self.vm_name
-                ).execute().get('disks', [])
-            )
-            result = stop_vm.execute(
-                vm_name=self.vm_name,
-                timeout=self.config.vm_stop_timeout,
-                discard_local_ssd=has_local_ssd,  # Auto-handle Local SSDs during restore
-                tracking_label='restore-vm-stop'
-            )
-            self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(1):
+                self._update_progress("Stopping")
+                self._log_debug(f"Stopping instance {self.vm_name}...")
+                # Auto-detect Local SSDs and handle automatically
+                has_local_ssd = any(
+                    disk.get('type') == 'SCRATCH'
+                    for disk in self.compute.instances().get(
+                        project=self.project, zone=self.zone, instance=self.vm_name
+                    ).execute().get('disks', [])
+                )
+                result = stop_vm.execute(
+                    vm_name=self.vm_name,
+                    timeout=self.config.vm_stop_timeout,
+                    discard_local_ssd=has_local_ssd,
+                    tracking_label='restore-vm-stop'
+                )
+                self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data, step_number=1)
+                if not result.success:
+                    self._finish_progress(False)
+                    self._rollback()
+                    return False
+                # Update checkpoint
+                self.checkpoint_manager.update_checkpoint(
+                    step=1, operation_name="Stop VM",
+                    rollback_data=result.rollback_data,
+                    context_updates=self._get_checkpoint_context()
+                )
+            else:
+                self._log_debug("Skipping Step 1 (Stop VM) - already completed")
 
             # Step 2: Detach rescue disk
-            self._update_progress("Restoring affected disk")
-            self._log_debug("Detaching rescue disk...")
-            result = detach_rescue.execute(
-                vm_name=self.vm_name,
-                device_name=self.rescue_device_name,
-                tracking_label='restore-disk-detach-rescue'
-            )
-            self.state_tracker.add_operation("Detach Rescue Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(2):
+                self._update_progress("Restoring affected disk")
+                # Idempotency check: skip if rescue disk already detached
+                if not self._is_disk_attached(self.rescue_disk_name):
+                    self._log_debug("Skipping Step 2 (Detach Rescue Disk) - disk already detached")
+                    self.checkpoint_manager.update_checkpoint(
+                        step=2, operation_name="Detach Rescue Disk",
+                        rollback_data={'vm_name': self.vm_name, 'disk_name': self.rescue_disk_name}
+                    )
+                else:
+                    self._log_debug("Detaching rescue disk...")
+                    result = detach_rescue.execute(
+                        vm_name=self.vm_name,
+                        device_name=self.rescue_device_name,
+                        tracking_label='restore-disk-detach-rescue'
+                    )
+                    self.state_tracker.add_operation("Detach Rescue Disk", result.success, result.message, result.rollback_data, step_number=2)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=2, operation_name="Detach Rescue Disk",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 2 (Detach Rescue Disk) - already completed")
 
             # Step 3: Detach original disk
-            self._log_debug("Detaching original boot disk...")
-            result = detach_original.execute(
-                vm_name=self.vm_name,
-                device_name=self.original_device_name,
-                tracking_label='restore-disk-detach-orig'
-            )
-            self.state_tracker.add_operation("Detach Original Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(3):
+                # Idempotency check: skip if original disk already detached
+                if not self._is_disk_attached(self.original_disk_name):
+                    self._log_debug("Skipping Step 3 (Detach Original Disk) - disk already detached")
+                    self.checkpoint_manager.update_checkpoint(
+                        step=3, operation_name="Detach Original Disk",
+                        rollback_data={'vm_name': self.vm_name, 'disk_name': self.original_disk_name}
+                    )
+                else:
+                    self._log_debug("Detaching original boot disk...")
+                    result = detach_original.execute(
+                        vm_name=self.vm_name,
+                        device_name=self.original_device_name,
+                        tracking_label='restore-disk-detach-orig'
+                    )
+                    self.state_tracker.add_operation("Detach Original Disk", result.success, result.message, result.rollback_data, step_number=3)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=3, operation_name="Detach Original Disk",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 3 (Detach Original Disk) - already completed")
 
             # Step 4: Re-attach original disk as boot
-            self._log_debug("Attaching boot disk...")
-            result = attach_original.execute(
-                vm_name=self.vm_name,
-                disk_name=self.original_disk_name,
-                boot=True,
-                tracking_label='restore-disk-attach-orig'
-            )
-            self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(4):
+                # Idempotency check: skip if original disk already attached as boot
+                if self._is_disk_boot(self.original_disk_name):
+                    self._log_debug("Skipping Step 4 (Attach Original Disk) - disk already attached as boot")
+                    self.checkpoint_manager.update_checkpoint(
+                        step=4, operation_name="Attach Original Disk",
+                        rollback_data={'vm_name': self.vm_name, 'disk_name': self.original_disk_name}
+                    )
+                else:
+                    self._log_debug("Attaching boot disk...")
+                    result = attach_original.execute(
+                        vm_name=self.vm_name,
+                        disk_name=self.original_disk_name,
+                        boot=True,
+                        tracking_label='restore-disk-attach-orig'
+                    )
+                    self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data, step_number=4)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=4, operation_name="Attach Original Disk",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 4 (Attach Original Disk) - already completed")
 
             # Step 5: Remove rescue metadata and restore backed up keys
-            self._log_debug("Removing rescue metadata...")
-            clean_metadata = self._get_clean_metadata()
-            # Use preserve_existing=False to REPLACE metadata (not merge)
-            # because clean_metadata already contains the correct final state
-            result = set_metadata.execute(
-                vm_name=self.vm_name,
-                metadata_items=clean_metadata,
-                preserve_existing=False,
-                tracking_label='restore-meta-restore-orig'
-            )
-            self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(5):
+                self._log_debug("Removing rescue metadata...")
+                clean_metadata = self._get_clean_metadata()
+                result = set_metadata.execute(
+                    vm_name=self.vm_name,
+                    metadata_items=clean_metadata,
+                    preserve_existing=False,
+                    tracking_label='restore-meta-restore-orig'
+                )
+                self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data, step_number=5)
+                if not result.success:
+                    self._finish_progress(False)
+                    self._rollback()
+                    return False
+                # Update checkpoint
+                self.checkpoint_manager.update_checkpoint(
+                    step=5, operation_name="Set Metadata",
+                    rollback_data=result.rollback_data
+                )
+            else:
+                self._log_debug("Skipping Step 5 (Set Metadata) - already completed")
 
             # Step 6: Start VM
-            self._update_progress("Starting")
-            self._log_debug(f"Starting instance {self.vm_name}...")
-            result = start_vm.execute(
-                vm_name=self.vm_name,
-                timeout=self.config.vm_start_timeout,
-                tracking_label='restore-vm-start'
-            )
-            self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data)
-            if not result.success:
-                self._finish_progress(False)
-                self._rollback()
-                return False
+            if not self._should_skip_step(6):
+                self._update_progress("Starting")
+                # Idempotency check: skip if VM is already running
+                vm_status = self._get_vm_status()
+                if vm_status == 'RUNNING':
+                    self._log_debug("Skipping Step 6 (Start VM) - VM already running")
+                    self.checkpoint_manager.update_checkpoint(
+                        step=6, operation_name="Start VM",
+                        rollback_data={'vm_name': self.vm_name, 'original_status': 'TERMINATED'}
+                    )
+                else:
+                    self._log_debug(f"Starting instance {self.vm_name}...")
+                    result = start_vm.execute(
+                        vm_name=self.vm_name,
+                        timeout=self.config.vm_start_timeout,
+                        tracking_label='restore-vm-start'
+                    )
+                    self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data, step_number=6)
+                    if not result.success:
+                        self._finish_progress(False)
+                        self._rollback()
+                        return False
+                    # Update checkpoint
+                    self.checkpoint_manager.update_checkpoint(
+                        step=6, operation_name="Start VM",
+                        rollback_data=result.rollback_data
+                    )
+            else:
+                self._log_debug("Skipping Step 6 (Start VM) - already completed")
 
             # Step 7: Delete rescue disk (only if config allows)
-            if self.config.delete_rescue_disk:
-                self._log_debug("Deleting rescue disk...")
-                result = delete_rescue.execute(
-                    disk_name=self.rescue_disk_name,
-                    tracking_label='restore-disk-delete-rescue'
+            if self.config.delete_rescue_disk and not self._should_skip_step(7):
+                # Idempotency check: skip if rescue disk doesn't exist
+                if not self._disk_exists(self.rescue_disk_name):
+                    self._log_debug("Skipping Step 7 (Delete Rescue Disk) - disk already deleted")
+                else:
+                    self._log_debug("Deleting rescue disk...")
+                    result = delete_rescue.execute(
+                        disk_name=self.rescue_disk_name,
+                        tracking_label='restore-disk-delete-rescue'
+                    )
+                    # Note: Don't add to state tracker (can't rollback deletion)
+                    if not result.success:
+                        self._log_debug("Rescue disk deletion failed (can delete manually)")
+                # Update checkpoint (final step)
+                self.checkpoint_manager.update_checkpoint(
+                    step=7, operation_name="Delete Rescue Disk",
+                    rollback_data={}
                 )
-                # Note: Don't add to state tracker (can't rollback deletion)
-                if not result.success:
-                    self._log_debug("Rescue disk deletion failed (can delete manually)")
+            elif self._should_skip_step(7):
+                self._log_debug("Skipping Step 7 (Delete Rescue Disk) - already completed")
 
-            # Success!
+            # Success! Clear checkpoint
+            self.checkpoint_manager.clear_checkpoint()
             self._finish_progress(True)
             return True
 

--- a/gce_rescue_v2/orchestration/state.py
+++ b/gce_rescue_v2/orchestration/state.py
@@ -22,6 +22,30 @@ class OperationState:
     message: str
     rollback_data: Dict[str, Any] = None
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    step_number: int = 0  # Step number in the workflow (1-indexed)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            'operation_name': self.operation_name,
+            'success': self.success,
+            'message': self.message,
+            'rollback_data': self.rollback_data,
+            'timestamp': self.timestamp,
+            'step_number': self.step_number
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'OperationState':
+        """Create from dictionary."""
+        return cls(
+            operation_name=data['operation_name'],
+            success=data['success'],
+            message=data['message'],
+            rollback_data=data.get('rollback_data'),
+            timestamp=data.get('timestamp', datetime.now().isoformat()),
+            step_number=data.get('step_number', 0)
+        )
 
 
 class StateTracker:
@@ -53,7 +77,8 @@ class StateTracker:
         self.workflow_start_time = datetime.now()
 
     def add_operation(self, operation_name: str, success: bool,
-                     message: str, rollback_data: Dict[str, Any] = None):
+                     message: str, rollback_data: Dict[str, Any] = None,
+                     step_number: int = 0):
         """
         Record an operation.
 
@@ -62,12 +87,14 @@ class StateTracker:
             success: Whether it succeeded
             message: Result message
             rollback_data: Data needed for rollback
+            step_number: Step number in the workflow (1-indexed)
         """
         state = OperationState(
             operation_name=operation_name,
             success=success,
             message=message,
-            rollback_data=rollback_data
+            rollback_data=rollback_data,
+            step_number=step_number if step_number else len(self.operations) + 1
         )
         self.operations.append(state)
 
@@ -120,3 +147,31 @@ class StateTracker:
         for i, op in enumerate(self.operations, 1):
             status = "[OK]" if op.success else "[X]"
             print(f"  {i}. {status} {op.operation_name}: {op.message}")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert state tracker to dictionary for serialization."""
+        return {
+            'operations': [op.to_dict() for op in self.operations],
+            'workflow_start_time': self.workflow_start_time.isoformat()
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'StateTracker':
+        """Create state tracker from dictionary."""
+        tracker = cls()
+        tracker.workflow_start_time = datetime.fromisoformat(data['workflow_start_time'])
+        tracker.operations = [
+            OperationState.from_dict(op_data)
+            for op_data in data.get('operations', [])
+        ]
+        return tracker
+
+    def get_current_step(self) -> int:
+        """Get the current step number (number of operations added)."""
+        return len(self.operations)
+
+    def get_last_operation(self) -> str:
+        """Get the name of the last operation added."""
+        if self.operations:
+            return self.operations[-1].operation_name
+        return None

--- a/gce_rescue_v2/tests/test_checkpoint.py
+++ b/gce_rescue_v2/tests/test_checkpoint.py
@@ -1,0 +1,542 @@
+"""
+Tests for checkpoint functionality (resumable operations).
+"""
+
+import json
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import Mock, patch, MagicMock
+
+from ..orchestration.checkpoint import (
+    CheckpointManager,
+    CheckpointData,
+    CompletedOperation,
+    CHECKPOINT_KEY,
+    CHECKPOINT_VERSION
+)
+from ..orchestration.state import OperationState, StateTracker
+
+
+class TestCompletedOperation:
+    """Tests for CompletedOperation dataclass."""
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        op = CompletedOperation(
+            name="Stop VM",
+            step=1,
+            rollback_data={'vm_name': 'test-vm', 'original_state': 'RUNNING'}
+        )
+        result = op.to_dict()
+
+        assert result['name'] == "Stop VM"
+        assert result['step'] == 1
+        assert result['rollback_data']['vm_name'] == 'test-vm'
+        assert result['rollback_data']['original_state'] == 'RUNNING'
+
+    def test_from_dict(self):
+        """Test deserialization from dict."""
+        data = {
+            'name': "Create Snapshot",
+            'step': 3,
+            'rollback_data': {'snapshot_name': 'pre-rescue-test-vm-123'}
+        }
+        op = CompletedOperation.from_dict(data)
+
+        assert op.name == "Create Snapshot"
+        assert op.step == 3
+        assert op.rollback_data['snapshot_name'] == 'pre-rescue-test-vm-123'
+
+    def test_from_dict_no_rollback_data(self):
+        """Test deserialization when rollback_data is missing."""
+        data = {'name': "Verify Startup", 'step': 9}
+        op = CompletedOperation.from_dict(data)
+
+        assert op.name == "Verify Startup"
+        assert op.step == 9
+        assert op.rollback_data == {}
+
+
+class TestCheckpointData:
+    """Tests for CheckpointData dataclass."""
+
+    def test_to_dict_and_back(self):
+        """Test round-trip serialization."""
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='abc123',
+            started_at='2024-01-15T10:30:00Z',
+            updated_at='2024-01-15T10:31:30Z',
+            current_step=3,
+            total_steps=9,
+            completed_operations=[
+                CompletedOperation("Stop VM", 1, {'vm_name': 'test-vm'}),
+                CompletedOperation("Detach Boot Disk", 2, {'disk_name': 'test-vm-disk'}),
+            ],
+            context={'vm_name': 'test-vm', 'zone': 'us-central1-a'}
+        )
+
+        # To dict and back
+        data = checkpoint.to_dict()
+        restored = CheckpointData.from_dict(data)
+
+        assert restored.version == checkpoint.version
+        assert restored.operation == checkpoint.operation
+        assert restored.session_id == checkpoint.session_id
+        assert restored.current_step == checkpoint.current_step
+        assert restored.total_steps == checkpoint.total_steps
+        assert len(restored.completed_operations) == 2
+        assert restored.completed_operations[0].name == "Stop VM"
+        assert restored.context['vm_name'] == 'test-vm'
+
+    def test_to_json_and_back(self):
+        """Test JSON serialization round-trip."""
+        checkpoint = CheckpointData(
+            version=1,
+            operation='restore',
+            session_id='xyz789',
+            started_at='2024-01-15T11:00:00Z',
+            updated_at='2024-01-15T11:01:00Z',
+            current_step=2,
+            total_steps=7,
+            completed_operations=[],
+            context={'rescue_disk_name': 'rescue-disk-123'}
+        )
+
+        json_str = checkpoint.to_json()
+        restored = CheckpointData.from_json(json_str)
+
+        assert restored.operation == 'restore'
+        assert restored.session_id == 'xyz789'
+        assert restored.context['rescue_disk_name'] == 'rescue-disk-123'
+
+    def test_get_last_completed_operation(self):
+        """Test getting last completed operation name."""
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at='2024-01-15T10:30:00Z',
+            updated_at='2024-01-15T10:30:00Z',
+            current_step=2,
+            total_steps=9,
+            completed_operations=[
+                CompletedOperation("Stop VM", 1, {}),
+                CompletedOperation("Detach Boot Disk", 2, {}),
+            ],
+            context={}
+        )
+
+        assert checkpoint.get_last_completed_operation() == "Detach Boot Disk"
+
+    def test_get_last_completed_operation_empty(self):
+        """Test getting last completed operation when list is empty."""
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at='2024-01-15T10:30:00Z',
+            updated_at='2024-01-15T10:30:00Z',
+            current_step=0,
+            total_steps=9,
+            completed_operations=[],
+            context={}
+        )
+
+        assert checkpoint.get_last_completed_operation() is None
+
+    def test_get_next_step_number(self):
+        """Test getting next step number."""
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at='2024-01-15T10:30:00Z',
+            updated_at='2024-01-15T10:30:00Z',
+            current_step=3,
+            total_steps=9,
+            completed_operations=[],
+            context={}
+        )
+
+        assert checkpoint.get_next_step_number() == 4
+
+    def test_get_age_display_seconds(self):
+        """Test age display for recent checkpoint."""
+        now = datetime.now(timezone.utc)
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at=now.isoformat().replace('+00:00', 'Z'),
+            updated_at=now.isoformat().replace('+00:00', 'Z'),
+            current_step=1,
+            total_steps=9,
+            completed_operations=[],
+            context={}
+        )
+
+        # Should be in seconds
+        age = checkpoint.get_age_display()
+        assert 'second' in age
+
+    def test_get_age_display_minutes(self):
+        """Test age display for checkpoint a few minutes old."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(minutes=5)
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at=past.isoformat().replace('+00:00', 'Z'),
+            updated_at=past.isoformat().replace('+00:00', 'Z'),
+            current_step=1,
+            total_steps=9,
+            completed_operations=[],
+            context={}
+        )
+
+        age = checkpoint.get_age_display()
+        assert 'minute' in age
+
+
+class TestCheckpointManager:
+    """Tests for CheckpointManager."""
+
+    @pytest.fixture
+    def mock_compute(self):
+        """Create mock compute client."""
+        compute = Mock()
+        compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': []
+            }
+        }
+        compute.instances.return_value.setMetadata.return_value.execute.return_value = {
+            'name': 'operation-123'
+        }
+        compute.zoneOperations.return_value.get.return_value.execute.return_value = {
+            'status': 'DONE'
+        }
+        return compute
+
+    @pytest.fixture
+    def manager(self, mock_compute):
+        """Create checkpoint manager with mock compute."""
+        return CheckpointManager(
+            compute=mock_compute,
+            project='test-project',
+            zone='us-central1-a',
+            vm_name='test-vm'
+        )
+
+    def test_create_checkpoint(self, manager, mock_compute):
+        """Test creating initial checkpoint."""
+        session_id = manager.create_checkpoint(
+            operation_type='rescue',
+            total_steps=9,
+            context={'vm_name': 'test-vm', 'zone': 'us-central1-a'}
+        )
+
+        # Should return a session ID
+        assert session_id is not None
+        assert len(session_id) == 8  # UUID first 8 chars
+
+        # Should have called setMetadata
+        mock_compute.instances.return_value.setMetadata.assert_called_once()
+
+    def test_load_checkpoint_exists(self, manager, mock_compute):
+        """Test loading existing checkpoint."""
+        checkpoint_data = {
+            'version': 1,
+            'operation': 'rescue',
+            'session_id': 'test123',
+            'started_at': '2024-01-15T10:30:00Z',
+            'updated_at': '2024-01-15T10:31:00Z',
+            'current_step': 2,
+            'total_steps': 9,
+            'completed_operations': [
+                {'name': 'Stop VM', 'step': 1, 'rollback_data': {}}
+            ],
+            'context': {'vm_name': 'test-vm'}
+        }
+
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': [
+                    {'key': CHECKPOINT_KEY, 'value': json.dumps(checkpoint_data)}
+                ]
+            }
+        }
+
+        checkpoint = manager.load_checkpoint()
+
+        assert checkpoint is not None
+        assert checkpoint.operation == 'rescue'
+        assert checkpoint.session_id == 'test123'
+        assert checkpoint.current_step == 2
+        assert len(checkpoint.completed_operations) == 1
+
+    def test_load_checkpoint_not_exists(self, manager, mock_compute):
+        """Test loading checkpoint when none exists."""
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': []
+            }
+        }
+
+        checkpoint = manager.load_checkpoint()
+        assert checkpoint is None
+
+    def test_load_checkpoint_corrupted(self, manager, mock_compute):
+        """Test loading corrupted checkpoint data."""
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': [
+                    {'key': CHECKPOINT_KEY, 'value': 'not valid json {{{'}
+                ]
+            }
+        }
+
+        checkpoint = manager.load_checkpoint()
+        assert checkpoint is None
+
+    def test_detect_incomplete_found(self, manager, mock_compute):
+        """Test detecting incomplete operation."""
+        checkpoint_data = {
+            'version': 1,
+            'operation': 'rescue',
+            'session_id': 'test123',
+            'started_at': '2024-01-15T10:30:00Z',
+            'updated_at': '2024-01-15T10:31:00Z',
+            'current_step': 3,
+            'total_steps': 9,
+            'completed_operations': [],
+            'context': {}
+        }
+
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': [
+                    {'key': CHECKPOINT_KEY, 'value': json.dumps(checkpoint_data)}
+                ]
+            }
+        }
+
+        incomplete = manager.detect_incomplete(operation_type='rescue')
+        assert incomplete is not None
+        assert incomplete.current_step == 3
+
+    def test_detect_incomplete_completed(self, manager, mock_compute):
+        """Test that completed operation is not detected as incomplete."""
+        checkpoint_data = {
+            'version': 1,
+            'operation': 'rescue',
+            'session_id': 'test123',
+            'started_at': '2024-01-15T10:30:00Z',
+            'updated_at': '2024-01-15T10:35:00Z',
+            'current_step': 9,  # All steps done
+            'total_steps': 9,
+            'completed_operations': [],
+            'context': {}
+        }
+
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': [
+                    {'key': CHECKPOINT_KEY, 'value': json.dumps(checkpoint_data)}
+                ]
+            }
+        }
+
+        incomplete = manager.detect_incomplete(operation_type='rescue')
+        assert incomplete is None
+
+    def test_detect_incomplete_wrong_operation_type(self, manager, mock_compute):
+        """Test that wrong operation type is not detected."""
+        checkpoint_data = {
+            'version': 1,
+            'operation': 'restore',  # Different operation type
+            'session_id': 'test123',
+            'started_at': '2024-01-15T10:30:00Z',
+            'updated_at': '2024-01-15T10:31:00Z',
+            'current_step': 3,
+            'total_steps': 7,
+            'completed_operations': [],
+            'context': {}
+        }
+
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': [
+                    {'key': CHECKPOINT_KEY, 'value': json.dumps(checkpoint_data)}
+                ]
+            }
+        }
+
+        incomplete = manager.detect_incomplete(operation_type='rescue')
+        assert incomplete is None
+
+    def test_is_stale(self, manager):
+        """Test stale checkpoint detection."""
+        now = datetime.now(timezone.utc)
+
+        # Recent checkpoint (not stale)
+        recent = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at=now.isoformat().replace('+00:00', 'Z'),
+            updated_at=now.isoformat().replace('+00:00', 'Z'),
+            current_step=1,
+            total_steps=9,
+            completed_operations=[],
+            context={}
+        )
+        assert manager.is_stale(recent) is False
+
+        # Old checkpoint (stale)
+        old = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at=(now - timedelta(hours=2)).isoformat().replace('+00:00', 'Z'),
+            updated_at=(now - timedelta(hours=2)).isoformat().replace('+00:00', 'Z'),
+            current_step=1,
+            total_steps=9,
+            completed_operations=[],
+            context={}
+        )
+        assert manager.is_stale(old) is True
+
+    def test_clear_checkpoint(self, manager, mock_compute):
+        """Test clearing checkpoint."""
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            'metadata': {
+                'fingerprint': 'abc123',
+                'items': [
+                    {'key': CHECKPOINT_KEY, 'value': '{}'},
+                    {'key': 'other-key', 'value': 'other-value'}
+                ]
+            }
+        }
+
+        result = manager.clear_checkpoint()
+        assert result is True
+
+        # Verify setMetadata was called
+        mock_compute.instances.return_value.setMetadata.assert_called_once()
+
+    def test_get_rollback_operations(self, manager):
+        """Test getting rollback operations in reverse order."""
+        checkpoint = CheckpointData(
+            version=1,
+            operation='rescue',
+            session_id='test',
+            started_at='2024-01-15T10:30:00Z',
+            updated_at='2024-01-15T10:30:00Z',
+            current_step=3,
+            total_steps=9,
+            completed_operations=[
+                CompletedOperation("Stop VM", 1, {'data': 'stop'}),
+                CompletedOperation("Detach Boot Disk", 2, {'data': 'detach'}),
+                CompletedOperation("Create Snapshot", 3, {'data': 'snapshot'}),
+            ],
+            context={}
+        )
+
+        rollback_ops = manager.get_rollback_operations(checkpoint)
+
+        assert len(rollback_ops) == 3
+        assert rollback_ops[0].name == "Create Snapshot"
+        assert rollback_ops[1].name == "Detach Boot Disk"
+        assert rollback_ops[2].name == "Stop VM"
+
+
+class TestOperationStateSerialization:
+    """Tests for OperationState serialization."""
+
+    def test_to_dict(self):
+        """Test OperationState to dict."""
+        state = OperationState(
+            operation_name="Stop VM",
+            success=True,
+            message="VM stopped",
+            rollback_data={'vm_name': 'test-vm'},
+            step_number=1
+        )
+
+        data = state.to_dict()
+
+        assert data['operation_name'] == "Stop VM"
+        assert data['success'] is True
+        assert data['message'] == "VM stopped"
+        assert data['rollback_data']['vm_name'] == 'test-vm'
+        assert data['step_number'] == 1
+
+    def test_from_dict(self):
+        """Test OperationState from dict."""
+        data = {
+            'operation_name': "Create Snapshot",
+            'success': True,
+            'message': "Snapshot created",
+            'rollback_data': {'snapshot_name': 'snap-123'},
+            'timestamp': '2024-01-15T10:30:00',
+            'step_number': 3
+        }
+
+        state = OperationState.from_dict(data)
+
+        assert state.operation_name == "Create Snapshot"
+        assert state.success is True
+        assert state.step_number == 3
+
+
+class TestStateTrackerSerialization:
+    """Tests for StateTracker serialization."""
+
+    def test_to_dict_and_back(self):
+        """Test StateTracker round-trip serialization."""
+        tracker = StateTracker()
+        tracker.add_operation("Stop VM", True, "VM stopped", {'vm_name': 'test'}, step_number=1)
+        tracker.add_operation("Detach Disk", True, "Disk detached", {'disk': 'test'}, step_number=2)
+
+        # To dict and back
+        data = tracker.to_dict()
+        restored = StateTracker.from_dict(data)
+
+        assert len(restored.operations) == 2
+        assert restored.operations[0].operation_name == "Stop VM"
+        assert restored.operations[1].operation_name == "Detach Disk"
+        assert restored.operations[0].step_number == 1
+        assert restored.operations[1].step_number == 2
+
+    def test_get_current_step(self):
+        """Test getting current step number."""
+        tracker = StateTracker()
+        assert tracker.get_current_step() == 0
+
+        tracker.add_operation("Stop VM", True, "VM stopped")
+        assert tracker.get_current_step() == 1
+
+        tracker.add_operation("Detach Disk", True, "Disk detached")
+        assert tracker.get_current_step() == 2
+
+    def test_get_last_operation(self):
+        """Test getting last operation name."""
+        tracker = StateTracker()
+        assert tracker.get_last_operation() is None
+
+        tracker.add_operation("Stop VM", True, "VM stopped")
+        assert tracker.get_last_operation() == "Stop VM"
+
+        tracker.add_operation("Detach Disk", True, "Disk detached")
+        assert tracker.get_last_operation() == "Detach Disk"

--- a/gce_rescue_v2/tests/test_integration.py
+++ b/gce_rescue_v2/tests/test_integration.py
@@ -19,11 +19,12 @@ def test_full_rescue_restore_cycle(monkeypatch):
         return Mock(), project or "default-project"
 
     class FakeRescueOrchestrator:
-        def __init__(self, compute, project, zone, vm_name, config, logger):
+        def __init__(self, compute, project, zone, vm_name, config, logger, log_file=None):
             self.compute = compute
             self.project = project
             self.zone = zone
             self.vm_name = vm_name
+            self.log_file = log_file
             # Required attributes for main.py success message
             self.os_type = 'linux'
             self.windows_rescue_password = None
@@ -42,11 +43,12 @@ def test_full_rescue_restore_cycle(monkeypatch):
             return True
 
     class FakeRestoreOrchestrator:
-        def __init__(self, compute, project, zone, vm_name, config, logger):
+        def __init__(self, compute, project, zone, vm_name, config, logger, log_file=None):
             self.compute = compute
             self.project = project
             self.zone = zone
             self.vm_name = vm_name
+            self.log_file = log_file
 
         def validate(self):
             state["calls"].append("restore-validate")


### PR DESCRIPTION
## Summary

Adds session recovery feature that allows users to resume or rollback interrupted rescue/restore operations.

**Key Features:**
- Checkpoint system stored in VM metadata (`gce-rescue-checkpoint`)
- Detects incomplete operations on next run with interactive prompt (Continue/Rollback/Abort)
- Idempotent operations handle partial state gracefully
- Progress resumes from where it left off (e.g., `(3/5)` not `(0/5)`)
- Log file persists across session recovery
- Handles transitional VM states (STAGING, PROVISIONING, STOPPING)
- Shows internal IP and IAP tunnel command for private network VMs
- Windows rescue password preserved across resume
- Auto-clears completed checkpoints to prevent stale state errors

## Test plan

- [x] Unit tests for checkpoint system (25 tests)
- [x] Manual testing: interrupt rescue at various steps, resume successfully
- [x] Manual testing: rollback from incomplete state
- [x] Manual testing: Windows VM with password preservation
- [x] All existing tests pass (131 passed)

## Changes

| File | Description |
|------|-------------|
| `orchestration/checkpoint.py` | New checkpoint manager for session recovery |
| `orchestration/rescue.py` | Idempotency checks, progress from checkpoint |
| `orchestration/restore.py` | Same idempotency and resume support |
| `operations/start_vm.py` | Handle transitional VM states |
| `cli.py` | Interactive prompt for incomplete operations |
| `main.py` | Log file persistence, IP display improvements |
| `CHANGELOG.md` | Beta.4 release notes |