### PR TITLE
feat: Add ARM64 support and block unsupported VM types

### DIFF
--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -43,6 +43,10 @@ class RescueConfig:
     windows_rescue_image_project: str = 'windows-cloud'
     windows_rescue_disk_size_gb: int = 50  # Windows needs more space
 
+    # ARM64 Linux rescue image (auto-selected for ARM64/T2A VMs)
+    arm64_rescue_image_family: str = 'debian-12-arm64'
+    arm64_rescue_image_project: str = 'debian-cloud'
+
     # Snapshot settings (safety feature)
     create_snapshot: bool = True  # DEFAULT: Create snapshot for safety
     require_snapshot: bool = False  # Abort if snapshot creation fails

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -11,7 +11,9 @@ Coordinates the rescue workflow:
 
 import time
 from ..core.config import RescueConfig, OS_TYPE_WINDOWS, OS_TYPE_LINUX
-from ..utils.os_detection import detect_os_type, get_os_display_name
+from ..utils.os_detection import (
+    detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64
+)
 from ..validators import (
     ValidationRunner,
     CredentialsValidator,
@@ -99,8 +101,9 @@ class RescueOrchestrator:
         self.original_disk_name = None
         self.original_device_name = None
 
-        # OS detection (will be set during execution)
+        # OS and architecture detection (will be set during execution)
         self.os_type = None
+        self.architecture = None
         self.vm_info = None
 
         # Windows rescue credentials (generated for RDP access)
@@ -263,6 +266,7 @@ class RescueOrchestrator:
             self.original_device_name = self._resumed_context.get('original_device_name')
             self.rescue_disk_name = self._resumed_context.get('rescue_disk_name')
             self.os_type = self._resumed_context.get('os_type')
+            self.architecture = self._resumed_context.get('architecture')
 
         self._log_debug(f"Resume state set: continuing from step {self._resume_from_step + 1}")
 
@@ -318,6 +322,7 @@ class RescueOrchestrator:
             'original_device_name': self.original_device_name,
             'rescue_disk_name': self.rescue_disk_name,
             'os_type': self.os_type,
+            'architecture': self.architecture,
             'log_file': self.log_file
         }
 
@@ -523,12 +528,18 @@ class RescueOrchestrator:
                         rescue_image_project = self.config.windows_rescue_image_project
                         rescue_image_family = self.config.windows_rescue_image_family
                         rescue_disk_size = self.config.windows_rescue_disk_size_gb
+                    elif self.architecture == ARCH_ARM64:
+                        # ARM64 Linux (T2A instances)
+                        rescue_image_project = self.config.arm64_rescue_image_project
+                        rescue_image_family = self.config.arm64_rescue_image_family
+                        rescue_disk_size = self.config.rescue_disk_size_gb
                     else:
+                        # x86_64 Linux (default)
                         rescue_image_project = self.config.rescue_image_project
                         rescue_image_family = self.config.rescue_image_family
                         rescue_disk_size = self.config.rescue_disk_size_gb
 
-                    self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB)...")
+                    self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
                     result = create_disk.execute(
                         disk_name=rescue_disk_name,
                         size_gb=rescue_disk_size,
@@ -770,9 +781,10 @@ class RescueOrchestrator:
             instance=self.vm_name
         ).execute()
 
-        # Detect OS type
+        # Detect OS type and architecture
         self.os_type = detect_os_type(self.vm_info)
-        self._log_debug(f"Detected OS: {get_os_display_name(self.os_type)}")
+        self.architecture = detect_architecture(self.vm_info)
+        self._log_debug(f"Detected OS: {get_os_display_name(self.os_type)}, Architecture: {self.architecture}")
 
         for disk in self.vm_info.get('disks', []):
             if disk.get('boot'):

--- a/gce_rescue_v2/tests/test_validators.py
+++ b/gce_rescue_v2/tests/test_validators.py
@@ -206,6 +206,89 @@ class TestVMStateValidator:
         assert result.passed is False
         assert "no boot disk" in result.message.lower()
 
+    def test_confidential_vm_blocked(self, mock_compute):
+        """Test Confidential VM is blocked with clear message."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "confidentialInstanceConfig": {"enableConfidentialCompute": True}
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is False
+        assert "Confidential VM" in result.message
+        assert "not supported" in result.message.lower()
+        assert "fix" in result.details
+
+    def test_confidential_vm_with_type(self, mock_compute):
+        """Test Confidential VM shows type in error message."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "confidentialInstanceConfig": {
+                "enableConfidentialCompute": True,
+                "confidentialInstanceType": "SEV_SNP"
+            }
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is False
+        assert "SEV_SNP" in result.message
+
+    def test_shielded_vm_secure_boot_blocked(self, mock_compute):
+        """Test Shielded VM with Secure Boot is blocked."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "shieldedInstanceConfig": {"enableSecureBoot": True}
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is False
+        assert "Shielded VM" in result.message
+        assert "Secure Boot" in result.message
+        assert "fix" in result.details
+
+    def test_shielded_vm_without_secure_boot_allowed(self, mock_compute):
+        """Test Shielded VM without Secure Boot is allowed."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "shieldedInstanceConfig": {
+                "enableSecureBoot": False,
+                "enableVtpm": True,
+                "enableIntegrityMonitoring": True
+            }
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is True
+
+    def test_non_confidential_non_shielded_vm_allowed(self, mock_compute):
+        """Test regular VM without Confidential or Shielded is allowed."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is True
+
 
 class TestValidationRunner:
     """Tests for ValidationRunner."""

--- a/gce_rescue_v2/tests/test_vm_features.py
+++ b/gce_rescue_v2/tests/test_vm_features.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for VM feature detection functions.
+
+Covers:
+- Architecture detection (x86_64, ARM64)
+- Shielded VM detection
+- Confidential VM detection
+"""
+
+import pytest
+
+from gce_rescue_v2.utils.os_detection import (
+    detect_architecture,
+    is_shielded_vm,
+    get_shielded_config,
+    is_confidential_vm,
+    get_confidential_type,
+    ARCH_X86_64,
+    ARCH_ARM64,
+)
+
+
+class TestArchitectureDetection:
+    """Tests for detect_architecture function."""
+
+    def test_x86_64_from_disk_field(self):
+        """Detect x86_64 from disk architecture field."""
+        vm = {
+            'disks': [
+                {'boot': True, 'architecture': 'X86_64', 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_X86_64
+
+    def test_arm64_from_disk_field(self):
+        """Detect ARM64 from disk architecture field."""
+        vm = {
+            'disks': [
+                {'boot': True, 'architecture': 'ARM64', 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_architecture_case_insensitive(self):
+        """Architecture detection handles different cases."""
+        vm = {
+            'disks': [
+                {'boot': True, 'architecture': 'arm64', 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_arm64_from_machine_type_t2a(self):
+        """Detect ARM64 from T2A machine type."""
+        vm = {
+            'machineType': 'zones/us-central1-a/machineTypes/t2a-standard-4',
+            'disks': [
+                {'boot': True, 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_arm64_from_short_machine_type(self):
+        """Detect ARM64 from short T2A machine type."""
+        vm = {
+            'machineType': 't2a-standard-1',
+            'disks': [
+                {'boot': True, 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_default_x86_64_no_architecture_field(self):
+        """Default to x86_64 when no architecture field."""
+        vm = {
+            'machineType': 'zones/us-central1-a/machineTypes/e2-micro',
+            'disks': [
+                {'boot': True, 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_X86_64
+
+    def test_default_x86_64_empty_vm(self):
+        """Default to x86_64 when VM has minimal info."""
+        vm = {}
+        assert detect_architecture(vm) == ARCH_X86_64
+
+    def test_multiple_disks_uses_boot_disk(self):
+        """Uses boot disk for architecture detection."""
+        vm = {
+            'disks': [
+                {'boot': False, 'architecture': 'X86_64', 'source': '/disks/data'},
+                {'boot': True, 'architecture': 'ARM64', 'source': '/disks/boot'},
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+
+class TestShieldedVMDetection:
+    """Tests for Shielded VM detection functions."""
+
+    def test_secure_boot_enabled(self):
+        """Detect Secure Boot enabled."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': True,
+                'enableVtpm': True,
+                'enableIntegrityMonitoring': True
+            }
+        }
+        assert is_shielded_vm(vm) is True
+
+    def test_secure_boot_disabled(self):
+        """Detect Secure Boot disabled."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': False,
+                'enableVtpm': True,
+                'enableIntegrityMonitoring': True
+            }
+        }
+        assert is_shielded_vm(vm) is False
+
+    def test_no_shielded_config(self):
+        """No shielded config means not a shielded VM."""
+        vm = {}
+        assert is_shielded_vm(vm) is False
+
+    def test_empty_shielded_config(self):
+        """Empty shielded config defaults to False."""
+        vm = {'shieldedInstanceConfig': {}}
+        assert is_shielded_vm(vm) is False
+
+    def test_get_shielded_config_all_enabled(self):
+        """Get full shielded config when all enabled."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': True,
+                'enableVtpm': True,
+                'enableIntegrityMonitoring': True
+            }
+        }
+        config = get_shielded_config(vm)
+        assert config['secure_boot'] is True
+        assert config['vtpm'] is True
+        assert config['integrity_monitoring'] is True
+
+    def test_get_shielded_config_partial(self):
+        """Get shielded config with partial settings."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': True
+            }
+        }
+        config = get_shielded_config(vm)
+        assert config['secure_boot'] is True
+        assert config['vtpm'] is False
+        assert config['integrity_monitoring'] is False
+
+    def test_get_shielded_config_empty(self):
+        """Get shielded config when not configured."""
+        vm = {}
+        config = get_shielded_config(vm)
+        assert config['secure_boot'] is False
+        assert config['vtpm'] is False
+        assert config['integrity_monitoring'] is False
+
+
+class TestConfidentialVMDetection:
+    """Tests for Confidential VM detection functions."""
+
+    def test_confidential_vm_enabled(self):
+        """Detect Confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True
+            }
+        }
+        assert is_confidential_vm(vm) is True
+
+    def test_confidential_vm_disabled(self):
+        """Detect non-confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': False
+            }
+        }
+        assert is_confidential_vm(vm) is False
+
+    def test_no_confidential_config(self):
+        """No confidential config means not confidential."""
+        vm = {}
+        assert is_confidential_vm(vm) is False
+
+    def test_empty_confidential_config(self):
+        """Empty confidential config defaults to False."""
+        vm = {'confidentialInstanceConfig': {}}
+        assert is_confidential_vm(vm) is False
+
+    def test_get_confidential_type_sev(self):
+        """Get SEV type for confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True,
+                'confidentialInstanceType': 'SEV'
+            }
+        }
+        assert get_confidential_type(vm) == 'SEV'
+
+    def test_get_confidential_type_sev_snp(self):
+        """Get SEV-SNP type for confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True,
+                'confidentialInstanceType': 'SEV_SNP'
+            }
+        }
+        assert get_confidential_type(vm) == 'SEV_SNP'
+
+    def test_get_confidential_type_tdx(self):
+        """Get TDX type for confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True,
+                'confidentialInstanceType': 'TDX'
+            }
+        }
+        assert get_confidential_type(vm) == 'TDX'
+
+    def test_get_confidential_type_default(self):
+        """Default to SEV when type not specified."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True
+            }
+        }
+        assert get_confidential_type(vm) == 'SEV'
+
+    def test_get_confidential_type_not_confidential(self):
+        """Return empty string for non-confidential VM."""
+        vm = {}
+        assert get_confidential_type(vm) == ''

--- a/gce_rescue_v2/utils/os_detection.py
+++ b/gce_rescue_v2/utils/os_detection.py
@@ -1,14 +1,19 @@
 """
-GCE Rescue - OS Detection Utility
+GCE Rescue - OS and VM Feature Detection Utility
 
-Detects whether a VM is running Windows or Linux based on:
-1. Guest OS features (most reliable)
-2. Boot disk source image
-3. License information
+Detects VM characteristics:
+- Operating system (Windows/Linux)
+- CPU architecture (x86_64/ARM64)
+- Shielded VM configuration
+- Confidential VM configuration
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 from ..core.config import OS_TYPE_LINUX, OS_TYPE_WINDOWS
+
+# Architecture types
+ARCH_X86_64 = 'x86_64'
+ARCH_ARM64 = 'arm64'
 
 
 def detect_os_type(vm: Dict[str, Any]) -> str:
@@ -87,3 +92,104 @@ def detect_os_from_compute(compute, project: str, zone: str, vm_name: str) -> st
     ).execute()
 
     return detect_os_type(vm)
+
+
+def detect_architecture(vm: Dict[str, Any]) -> str:
+    """
+    Detect the CPU architecture of a VM.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        'x86_64' or 'arm64'
+
+    Detection methods:
+    1. Check boot disk 'architecture' field (most reliable)
+    2. Check machine type for T2A family (ARM64)
+    """
+    # Method 1: Check boot disk architecture field
+    for disk in vm.get('disks', []):
+        if disk.get('boot'):
+            arch = disk.get('architecture', '').upper()
+            if arch == 'ARM64':
+                return ARCH_ARM64
+            elif arch == 'X86_64':
+                return ARCH_X86_64
+
+    # Method 2: Check machine type (T2A = ARM64)
+    machine_type = vm.get('machineType', '').lower()
+    # Machine type format: zones/ZONE/machineTypes/TYPE or just TYPE
+    machine_type_name = machine_type.split('/')[-1] if '/' in machine_type else machine_type
+    if machine_type_name.startswith('t2a-'):
+        return ARCH_ARM64
+
+    # Default to x86_64
+    return ARCH_X86_64
+
+
+def is_shielded_vm(vm: Dict[str, Any]) -> bool:
+    """
+    Check if VM has Shielded VM features enabled (Secure Boot).
+
+    Shielded VMs with Secure Boot enabled cannot boot unsigned rescue disks.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        True if Secure Boot is enabled
+    """
+    shielded_config = vm.get('shieldedInstanceConfig', {})
+    return shielded_config.get('enableSecureBoot', False)
+
+
+def get_shielded_config(vm: Dict[str, Any]) -> Dict[str, bool]:
+    """
+    Get full Shielded VM configuration.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        Dict with secure_boot, vtpm, and integrity_monitoring settings
+    """
+    shielded_config = vm.get('shieldedInstanceConfig', {})
+    return {
+        'secure_boot': shielded_config.get('enableSecureBoot', False),
+        'vtpm': shielded_config.get('enableVtpm', False),
+        'integrity_monitoring': shielded_config.get('enableIntegrityMonitoring', False)
+    }
+
+
+def is_confidential_vm(vm: Dict[str, Any]) -> bool:
+    """
+    Check if VM is a Confidential VM.
+
+    Confidential VMs use memory encryption (AMD SEV/Intel TDX) and cannot
+    be rescued because the disk contents cannot be accessed externally.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        True if Confidential Computing is enabled
+    """
+    confidential_config = vm.get('confidentialInstanceConfig', {})
+    return confidential_config.get('enableConfidentialCompute', False)
+
+
+def get_confidential_type(vm: Dict[str, Any]) -> str:
+    """
+    Get the type of Confidential Computing technology.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        Type string (SEV, SEV_SNP, TDX) or empty string if not confidential
+    """
+    confidential_config = vm.get('confidentialInstanceConfig', {})
+    if not confidential_config.get('enableConfidentialCompute', False):
+        return ''
+    return confidential_config.get('confidentialInstanceType', 'SEV')

--- a/gce_rescue_v2/validators/vm_state.py
+++ b/gce_rescue_v2/validators/vm_state.py
@@ -7,6 +7,7 @@ Validates that the VM exists and is in a valid state for rescue operations.
 from googleapiclient.errors import HttpError
 
 from .base import BaseValidator, ValidationResult
+from ..utils.os_detection import is_shielded_vm, is_confidential_vm, get_confidential_type
 
 
 class VMStateValidator(BaseValidator):
@@ -125,6 +126,55 @@ class VMStateValidator(BaseValidator):
                     passed=False,
                     message="VM has no boot disk",
                     details={"error": "No boot disk found"}
+                )
+
+            # Check for Confidential VM (not supported)
+            if is_confidential_vm(vm):
+                conf_type = get_confidential_type(vm) or 'SEV'
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message=f"Confidential VMs ({conf_type}) are not supported",
+                    details={
+                        "vm_name": self.vm_name,
+                        "confidential_type": conf_type,
+                        "reason": (
+                            "Confidential VMs use memory encryption that prevents "
+                            "external access to disk contents from a rescue environment."
+                        ),
+                        "fix": (
+                            "Alternatives for Confidential VMs:\n"
+                            f"  1. Use serial console: gcloud compute instances "
+                            f"get-serial-port-output {self.vm_name} --zone={self.zone}\n"
+                            "  2. Create a snapshot and new VM for data recovery\n"
+                            "  3. Contact Google Cloud Support for assistance"
+                        )
+                    }
+                )
+
+            # Check for Shielded VM with Secure Boot (not supported)
+            if is_shielded_vm(vm):
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message="Shielded VMs with Secure Boot are not supported",
+                    details={
+                        "vm_name": self.vm_name,
+                        "reason": (
+                            "Shielded VMs with Secure Boot enabled require signed boot disks. "
+                            "The rescue disk cannot boot with Secure Boot enabled."
+                        ),
+                        "fix": (
+                            "Options for Shielded VMs:\n"
+                            f"  1. Temporarily disable Secure Boot:\n"
+                            f"     gcloud compute instances stop {self.vm_name} --zone={self.zone}\n"
+                            f"     gcloud compute instances update {self.vm_name} --zone={self.zone} "
+                            "--no-shielded-secure-boot\n"
+                            "     Then run rescue again.\n"
+                            "  2. Use serial console for debugging\n"
+                            "  3. Create a snapshot and attach to another VM"
+                        )
+                    }
                 )
 
             # Build result details


### PR DESCRIPTION
## Summary

- Add CPU architecture detection (x86_64/ARM64) from disk field or T2A machine type
- Auto-select `debian-12-arm64` rescue image for ARM64/T2A instances
- Block Shielded VMs with Secure Boot enabled (cannot boot unsigned rescue disk)
- Block Confidential VMs (encrypted memory prevents external disk access)
- Include actionable fix suggestions in validation error messages

## Changes

| File | Change |
|------|--------|
| `core/config.py` | Add ARM64 rescue image config |
| `utils/os_detection.py` | Add architecture, shielded, confidential detection |
| `validators/vm_state.py` | Block unsupported VM types with helpful errors |
| `orchestration/rescue.py` | Use correct rescue image based on architecture |
| `tests/test_vm_features.py` | 24 new tests for detection functions |

## Test plan

- [x] All 24 new unit tests pass
- [x] Test rescue on T2A (ARM64) instance
- [x] Verify Shielded VM with Secure Boot is blocked with helpful message
- [x] Verify Confidential VM is blocked with helpful message