### PR TITLE
feat: Add V2 promotion banner to V1 CLI

### DIFF
--- a/gce_rescue/bin/rescue.py
+++ b/gce_rescue/bin/rescue.py
@@ -18,6 +18,7 @@
 
 from datetime import datetime
 import logging
+import sys
 
 from gce_rescue.config import process_args, set_configs
 from gce_rescue import messages
@@ -25,8 +26,19 @@ from gce_rescue.gce import Instance
 from gce_rescue.tasks.actions import call_tasks
 from gce_rescue.utils import read_input, set_logging
 
+
+def show_v2_banner():
+  """Show banner promoting V2 availability."""
+  yellow = '\033[93m'
+  reset = '\033[0m'
+  banner = f"{yellow}NEW: GCE Rescue V2 available. Try: gce-rescue-v2 -h{reset}"
+  print(banner, file=sys.stderr)
+
+
 def main():
   """ Main script function. """
+  show_v2_banner()
+
   parser = process_args()
   args = parser.parse_args()
   set_configs(args)


### PR DESCRIPTION
## Summary

Adds a promotion banner to the V1 CLI to inform users about V2 availability.

When users run V1 commands, they'll see a message encouraging them to try V2 for Windows support and improved features.

## Test plan

- [x] V1 CLI still works normally
- [x] Banner displays on V1 command execution