### PR TITLE
feat: Add diagnose and repair commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.4] - 2026-02-02
+
+### Added
+
+- **ARM64 Support**: Automatic architecture detection and rescue image selection
+  - Detects ARM64 from disk architecture field or T2A machine type
+  - Auto-selects `debian-12-arm64` rescue image for ARM64 instances
+  - Works with Ampere Altra (T2A) VMs
+
+- **Unsupported VM Blocking**: Clear validation errors for incompatible VM types
+  - Blocks Shielded VMs with Secure Boot (can't boot unsigned rescue disk)
+  - Blocks Confidential VMs (encrypted memory prevents external disk access)
+  - Includes actionable suggestions in error messages
+
 ## [2.0.0-beta.4] - 2026-01-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.5] - 2026-02-15
+
+### Added
+
+- **`diagnose` command**: Read-only boot diagnostics from serial console
+  - Pattern library for fstab errors (UUID not found, device missing, mount
+    failed, emergency mode, dependency failed, device timeout, fsck failed)
+  - OS detection and license type display (PAYG, BYOL, free-tier)
+  - Tiered deduplication (category + description level)
+  - Multiple output formats: table, json, yaml
+  - Context lines showing surrounding serial output for each error
+
+- **`repair` command**: Automated diagnose-fix-restore in one command (Linux only)
+  - Embeds fix script directly in startup script (no SSH needed)
+  - Creates backup snapshot before any changes (default: enabled)
+  - Backs up modified files on disk (e.g., `/etc/fstab.gce-repair-backup`)
+  - Structured result parsing from serial console markers
+  - Multi-line progress display showing rescue/repair/restore phases
+  - Supports `--no-snapshot` for faster repair
+  - Resume support for interrupted repair operations
+  - fstab fix script: comments out invalid UUID, device, and label entries
+
+### Improved
+
+- **Safety and transparency**: Users now see exactly what the tool will change
+  - Rescue confirmation lists all major changes (disk detach, metadata
+    replacement, rescue disk creation)
+  - Restore confirmation shows disk swap, metadata restore, rescue disk deletion
+  - All repair failure paths show backup snapshot name for recovery
+  - Snapshot cleanup hint shown after successful restore with `gcloud` delete
+    command
+  - Repair results show fstab backup location on disk
+
+- **Documentation**: Complete overhaul of internal docs
+  - Architecture doc rewritten with diagrams and safety mechanism details
+  - CLI reference updated with decision tree, diagnose and repair sections
+  - FAQ updated with repair safety info, roadmap, and new feature tables
+  - Contributing guide updated with fix script and boot pattern guides
+
+### Fixed
+
+- Entry point in pyproject.toml corrected from `gce-rescue` to `gce-rescue-v2`
+- Snapshot-on-resume: snapshot name restored from checkpoint context
+- Graceful degradation when `instances.get` returns 403
+
 ## [2.0.0-beta.4] - 2026-02-02
 
 ### Added

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 absl-py = ">=1.2.0"
 google-api-python-client = ">=2.68.0"
 google-auth = ">=2.15.0"
+pyyaml = ">=6.0"
 pylint = "*"
 bumpversion = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f8c14c79e90c97984625a7af2e56c3a0fca089c9e4bfed4e16835bbc9ba27f1d"
+            "sha256": "e210052e1f59c8c22fbd5b12c29dabd481ad305bda64d87ee0d0a126970e6837"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.9"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -18,19 +16,20 @@
     "default": {
         "absl-py": {
             "hashes": [
-                "sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47",
-                "sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"
+                "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d",
+                "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4"
             ],
             "index": "pypi",
-            "version": "==1.4.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.4.0"
         },
         "astroid": {
             "hashes": [
-                "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324",
-                "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"
+                "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753",
+                "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0"
             ],
-            "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.5"
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==4.0.4"
         },
         "bump2version": {
             "hashes": [
@@ -48,215 +47,359 @@
             "index": "pypi",
             "version": "==0.6.0"
         },
-        "cachetools": {
-            "hashes": [
-                "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14",
-                "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"
-            ],
-            "markers": "python_version ~= '3.7'",
-            "version": "==5.3.0"
-        },
         "certifi": {
             "hashes": [
-                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
-                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+                "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c",
+                "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2023.5.7"
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.1.4"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb",
+                "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b",
+                "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f",
+                "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9",
+                "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44",
+                "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2",
+                "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c",
+                "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75",
+                "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65",
+                "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e",
+                "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a",
+                "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e",
+                "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25",
+                "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a",
+                "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe",
+                "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b",
+                "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91",
+                "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592",
+                "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187",
+                "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c",
+                "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1",
+                "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94",
+                "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba",
+                "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb",
+                "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165",
+                "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+                "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca",
+                "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c",
+                "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6",
+                "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c",
+                "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0",
+                "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743",
+                "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63",
+                "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5",
+                "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5",
+                "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4",
+                "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d",
+                "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b",
+                "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93",
+                "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205",
+                "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27",
+                "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512",
+                "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d",
+                "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c",
+                "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037",
+                "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26",
+                "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322",
+                "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb",
+                "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c",
+                "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8",
+                "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4",
+                "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414",
+                "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9",
+                "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664",
+                "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9",
+                "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775",
+                "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739",
+                "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc",
+                "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062",
+                "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe",
+                "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9",
+                "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92",
+                "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5",
+                "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13",
+                "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d",
+                "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f",
+                "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495",
+                "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6",
+                "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c",
+                "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef",
+                "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5",
+                "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18",
+                "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad",
+                "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3",
+                "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7",
+                "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5",
+                "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534",
+                "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49",
+                "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2",
+                "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5",
+                "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453",
+                "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.0.0"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
-                "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
-                "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
-                "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
-                "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
-                "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
-                "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
-                "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
-                "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
-                "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
-                "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
-                "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
-                "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
-                "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
-                "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
-                "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
-                "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
-                "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
-                "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5",
-                "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
-                "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
-                "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
-                "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
-                "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
-                "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
-                "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
-                "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
-                "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
-                "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
-                "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
-                "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
-                "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
-                "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
-                "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
-                "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
-                "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
-                "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
-                "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
-                "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
-                "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
-                "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
-                "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
-                "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
-                "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
-                "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
-                "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
-                "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
-                "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
-                "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
-                "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
-                "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
-                "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
-                "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
-                "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
-                "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
-                "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
-                "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
-                "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
-                "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
-                "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
-                "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
-                "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
-                "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
-                "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
-                "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
-                "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
-                "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
-                "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
-                "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
-                "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
-                "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
-                "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
-                "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
-                "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
-                "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
+                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
+                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
+                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
+                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
+                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
+                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
+                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
+                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
+                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
+                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
+                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
+                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
+                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
+                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
+                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
+                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
+                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
+                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
+                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
+                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
+                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
+                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
+                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
+                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
+                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
+                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
+                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
+                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
+                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
+                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
+                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
+                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
+                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
+                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
+                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
+                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
+                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
+                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
+                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
+                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
+                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
+                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
+                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
+                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
+                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
+                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
+                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
+                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
+                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
+                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
+                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
+                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
+                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
+                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
+                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
+                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
+                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
+                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
+                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
+                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
+                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
+                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
+                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
+                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
+                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
+                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
+                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
+                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
+                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
+                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
+                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
+                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
+                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
+                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
+                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
+                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
+                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
+                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
+                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
+                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
+                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
+                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
+                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
+                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
+                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
+                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
+                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
+                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
+                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
+                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
+                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
+                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
+                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
+                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
+                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
+                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
+                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
+                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
+                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
+                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
+                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
+                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
+                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
+                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
+                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
+                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
+                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
+                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
+                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
+                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
+                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
+                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
+                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.0"
+            "version": "==3.4.4"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.4.6"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72",
+                "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235",
+                "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9",
+                "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356",
+                "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257",
+                "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad",
+                "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4",
+                "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c",
+                "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614",
+                "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed",
+                "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31",
+                "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229",
+                "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0",
+                "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731",
+                "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b",
+                "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4",
+                "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4",
+                "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263",
+                "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595",
+                "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1",
+                "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678",
+                "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48",
+                "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76",
+                "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0",
+                "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18",
+                "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d",
+                "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d",
+                "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1",
+                "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981",
+                "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7",
+                "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82",
+                "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2",
+                "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4",
+                "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663",
+                "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c",
+                "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d",
+                "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a",
+                "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a",
+                "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d",
+                "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b",
+                "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a",
+                "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826",
+                "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee",
+                "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9",
+                "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648",
+                "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da",
+                "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2",
+                "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2",
+                "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"
+            ],
+            "markers": "python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'",
+            "version": "==46.0.5"
         },
         "dill": {
             "hashes": [
-                "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
-                "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"
+                "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d",
+                "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa"
             ],
-            "markers": "python_version < '3.11'",
-            "version": "==0.3.6"
+            "markers": "python_version >= '3.9'",
+            "version": "==0.4.1"
         },
         "google-api-core": {
             "hashes": [
-                "sha256:4b9bb5d5a380a0befa0573b302651b8a9a89262c1730e37bf423cec511804c22",
-                "sha256:ce222e27b0de0d7bc63eb043b956996d6dccab14cc3b690aaea91c9cc99dc16e"
+                "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7",
+                "sha256:d30bc60980daa36e314b5d5a3e5958b0200cb44ca8fa1be2b614e932b75a3ea9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.11.0"
+            "version": "==2.29.0"
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:0f320190ab9d5bd2fdb0cb894e8e53bb5e17d4888ee8dc4d26ba65ce378409e2",
-                "sha256:3ca4e93821f4e9ac29b91ab0d9df168b42c8ad0fb8bff65b8c2ccb2d462b0464"
+                "sha256:5357f34552e3724d80d2604c8fa146766e0a9d6bb0afada886fafed9feafeef6",
+                "sha256:d9b5266758f96c39b8c21d9bbfeb4e58c14dbfba3c931f7c5a8d7fdcd292dd57"
             ],
             "index": "pypi",
-            "version": "==2.86.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.190.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:ce311e2bc58b130fddf316df57c9b3943c2a7b4f6ec31de9663a9333e4064efc",
-                "sha256:f586b274d3eb7bd932ea424b1c702a30e0393a2e2bc4ca3eae8263ffd8be229f"
+                "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f",
+                "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce"
             ],
             "index": "pypi",
-            "version": "==2.17.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.48.0"
         },
         "google-auth-httplib2": {
             "hashes": [
-                "sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10",
-                "sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac"
+                "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b",
+                "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776"
             ],
-            "version": "==0.1.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.3.0"
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:4168fcb568a826a52f23510412da405abd93f4d23ba544bb68d943b14ba3cb44",
-                "sha256:b287dc48449d1d41af0c69f4ea26242b5ae4c3d7249a38b0984c86a4caffff1f"
+                "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038",
+                "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.59.0"
+            "version": "==1.72.0"
         },
         "httplib2": {
             "hashes": [
-                "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc",
-                "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81"
+                "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24",
+                "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.22.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==0.31.2"
         },
         "idna": {
             "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
+                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.4"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
         },
         "isort": {
             "hashes": [
-                "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
-                "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
+                "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1",
+                "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187"
             ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==5.12.0"
-        },
-        "lazy-object-proxy": {
-            "hashes": [
-                "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
-                "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82",
-                "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
-                "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
-                "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
-                "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
-                "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
-                "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
-                "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
-                "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
-                "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
-                "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
-                "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
-                "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
-                "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586",
-                "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
-                "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821",
-                "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
-                "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b",
-                "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
-                "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
-                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
-                "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
-                "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
-                "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
-                "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
-                "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f",
-                "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
-                "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
-                "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e",
-                "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671",
-                "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
-                "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455",
-                "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734",
-                "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
-                "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.9.0"
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==7.0.0"
         },
         "mccabe": {
             "hashes": [
@@ -268,207 +411,196 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f",
-                "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"
+                "sha256:61d8b967d34791c162d30d60737369cbbd77debad5b981c4bfda1842e71e0d66",
+                "sha256:f310f16e89c4e29117805d8328f7c10876eeff36c94eac879532812110f7d39f"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.9.1"
+        },
+        "proto-plus": {
+            "hashes": [
+                "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147",
+                "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.5.1"
+            "version": "==1.27.1"
         },
         "protobuf": {
             "hashes": [
-                "sha256:2036a3a1e7fc27f973fa0a7888dce712393af644f4695385f117886abc792e39",
-                "sha256:32e78beda26d7a101fecf15d7a4a792278a0d26a31bc327ff05564a9d68ab8ee",
-                "sha256:346990f634272caac1f09efbcfbbacb23098b1f606d172534c6fa2d9758bb436",
-                "sha256:3b8905eafe4439076e1f58e9d1fa327025fd2777cf90f14083092ae47f77b0aa",
-                "sha256:3ce113b3f3362493bddc9069c2163a38f240a9ed685ff83e7bcb756b05e1deb0",
-                "sha256:410bcc0a5b279f634d3e16082ce221dfef7c3392fac723500e2e64d1806dd2be",
-                "sha256:5b9cd6097e6acae48a68cb29b56bc79339be84eca65b486910bb1e7a30e2b7c1",
-                "sha256:65f0ac96ef67d7dd09b19a46aad81a851b6f85f89725577f16de38f2d68ad477",
-                "sha256:91fac0753c3c4951fbb98a93271c43cc7cf3b93cf67747b3e600bb1e5cc14d61",
-                "sha256:95789b569418a3e32a53f43d7763be3d490a831e9c08042539462b6d972c2d7e",
-                "sha256:ac50be82491369a9ec3710565777e4da87c6d2e20404e0abb1f3a8f10ffd20f0",
-                "sha256:decf119d54e820f298ee6d89c72d6b289ea240c32c521f00433f9dc420595f38",
-                "sha256:f9510cac91e764e86acd74e2b7f7bc5e6127a7f3fb646d7c8033cfb84fd1176a"
+                "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c",
+                "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02",
+                "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c",
+                "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd",
+                "sha256:8f04fa32763dcdb4973d537d6b54e615cc61108c7cb38fe59310c3192d29510a",
+                "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190",
+                "sha256:a3157e62729aafb8df6da2c03aa5c0937c7266c626ce11a278b6eb7963c4e37c",
+                "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5",
+                "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0",
+                "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.23.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==6.33.5"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57",
-                "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"
+                "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf",
+                "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==0.5.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.6.2"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:5bd01446b736eb9d31512a30d46c1ac3395d676c6f3cafa4c03eb54b9925631c",
-                "sha256:d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d"
+                "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a",
+                "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==0.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.4.2"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+                "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==3.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1",
-                "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"
+                "sha256:63e06a37d5922555ee2c20963eb42559918c20bd2b21244e4ef426e7c43b92e0",
+                "sha256:d9b71674e19b1c36d79265b5887bf8e55278cbe236c9e95d22dc82cf044fdbd2"
             ],
             "index": "pypi",
-            "version": "==2.17.4"
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==4.0.4"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+                "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d",
+                "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"
             ],
-            "markers": "python_version >= '3.1'",
-            "version": "==3.0.9"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.3.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c",
+                "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a",
+                "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3",
+                "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956",
+                "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6",
+                "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c",
+                "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65",
+                "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a",
+                "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0",
+                "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b",
+                "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1",
+                "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6",
+                "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7",
+                "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e",
+                "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007",
+                "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310",
+                "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4",
+                "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9",
+                "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295",
+                "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea",
+                "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0",
+                "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e",
+                "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac",
+                "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9",
+                "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7",
+                "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35",
+                "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb",
+                "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b",
+                "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69",
+                "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5",
+                "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b",
+                "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c",
+                "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369",
+                "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd",
+                "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824",
+                "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198",
+                "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065",
+                "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c",
+                "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c",
+                "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764",
+                "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196",
+                "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b",
+                "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00",
+                "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac",
+                "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8",
+                "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e",
+                "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28",
+                "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3",
+                "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5",
+                "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4",
+                "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b",
+                "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf",
+                "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5",
+                "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702",
+                "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8",
+                "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788",
+                "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da",
+                "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d",
+                "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc",
+                "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c",
+                "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba",
+                "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f",
+                "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917",
+                "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5",
+                "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26",
+                "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f",
+                "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b",
+                "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be",
+                "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c",
+                "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3",
+                "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6",
+                "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926",
+                "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.3"
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             ],
-            "index": "pypi",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
         },
         "rsa": {
             "hashes": [
-                "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
-                "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
+                "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762",
+                "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.9"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.16.0"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==4.9.1"
         },
         "tomlkit": {
             "hashes": [
-                "sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171",
-                "sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"
+                "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680",
+                "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.11.8"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:6ad00b63f849b7dcc313b70b6b304ed67b2b2963b3098a33efe18056b1a9a223",
-                "sha256:ff6b238610c747e44c268aa4bb23c8c735d665a63726df3f9431ce707f2aa768"
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==4.6.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==0.14.0"
         },
         "uritemplate": {
             "hashes": [
-                "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0",
-                "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e"
+                "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e",
+                "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.1.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.2.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc",
-                "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.2"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0",
-                "sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420",
-                "sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a",
-                "sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c",
-                "sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079",
-                "sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923",
-                "sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f",
-                "sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1",
-                "sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8",
-                "sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86",
-                "sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0",
-                "sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364",
-                "sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e",
-                "sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c",
-                "sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e",
-                "sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c",
-                "sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727",
-                "sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff",
-                "sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e",
-                "sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29",
-                "sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7",
-                "sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72",
-                "sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475",
-                "sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a",
-                "sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317",
-                "sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2",
-                "sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd",
-                "sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640",
-                "sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98",
-                "sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248",
-                "sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e",
-                "sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d",
-                "sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec",
-                "sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1",
-                "sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e",
-                "sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9",
-                "sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92",
-                "sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb",
-                "sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094",
-                "sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46",
-                "sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29",
-                "sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd",
-                "sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705",
-                "sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8",
-                "sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975",
-                "sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb",
-                "sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e",
-                "sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b",
-                "sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418",
-                "sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019",
-                "sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1",
-                "sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba",
-                "sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6",
-                "sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2",
-                "sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3",
-                "sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7",
-                "sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752",
-                "sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416",
-                "sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f",
-                "sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1",
-                "sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc",
-                "sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145",
-                "sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee",
-                "sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a",
-                "sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7",
-                "sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b",
-                "sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653",
-                "sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0",
-                "sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90",
-                "sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29",
-                "sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6",
-                "sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034",
-                "sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09",
-                "sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559",
-                "sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==1.15.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.6.3"
         }
     },
     "develop": {

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 
 > ### GCE Rescue V2 Beta Now Available!
 >
-> **V2 includes:** Windows VM support, automatic rollback, simplified CLI
+> **V2 includes:** Boot diagnostics (`diagnose`), auto-fix (`repair`), Windows support, automatic rollback, session recovery
 >
 > ```bash
 > pip install git+https://github.com/GoogleCloudPlatform/gce-rescue.git@v2-beta
-> gce-rescue-v2 rescue my-vm --zone=us-central1-a
+> gce-rescue-v2 diagnose my-vm --zone=us-central1-a    # What's wrong?
+> gce-rescue-v2 repair my-vm --zone=us-central1-a      # Auto-fix (Linux)
+> gce-rescue-v2 rescue my-vm --zone=us-central1-a      # Manual fix
 > ```
 >
 > **[View V2 Documentation](gce_rescue_v2/README.md)** | V1 documentation continues below

--- a/gce_rescue_v2/README.md
+++ b/gce_rescue_v2/README.md
@@ -10,7 +10,11 @@
 |------|----|----|
 | **OS Support** | Linux only | Linux + Windows |
 | **CLI Style** | Short flags (`-n`, `-z`) | gcloud-style (`--zone=`) |
-| **Commands** | Single command (toggles) | Separate `rescue` / `restore` |
+| **Commands** | Single command (toggles) | `diagnose` / `repair` / `rescue` / `restore` |
+| **Boot Diagnostics** | None | Serial console analysis (`diagnose`) |
+| **Auto-Fix** | None | Automated repair for fstab errors (`repair`) |
+| **Rollback** | Manual cleanup | Automatic rollback on failure |
+| **Session Recovery** | None | Resume or rollback interrupted operations |
 | **Architecture** | Task-based | Operation-based with rollback |
 
 ## Prerequisites
@@ -65,8 +69,32 @@ gce-rescue-v2 --version
 
 ## Commands
 
+```
+VM won't boot
+    │
+    ├─ Not sure what's wrong?
+    │   └─ gce-rescue-v2 diagnose   (read-only, safe anytime)
+    │
+    ├─ diagnose found a fixable issue (e.g. fstab)?
+    │   └─ gce-rescue-v2 repair     (auto-fix, Linux only)
+    │
+    ├─ Need manual access to the disk?
+    │   ├─ gce-rescue-v2 rescue     (enter rescue mode)
+    │   ├─ SSH/RDP in and fix
+    │   └─ gce-rescue-v2 restore    (exit rescue mode)
+    │
+    └─ VM stuck from a previous rescue?
+        └─ gce-rescue-v2 restore    (or re-run rescue to resume/rollback)
+```
+
 ```bash
-# Rescue (enter rescue mode)
+# Diagnose boot issues (read-only)
+gce-rescue-v2 diagnose VM_NAME --zone ZONE [--project PROJECT] [--format json]
+
+# Auto-fix diagnosed issues (Linux only)
+gce-rescue-v2 repair VM_NAME --zone ZONE [--project PROJECT] [--no-snapshot] [--quiet]
+
+# Rescue (enter rescue mode for manual fix)
 gce-rescue-v2 rescue VM_NAME --zone ZONE [--project PROJECT] [--no-snapshot] [--quiet]
 
 # Restore (exit rescue mode)
@@ -81,7 +109,65 @@ gce-rescue-v2 restore VM_NAME --zone ZONE [--project PROJECT] [--quiet]
 | `--quiet` | No confirmation prompts (for automation) |
 | `--format` | Output format: `table`, `json`, `yaml` |
 
-## Example: Linux VM
+## Example: Diagnose
+
+```bash
+$ gce-rescue-v2 diagnose web-server --zone=us-central1-a
+
+Diagnosis for instance [web-server]:
+
+  Status: boot_errors_detected
+  OS: Linux (debian-12)
+
+  Boot errors found:
+
+  [CRITICAL] fstab: UUID specified in /etc/fstab cannot be found
+    Context:
+      > [DEPEND] Dependency failed for /mnt/data.
+      > UUID=deadbeef-1234-5678-9abc-def012345678 does not exist.
+
+    To fix this issue:
+      1. Boot into rescue mode:
+         $ gce-rescue-v2 rescue web-server --zone=us-central1-a
+      2. Edit fstab: nano /mnt/sysroot/etc/fstab
+      3. Comment out the invalid entry and save.
+      4. Restore:
+         $ gce-rescue-v2 restore web-server --zone=us-central1-a
+
+    Or auto-fix with: gce-rescue-v2 repair web-server --zone=us-central1-a
+```
+
+## Example: Repair (auto-fix)
+
+```bash
+$ gce-rescue-v2 repair web-server --zone=us-central1-a
+
+Diagnosis for instance [web-server]:
+  [CRITICAL] fstab: UUID specified in /etc/fstab cannot be found
+
+Repair plan:
+  1. Create a backup snapshot of the boot disk.
+  2. Boot into rescue mode with embedded fix script.
+  3. Apply fix: comment out invalid fstab entries.
+  4. Restore original boot disk and start VM.
+
+Do you want to proceed with repair (y/N)? y
+
+Repairing instance [web-server]:
+  Rescue:  Stopping VM -> Creating snapshot -> Creating rescue disk -> Starting rescue VM -> Mounting disk  done.
+  Repair:  Applying fix -> Verifying fix  done.
+  Restore: Stopping VM -> Restoring boot disk -> Starting VM  done.
+
+Repair results:
+  [FIXED] fstab: Commented out invalid UUID entry for /mnt/data (deadbeef-1234...)
+  1 issue fixed.
+  Original fstab backed up to: /etc/fstab.gce-repair-backup
+  Backup snapshot: pre-rescue-web-server-1739600000
+
+Repair complete. Instance [web-server] is now running. (1m 42s)
+```
+
+## Example: Linux VM (manual rescue)
 
 **Rescue:**
 
@@ -229,6 +315,8 @@ Forgot password? Reset it:
 
 | Action | V1 | V2 |
 |--------|----|----|
+| Diagnose boot issues | N/A | `gce-rescue-v2 diagnose VM --zone ZONE` |
+| Auto-fix boot issues | N/A | `gce-rescue-v2 repair VM --zone ZONE` |
 | Enter rescue | `gce-rescue -n VM -z ZONE` | `gce-rescue-v2 rescue VM --zone ZONE` |
 | Exit rescue | `gce-rescue -n VM -z ZONE` (same) | `gce-rescue-v2 restore VM --zone ZONE` |
 | Skip snapshot | `--skip-snapshot` | `--no-snapshot` |

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -16,10 +16,12 @@ import argparse
 import sys
 import os
 import json
+import threading
+import time
 import yaml
 from typing import Optional, Dict, Any
 from .core.config import RescueConfig, RestoreConfig, VERSION
-from .main import rescue_vm, restore_vm
+from .main import rescue_vm, restore_vm, repair_vm
 from .utils.colors import error_prefix, warning_prefix, clear_lines
 from .utils.report_formatter import DiagnosisReportFormatter
 from .orchestration.checkpoint import CheckpointManager, CheckpointData
@@ -29,7 +31,7 @@ class OutputFormatter:
     """
     Handle output formatting similar to gcloud.
 
-    Supports: json, yaml, table, csv, value
+    Supports: json, yaml, table
     """
 
     @staticmethod
@@ -105,6 +107,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
     # Flags specific to each command (for helpful error messages)
     RESCUE_ONLY_FLAGS = ['--snapshot', '--no-snapshot']
     RESTORE_ONLY_FLAGS = ['--keep-rescue-disk']
+    REPAIR_ONLY_FLAGS = []  # repair uses same flags as rescue for now
 
     def error(self, message: str):
         """Override to provide cleaner error format."""
@@ -128,7 +131,8 @@ class CustomArgumentParser(argparse.ArgumentParser):
                     lines.append("Available commands:")
                     lines.append("  rescue         Boot a VM into rescue mode")
                     lines.append("  restore        Restore a VM from rescue mode")
-                    lines.append("  diagnose  Diagnose VM boot issues (read-only)")
+                    lines.append("  diagnose       Diagnose VM boot issues (read-only)")
+                    lines.append("  repair         Diagnose and auto-fix boot issues")
                 else:
                     lines.append(f"{message}")
             else:
@@ -181,7 +185,8 @@ class CustomArgumentParser(argparse.ArgumentParser):
                 "Commands:",
                 "  rescue         Boot a VM into rescue mode",
                 "  restore        Restore a VM from rescue mode",
-                "  diagnose  Diagnose VM boot issues (read-only)",
+                "  diagnose       Diagnose VM boot issues (read-only)",
+                "  repair         Diagnose and auto-fix boot issues",
                 "",
                 "Examples:",
                 "  $ gce-rescue-v2 rescue my-vm --zone=us-central1-a",
@@ -244,6 +249,9 @@ EXAMPLES
 
     Diagnose boot issues:
         $ gce-rescue-v2 diagnose my-vm --zone=us-central1-a
+
+    Auto-repair boot issues:
+        $ gce-rescue-v2 repair my-vm --zone=us-central1-a
 
 SUPPORTED OS
     - Linux (auto-detected): Boots Debian 12 rescue environment
@@ -345,6 +353,35 @@ NOTES
 
     _add_common_args(diagnose_parser)
 
+    # REPAIR COMMAND
+    repair_parser = subparsers.add_parser(
+        'repair',
+        help='Diagnose and auto-fix boot issues (Linux only)',
+        description='Automatically diagnose and repair boot issues. Combines diagnose, rescue (with embedded fix), and restore into a single command.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+EXAMPLES
+    Repair a VM with boot issues:
+        $ gce-rescue-v2 repair my-vm --zone=us-central1-a
+
+    Repair without snapshot (faster):
+        $ gce-rescue-v2 repair my-vm --zone=us-central1-a --no-snapshot
+
+    Repair in automation (no prompts):
+        $ gce-rescue-v2 repair my-vm --zone=us-central1-a --quiet
+
+SUPPORTED FIXES
+    - fstab: Comments out invalid UUID, device, or label entries
+
+NOTES
+    This command is Linux-only. For Windows VMs, use 'rescue' for manual fix.
+    The VM will be stopped during repair and restarted when complete.
+        """
+    )
+
+    _add_common_args(repair_parser)
+    _add_repair_args(repair_parser)
+
     return parser
 
 
@@ -426,6 +463,23 @@ def _add_rescue_args(parser: argparse.ArgumentParser):
     )
 
 
+def _add_repair_args(parser: argparse.ArgumentParser):
+    """Add repair-specific arguments."""
+    snapshot_group = parser.add_argument_group('SNAPSHOT FLAGS')
+    snapshot_group.add_argument(
+        '--snapshot',
+        action='store_true',
+        default=True,
+        help='Create snapshot of boot disk before repair (default: enabled)'
+    )
+    snapshot_group.add_argument(
+        '--no-snapshot',
+        dest='snapshot',
+        action='store_false',
+        help='Skip snapshot creation (faster but riskier)'
+    )
+
+
 def _add_restore_args(parser: argparse.ArgumentParser):
     """Add restore-specific arguments."""
 
@@ -497,6 +551,49 @@ def args_to_restore_config(args: argparse.Namespace) -> RestoreConfig:
     config.log_level = verbosity_map.get(args.verbosity, 'INFO')
 
     return config
+
+
+class _Spinner:
+    """Simple inline spinner for short-lived operations."""
+
+    def __init__(self, message: str):
+        self._message = message
+        self._stop = False
+        self._thread = None
+
+    def start(self):
+        self._stop = False
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+
+    def stop(self, clear: bool = True):
+        self._stop = True
+        if self._thread:
+            self._thread.join(timeout=0.5)
+        if clear:
+            sys.stdout.write(f"\r{' ' * (len(self._message) + 10)}\r")
+            sys.stdout.flush()
+
+    def _spin(self):
+        chars = ['|', '/', '-', '\\']
+        idx = 0
+        while not self._stop:
+            sys.stdout.write(f"\r{self._message}..{chars[idx]}")
+            sys.stdout.flush()
+            idx = (idx + 1) % len(chars)
+            time.sleep(0.1)
+
+
+def _format_duration(seconds: float) -> str:
+    """Format seconds into a human-readable duration string (e.g. '1m 42s')."""
+    total = int(seconds)
+    if total < 60:
+        return f"{total}s"
+    minutes = total // 60
+    secs = total % 60
+    if secs == 0:
+        return f"{minutes}m"
+    return f"{minutes}m {secs}s"
 
 
 def _parse_api_error(e: Exception, vm_name: str, zone: str, project: str = None) -> str:
@@ -744,8 +841,6 @@ def _handle_restore_checkpoint_rollback(compute, project: str, zone: str, vm_nam
         SetMetadataOperation, StartVMOperation
     )
 
-    print(f"\nRolling back to rescue mode for instance [{vm_name}]:")
-
     # Create operations map for restore operations
     operations_map = {
         "Stop VM": StopVMOperation(compute, project, zone, logger),
@@ -767,20 +862,181 @@ def _handle_restore_checkpoint_rollback(compute, project: str, zone: str, vm_nam
             step_number=op.step
         )
 
-    # Perform rollback
+    # Check if there's anything to rollback
+    rollback_ops = state_tracker.get_rollback_operations()
+    if not rollback_ops:
+        checkpoint_mgr = CheckpointManager(compute, project, zone, vm_name, logger)
+        checkpoint_mgr.clear_checkpoint()
+        print(f"\nNo changes were made. Checkpoint cleared for instance [{vm_name}].")
+        return True
+
+    # Perform rollback with progress indicator
+    print(f"\nRolling back to rescue mode for instance [{vm_name}]:")
+    spinner = _Spinner("  Undoing changes")
+    spinner.start()
     handler = RollbackHandler(logger)
     success = handler.rollback(state_tracker, operations_map)
+    spinner.stop()
 
     # Clear checkpoint after rollback
     checkpoint_mgr = CheckpointManager(compute, project, zone, vm_name, logger)
     checkpoint_mgr.clear_checkpoint()
 
     if success:
-        print(f"\nInstance [{vm_name}] is back in rescue mode.")
+        print(f"Instance [{vm_name}] is back in rescue mode.")
     else:
-        print(f"\n{error_prefix()} Rollback completed with errors. Manual intervention may be required.")
+        print(f"{error_prefix()} Rollback completed with errors. Manual intervention may be required.", file=sys.stderr)
 
     return success
+
+
+def _reconcile_rescue_state(compute, project: str, zone: str, vm_name: str,
+                            checkpoint: CheckpointData, state_tracker,
+                            logger=None) -> None:
+    """
+    Reconcile checkpoint state with actual VM disk state.
+
+    Inspects the real VM via GCP API and adds any operations that completed
+    server-side but weren't checkpointed (e.g., Ctrl+C during API call).
+
+    Args:
+        compute: GCP compute client
+        project: GCP project ID
+        zone: GCP zone
+        vm_name: VM name
+        checkpoint: Checkpoint data from metadata
+        state_tracker: StateTracker to add missing operations to
+        logger: Optional logger
+    """
+    def _log(msg):
+        if logger:
+            logger.debug(f"[Reconcile] {msg}")
+
+    context = checkpoint.context or {}
+    original_disk_name = context.get('original_disk_name')
+    rescue_disk_name = context.get('rescue_disk_name')
+
+    if not original_disk_name:
+        _log("No original_disk_name in checkpoint context, skipping reconciliation")
+        return
+
+    # Get actual VM state
+    try:
+        vm = compute.instances().get(
+            project=project, zone=zone, instance=vm_name
+        ).execute()
+    except Exception as e:
+        _log(f"Could not fetch VM state: {e}")
+        return
+
+    attached_disks = vm.get('disks', [])
+    attached_disk_names = []
+    for d in attached_disks:
+        source = d.get('source', '')
+        if source:
+            attached_disk_names.append(source.split('/')[-1])
+
+    checkpointed_op_names = {op.name for op in checkpoint.completed_operations}
+
+    # Check 1: Original boot disk detached but not in checkpoint
+    if original_disk_name not in attached_disk_names:
+        if "Detach Boot Disk" not in checkpointed_op_names:
+            _log(f"Original boot disk '{original_disk_name}' is detached but not in checkpoint - adding to rollback")
+            disk_source = f"projects/{project}/zones/{zone}/disks/{original_disk_name}"
+            state_tracker.add_operation(
+                operation_name="Detach Boot Disk",
+                success=True,
+                message="Detected via reconciliation (completed but not checkpointed)",
+                rollback_data={
+                    'vm_name': vm_name,
+                    'disk_info': {
+                        'source': disk_source,
+                        'boot': True,
+                        'autoDelete': True,
+                        'deviceName': original_disk_name,
+                        'mode': 'READ_WRITE'
+                    }
+                },
+                step_number=2
+            )
+
+    # Check 2: Rescue disk exists and is attached but not in checkpoint
+    if rescue_disk_name and rescue_disk_name in attached_disk_names:
+        if "Attach Rescue Disk" not in checkpointed_op_names:
+            _log(f"Rescue disk '{rescue_disk_name}' is attached but not in checkpoint - adding to rollback")
+            # Need to add Create Rescue Disk first (so rollback deletes it)
+            if "Create Rescue Disk" not in checkpointed_op_names:
+                state_tracker.add_operation(
+                    operation_name="Create Rescue Disk",
+                    success=True,
+                    message="Detected via reconciliation",
+                    rollback_data={'disk_name': rescue_disk_name},
+                    step_number=4
+                )
+            state_tracker.add_operation(
+                operation_name="Attach Rescue Disk",
+                success=True,
+                message="Detected via reconciliation",
+                rollback_data={
+                    'vm_name': vm_name,
+                    'device_name': rescue_disk_name
+                },
+                step_number=5
+            )
+
+    # Check 3: Rescue disk exists (not attached) but creation not in checkpoint
+    if rescue_disk_name and "Create Rescue Disk" not in checkpointed_op_names:
+        if rescue_disk_name not in attached_disk_names:
+            try:
+                compute.disks().get(
+                    project=project, zone=zone, disk=rescue_disk_name
+                ).execute()
+                _log(f"Rescue disk '{rescue_disk_name}' exists but not in checkpoint - adding to rollback")
+                state_tracker.add_operation(
+                    operation_name="Create Rescue Disk",
+                    success=True,
+                    message="Detected via reconciliation",
+                    rollback_data={'disk_name': rescue_disk_name},
+                    step_number=4
+                )
+            except Exception:
+                pass  # Disk doesn't exist, nothing to reconcile
+
+    # Check 4: Rescue metadata set but not in checkpoint
+    metadata_obj = vm.get('metadata', {})
+    metadata_items = metadata_obj.get('items', [])
+    has_rescue_metadata = any(item.get('key') == 'rescue-mode' for item in metadata_items)
+    if has_rescue_metadata and "Set Metadata" not in checkpointed_op_names:
+        _log("Rescue metadata found but not in checkpoint - adding to rollback")
+        # Reconstruct pre-rescue metadata by removing rescue keys and restoring backups
+        rescue_keys = {'rescue-mode', 'startup-script', 'windows-startup-script-ps1',
+                       'rescue-original-disk', 'rescue-os-type'}
+        backup_prefix = 'rescue-backup-'
+        restored_items = []
+        for item in metadata_items:
+            if item['key'] in rescue_keys:
+                continue
+            if item['key'].startswith(backup_prefix):
+                restored_items.append({
+                    'key': item['key'][len(backup_prefix):],
+                    'value': item['value']
+                })
+            else:
+                restored_items.append(item)
+        original_metadata = {
+            'fingerprint': metadata_obj.get('fingerprint', ''),
+            'items': restored_items
+        }
+        state_tracker.add_operation(
+            operation_name="Set Metadata",
+            success=True,
+            message="Detected via reconciliation",
+            rollback_data={
+                'vm_name': vm_name,
+                'original_metadata': original_metadata
+            },
+            step_number=6
+        )
 
 
 def _handle_checkpoint_rollback(compute, project: str, zone: str, vm_name: str,
@@ -807,8 +1063,6 @@ def _handle_checkpoint_rollback(compute, project: str, zone: str, vm_name: str,
         CreateSnapshotOperation, CreateDiskOperation
     )
 
-    print(f"\nRolling back instance [{vm_name}]:")
-
     # Create operations map
     operations_map = {
         "Stop VM": StopVMOperation(compute, project, zone, logger),
@@ -832,18 +1086,38 @@ def _handle_checkpoint_rollback(compute, project: str, zone: str, vm_name: str,
             step_number=op.step
         )
 
-    # Perform rollback
+    # Reconcile with actual VM state to catch operations that completed
+    # server-side but weren't checkpointed (e.g., Ctrl+C during API call)
+    if checkpoint.operation == 'rescue':
+        _reconcile_rescue_state(
+            compute, project, zone, vm_name, checkpoint, state_tracker, logger
+        )
+
+    # Check if there's anything to rollback
+    rollback_ops = state_tracker.get_rollback_operations()
+    if not rollback_ops:
+        # Nothing was changed — just clear the stale checkpoint
+        checkpoint_mgr = CheckpointManager(compute, project, zone, vm_name, logger)
+        checkpoint_mgr.clear_checkpoint()
+        print(f"\nNo changes were made. Checkpoint cleared for instance [{vm_name}].")
+        return True
+
+    # Perform rollback with progress indicator
+    print(f"\nRolling back instance [{vm_name}]:")
+    spinner = _Spinner("  Undoing changes")
+    spinner.start()
     handler = RollbackHandler(logger)
     success = handler.rollback(state_tracker, operations_map)
+    spinner.stop()
 
     # Clear checkpoint after rollback
     checkpoint_mgr = CheckpointManager(compute, project, zone, vm_name, logger)
     checkpoint_mgr.clear_checkpoint()
 
     if success:
-        print(f"\nInstance [{vm_name}] has been restored to its original state.")
+        print(f"Instance [{vm_name}] has been restored to its original state.")
     else:
-        print(f"\n{error_prefix()} Rollback completed with errors. Manual intervention may be required.")
+        print(f"{error_prefix()} Rollback completed with errors. Manual intervention may be required.", file=sys.stderr)
 
     return success
 
@@ -916,7 +1190,7 @@ def handle_rescue(args: argparse.Namespace) -> int:
             print("WARNING: Stopping this VM will PERMANENTLY LOSE all data on Local SSDs!", file=sys.stderr)
             print("", file=sys.stderr)
             print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
-            print(f"  gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --quiet --force", file=sys.stderr)
+            print(f"  $ gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --quiet --force", file=sys.stderr)
             return 1
 
     # Interactive confirmation (unless --quiet or resuming)
@@ -924,7 +1198,7 @@ def handle_rescue(args: argparse.Namespace) -> int:
         # Count lines for clearing after confirmation
         lines_printed = 0
 
-        print(f"\nYou are about to rescue instance [{args.instance_name}] in zone [{args.zone}].")
+        print(f"\nYou are about to rescue instance [{args.instance_name}] in zone [{args.zone}] project [{project}].")
         lines_printed += 2  # includes leading newline
         print("")
         lines_printed += 1
@@ -932,11 +1206,18 @@ def handle_rescue(args: argparse.Namespace) -> int:
         lines_printed += 1
         print(f" - Stop instance [{args.instance_name}].")
         lines_printed += 1
-        print(" - Create a snapshot of your affected boot disk.")
+        if args.snapshot:
+            print(" - Create a backup snapshot of the boot disk.")
+        else:
+            print(" - Snapshot creation skipped (--no-snapshot).")
         lines_printed += 1
-        print(" - Create a rescue disk and boot from it.")
+        print(" - Detach the original boot disk.")
         lines_printed += 1
-        print(" - Attach your affected boot disk for repair.")
+        print(" - Create a rescue disk and attach it as the new boot disk.")
+        lines_printed += 1
+        print(" - Replace startup-script metadata (original will be backed up).")
+        lines_printed += 1
+        print(" - Start the VM and attach original disk as secondary for repair.")
         lines_printed += 1
 
         # Show Local SSD warning if applicable
@@ -1059,11 +1340,16 @@ def handle_restore(args: argparse.Namespace) -> int:
         lines_printed += 1
         print(f" - Stop instance [{args.instance_name}].")
         lines_printed += 1
-        print(" - Delete the rescue disk.")
+        print(" - Detach rescue disk and re-attach original disk as boot.")
         lines_printed += 1
-        print(" - Restore your affected boot disk as the primary boot device.")
+        print(" - Restore original metadata (startup-script, etc.).")
         lines_printed += 1
         print(f" - Start instance [{args.instance_name}].")
+        lines_printed += 1
+        if hasattr(args, 'keep_rescue_disk') and args.keep_rescue_disk:
+            print(" - Keep rescue disk for post-mortem analysis.")
+        else:
+            print(" - Delete the rescue disk.")
         lines_printed += 1
         print("")
         lines_printed += 1
@@ -1150,23 +1436,79 @@ def handle_diagnose(args: argparse.Namespace) -> int:
     )
     logger = logging.getLogger(__name__)
 
-    # Pre-flight validation: credentials + permissions + VM exists
+    # Pre-flight validation: credentials + permissions + VM state
     runner = ValidationRunner()
     runner.add(CredentialsValidator(compute, project, args.zone))
     runner.add(DiagnosePermissionsValidator(
         compute, project, args.zone, args.instance_name,
         tracking_label='diagnose-val-iam'
     ))
+
+    spinner = _Spinner("Checking VM state")
+    if not debug:
+        spinner.start()
     results = runner.run_all(logger)
+
+    # Also fetch VM info for state/rescue/OS checks under the same spinner
+    vm = None
+    try:
+        vm = compute.instances().get(
+            project=project, zone=args.zone, instance=args.instance_name
+        ).execute()
+    except Exception as e:
+        logger.debug(f"Could not fetch VM info: {e}")
+        # VM existence validated during diagnose execution
+
+    if not debug:
+        spinner.stop()
 
     if not results.all_passed():
         results.print_failures()
         return 1
 
+    # Pre-flight checks on VM (rescue mode first, then state, then OS)
+    if vm:
+        # Rescue mode check first — always suggest restoring
+        metadata_items = vm.get('metadata', {}).get('items', [])
+        if any(item.get('key') == 'rescue-mode' for item in metadata_items):
+            print(f"{error_prefix()} Instance [{args.instance_name}] is in rescue mode.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("Serial console shows the rescue environment, not original boot errors.", file=sys.stderr)
+            print("Restore the VM first, then run diagnose:", file=sys.stderr)
+            print(f"  $ gce-rescue-v2 restore {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            return 1
+
+        # Must be RUNNING (serial console has no logs when terminated)
+        vm_status = vm.get('status', 'UNKNOWN')
+        if vm_status != 'RUNNING':
+            print(f"{error_prefix()} Instance [{args.instance_name}] is {vm_status}.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("Diagnose requires serial console output from a running VM.", file=sys.stderr)
+            if vm_status == 'TERMINATED':
+                print("Start the VM first:", file=sys.stderr)
+                print(f"  $ gcloud compute instances start {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            return 1
+
+        # Linux only
+        from .utils.os_detection import detect_os_type
+        os_type = detect_os_type(vm)
+        if os_type == 'windows':
+            print(f"{error_prefix()} Diagnose is only supported for Linux VMs.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("For Windows VMs, use rescue mode for manual investigation:", file=sys.stderr)
+            print(f"  $ gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            return 1
+
     # Create and execute diagnose operation
     try:
         diagnose_op = DiagnoseOperation(compute, project, args.zone, logger)
-        result = diagnose_op.execute(args.instance_name)
+
+        spinner = _Spinner("Analyzing serial console output")
+        if not debug:
+            spinner.start()
+        result = diagnose_op.execute(args.instance_name, tracking_label='diagnose')
+        if not debug:
+            spinner.stop()
 
         if not result.success:
             # Operation failed (e.g., serial console disabled)
@@ -1184,7 +1526,7 @@ def handle_diagnose(args: argparse.Namespace) -> int:
         diagnosis = result.rollback_data
 
         # If format is json/yaml, use structured output
-        if args.format in ('json', 'yaml', 'table', 'value'):
+        if args.format in ('json', 'yaml', 'table'):
             print(OutputFormatter.format_output(diagnosis, args.format))
             return 0
 
@@ -1198,6 +1540,376 @@ def handle_diagnose(args: argparse.Namespace) -> int:
         logger.error(f"Unexpected error during diagnosis: {e}", exc_info=debug)
         print(f"{error_prefix()} Unexpected error: {e}", file=sys.stderr)
         return 1
+
+
+def _show_repair_results(result: Dict[str, Any], vm_name: str,
+                         zone: str = '', project: str = '') -> int:
+    """Display repair results and return exit code."""
+    status = result.get('status', 'unknown')
+    fix_lines = result.get('fix_lines', [])
+    fixed_count = result.get('fixed_count', 0)
+    error = result.get('error')
+    snapshot_name = result.get('snapshot_name')
+    duration = result.get('duration_seconds', 0)
+
+    duration_str = _format_duration(duration) if duration else ''
+
+    if status == 'success':
+        print("")
+        print("Repair results:")
+        for line in fix_lines:
+            print(f"  {line}")
+        issue_word = "issue" if fixed_count == 1 else "issues"
+        print(f"  {fixed_count} {issue_word} fixed.")
+        if any('fstab' in line.lower() for line in fix_lines):
+            print(f"  Original fstab backed up to: /etc/fstab.gce-repair-backup")
+        if snapshot_name:
+            print(f"  Backup snapshot: {snapshot_name}")
+        print("")
+        completion = f"Repair complete. Instance [{vm_name}] is now running."
+        if duration_str:
+            completion += f" ({duration_str})"
+        print(completion)
+        return 0
+
+    elif status == 'no_issues':
+        print("")
+        print("Repair results:")
+        print("  No issues needed fixing (fstab entries were already valid).")
+        if snapshot_name:
+            print(f"  Backup snapshot: {snapshot_name}")
+        print("")
+        completion = f"Repair complete. Instance [{vm_name}] is now running."
+        if duration_str:
+            completion += f" ({duration_str})"
+        print(completion)
+        return 0
+
+    elif status == 'no_fix':
+        print("No automated fix available for the detected issues.")
+        return 0
+
+    elif status == 'failed':
+        print("", file=sys.stderr)
+        print(f"{warning_prefix()} Fix script reported a problem: {error}", file=sys.stderr)
+        if fix_lines:
+            print("Partial results:", file=sys.stderr)
+            for line in fix_lines:
+                print(f"  {line}", file=sys.stderr)
+            if any('fstab' in line.lower() for line in fix_lines):
+                print(f"  Original fstab backed up to: /etc/fstab.gce-repair-backup", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(f"Instance [{vm_name}] has been restored and is running.", file=sys.stderr)
+        if snapshot_name:
+            print(f"Backup snapshot: {snapshot_name}", file=sys.stderr)
+            print("To revert to the pre-repair state:", file=sys.stderr)
+            print(f"  https://console.cloud.google.com/compute/snapshotsDetail"
+                  f"/projects/{project}/global/snapshots/{snapshot_name}",
+                  file=sys.stderr)
+        print("The issue may require manual intervention.", file=sys.stderr)
+        return 1
+
+    elif status == 'mount_failed':
+        print("", file=sys.stderr)
+        print(f"{error_prefix()} {error}", file=sys.stderr)
+        print("", file=sys.stderr)
+        if snapshot_name:
+            print(f"Backup snapshot: {snapshot_name}", file=sys.stderr)
+        print("VM is in rescue mode for manual investigation.", file=sys.stderr)
+        print("Connect via SSH and inspect the disk, then restore:", file=sys.stderr)
+        ssh_cmd = f"  $ gcloud compute ssh {vm_name} --zone={zone}"
+        if project:
+            ssh_cmd += f" --project={project}"
+        print(ssh_cmd, file=sys.stderr)
+        restore_cmd = f"  $ gce-rescue-v2 restore {vm_name}"
+        if zone:
+            restore_cmd += f" --zone={zone}"
+        if project:
+            restore_cmd += f" --project={project}"
+        print(restore_cmd, file=sys.stderr)
+        return 1
+
+    elif status == 'rescue_failed':
+        print("", file=sys.stderr)
+        print(f"{error_prefix()} {error}", file=sys.stderr)
+        if snapshot_name:
+            print(f"Backup snapshot: {snapshot_name}", file=sys.stderr)
+        return 1
+
+    elif status == 'restore_failed':
+        print("", file=sys.stderr)
+        print(f"{error_prefix()} Restore failed after repair.", file=sys.stderr)
+        if fix_lines:
+            print("Repair did complete:", file=sys.stderr)
+            for line in fix_lines:
+                print(f"  {line}", file=sys.stderr)
+        print("", file=sys.stderr)
+        if snapshot_name:
+            print(f"Backup snapshot: {snapshot_name}", file=sys.stderr)
+        print("VM may still be in rescue mode. Try restoring manually:", file=sys.stderr)
+        restore_cmd = f"  $ gce-rescue-v2 restore {vm_name}"
+        if zone:
+            restore_cmd += f" --zone={zone}"
+        if project:
+            restore_cmd += f" --project={project}"
+        print(restore_cmd, file=sys.stderr)
+        return 1
+
+    else:
+        print(f"\n{error_prefix()} Unexpected result: {status}", file=sys.stderr)
+        if error:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+
+def handle_repair(args: argparse.Namespace) -> int:
+    """Handle repair command."""
+    from .core.auth import AuthManager
+
+    # Get project from args or gcloud config
+    project = args.project or get_gcloud_config('core/project')
+
+    if not project:
+        print(f"{error_prefix()} No project specified.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Please specify a project using one of these methods:", file=sys.stderr)
+        print("  1. --project=PROJECT_ID flag", file=sys.stderr)
+        print("  2. gcloud config set project PROJECT_ID", file=sys.stderr)
+        print("  3. Set CLOUDSDK_CORE_PROJECT environment variable", file=sys.stderr)
+        return 1
+
+    # Get compute client
+    try:
+        auth = AuthManager()
+        compute, project = auth.get_client(project)
+    except Exception as e:
+        print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
+        return 1
+
+    # Setup logging
+    import logging
+    debug = args.verbosity == 'debug'
+    log_level = logging.DEBUG if debug else logging.WARNING
+    logging.basicConfig(level=log_level, format='%(levelname)s: %(message)s')
+    logger = logging.getLogger(__name__)
+    logger.console_level = log_level
+
+    # Create repair orchestrator
+    from .orchestration.repair import RepairOrchestrator, SUPPORTED_FIX_CATEGORIES
+    config = args_to_rescue_config(args)
+
+    orchestrator = RepairOrchestrator(
+        compute=compute, project=project, zone=args.zone,
+        vm_name=args.instance_name, config=config, logger=logger
+    )
+
+    # Pre-flight: check VM state (rescue mode, running, etc.)
+    spinner = _Spinner("Checking VM state")
+    if not debug:
+        spinner.start()
+    try:
+        vm = compute.instances().get(
+            project=project, zone=args.zone, instance=args.instance_name
+        ).execute()
+    except Exception as e:
+        if not debug:
+            spinner.stop()
+        logger.debug(f"Could not fetch VM info: {e}")
+        vm = None
+
+    if not debug:
+        spinner.stop()
+
+    if vm:
+        vm_status = vm.get('status', 'UNKNOWN')
+        metadata_items = vm.get('metadata', {}).get('items', [])
+        in_rescue = any(item.get('key') == 'rescue-mode' for item in metadata_items)
+
+        # Check for incomplete rescue checkpoint (from interrupted repair)
+        if not in_rescue and not args.quiet:
+            checkpoint_mgr = CheckpointManager(
+                compute, project, args.zone, args.instance_name, logger
+            )
+            checkpoint = checkpoint_mgr.detect_incomplete(
+                operation_type='rescue'
+            )
+            if checkpoint:
+                print(f"\n{warning_prefix()} An incomplete rescue operation was "
+                      f"detected for instance [{args.instance_name}].")
+                print("")
+                print(f"  Started:    {checkpoint.started_at[:19].replace('T', ' ')} "
+                      f"({checkpoint.get_age_display()})")
+                print(f"  Progress:   {checkpoint.current_step} of "
+                      f"{checkpoint.total_steps} steps completed")
+                last_step = checkpoint.get_last_completed_operation() or "None"
+                print(f"  Last step:  {last_step}")
+                print("")
+                print("This must be resolved before repair can proceed.")
+                print("")
+                print("  [1] Rollback  Undo completed steps and restore original state")
+                print("  [2] Abort     Do nothing and exit")
+                print("")
+
+                while True:
+                    try:
+                        response = input("Enter your choice (1/2): ").strip()
+                        if response == '1':
+                            success = _handle_checkpoint_rollback(
+                                compute, project, args.zone,
+                                args.instance_name, checkpoint, logger
+                            )
+                            if success:
+                                print("")
+                                print("Run repair again to fix boot issues:")
+                                print(
+                                    f"  $ gce-rescue-v2 repair "
+                                    f"{args.instance_name} --zone={args.zone} "
+                                    f"--project={project}"
+                                )
+                            return 0 if success else 1
+                        elif response == '2':
+                            return 0
+                        else:
+                            print("Please enter 1 or 2.")
+                    except (KeyboardInterrupt, EOFError):
+                        print("\nAborted.")
+                        return 0
+
+        # If not in rescue mode, must be RUNNING
+        if not in_rescue and vm_status != 'RUNNING':
+            print(f"{error_prefix()} Instance [{args.instance_name}] is {vm_status}.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("Repair requires the VM to be running for serial console diagnosis.", file=sys.stderr)
+            if vm_status == 'TERMINATED':
+                print("Start the VM first:", file=sys.stderr)
+                print(f"  $ gcloud compute instances start {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            return 1
+
+        if in_rescue:
+            print(f"{warning_prefix()} Instance [{args.instance_name}] is in rescue mode "
+                  f"from a previous operation.")
+            print("")
+            print("  [1] Continue  Check repair results and restore the VM")
+            print("  [2] Abort     Do nothing and exit")
+            print("")
+
+            while True:
+                try:
+                    response = input("Enter your choice (1/2): ").strip()
+                    if response == '1':
+                        break
+                    elif response == '2':
+                        return 0
+                    else:
+                        print("Please enter 1 or 2.")
+                except (KeyboardInterrupt, EOFError):
+                    print("\nAborted.")
+                    return 0
+
+            print("")
+            result = orchestrator.resume()
+            return _show_repair_results(result, args.instance_name,
+                                        zone=args.zone, project=project)
+
+    # Validate (credentials, IAM, Shielded/Confidential, Linux-only)
+    spinner = _Spinner("Validating permissions")
+    if not debug:
+        spinner.start()
+    valid = orchestrator.validate()
+    if not debug:
+        spinner.stop()
+    if not valid:
+        return 1
+
+    # Diagnose
+    spinner = _Spinner("Analyzing serial console output")
+    if not debug:
+        spinner.start()
+    diagnosis = orchestrator.diagnose()
+    if not debug:
+        spinner.stop()
+    if diagnosis is None:
+        return 1
+
+    # Show diagnosis report (skip manual fix steps since repair plan follows)
+    formatter = DiagnosisReportFormatter()
+    print(formatter.format_report(diagnosis, skip_fix_section=True))
+    print("")
+
+    # Check if there are any boot errors
+    boot_errors = diagnosis.get('boot_errors', [])
+    if not boot_errors:
+        print("No boot issues found. Repair not needed.")
+        return 0
+
+    # Check if any errors are fixable
+    fixable = orchestrator.get_fixable_categories(diagnosis)
+    unfixable = orchestrator.get_unfixable_categories(diagnosis)
+
+    if not fixable:
+        for cat in unfixable:
+            print(
+                f"Detected [{cat.upper()}] issue but automated fix is not yet available."
+            )
+        print("")
+        print("Use rescue mode for manual repair:")
+        print(
+            f"  $ gce-rescue-v2 rescue {args.instance_name} "
+            f"--zone={args.zone} --project={project}"
+        )
+        return 0
+
+    # Show unfixable categories as warnings
+    if unfixable:
+        for cat in unfixable:
+            print(
+                f"{warning_prefix()} [{cat.upper()}] issue detected but "
+                f"no automated fix available. Will require manual repair."
+            )
+        print("")
+
+    # Show repair plan
+    snapshot_enabled = getattr(args, 'snapshot', True)
+    print("Repair plan:")
+    step = 1
+    if snapshot_enabled:
+        print(f"  {step}. Create backup snapshot of boot disk")
+        step += 1
+    print(f"  {step}. Enter rescue mode (stop VM, swap boot disk)")
+    step += 1
+    fix_descriptions = {
+        'fstab': 'Fix /etc/fstab (comment out invalid entries)',
+    }
+    for cat in fixable:
+        desc = fix_descriptions.get(cat, f'Fix {cat}')
+        print(f"  {step}. {desc}")
+        step += 1
+    print(f"  {step}. Restore original boot disk and start VM")
+    print("")
+
+    # Confirmation (unless --quiet)
+    if not args.quiet:
+        try:
+            safety_note = ""
+            if snapshot_enabled:
+                safety_note = " A backup snapshot will be created before any changes."
+            response = input(
+                f"This will stop the VM, apply fixes, and restart it.{safety_note} "
+                f"Proceed? [y/N]: "
+            ).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            return 0
+
+        if response not in ('y', 'yes'):
+            print("\nAborted by user.")
+            return 0
+        print("")
+
+    # Execute repair
+    result = orchestrator.execute(diagnosis)
+    return _show_repair_results(result, args.instance_name,
+                                zone=args.zone, project=project)
 
 
 def main():
@@ -1219,15 +1931,17 @@ def main():
             return handle_restore(args)
         elif args.command == 'diagnose':
             return handle_diagnose(args)
+        elif args.command == 'repair':
+            return handle_repair(args)
         else:
-            print(f"{error_prefix()} (gce-rescue) Unknown command: {args.command}", file=sys.stderr)
+            print(f"{error_prefix()} (gce-rescue-v2) Unknown command: {args.command}", file=sys.stderr)
             return 1
 
     except KeyboardInterrupt:
         print("\n\nOperation cancelled by user.", file=sys.stderr)
         return 130  # Standard exit code for SIGINT
     except Exception as e:
-        print(f"{error_prefix()} (gce-rescue) Unexpected error: {str(e)}", file=sys.stderr)
+        print(f"{error_prefix()} (gce-rescue-v2) Unexpected error: {str(e)}", file=sys.stderr)
         if '--verbosity=debug' in sys.argv or '--verbosity debug' in sys.argv:
             import traceback
             traceback.print_exc()

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -128,7 +128,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
                     lines.append("Available commands:")
                     lines.append("  rescue         Boot a VM into rescue mode")
                     lines.append("  restore        Restore a VM from rescue mode")
-                    lines.append("  diagnose-boot  Diagnose VM boot issues (read-only)")
+                    lines.append("  diagnose  Diagnose VM boot issues (read-only)")
                 else:
                     lines.append(f"{message}")
             else:
@@ -181,7 +181,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
                 "Commands:",
                 "  rescue         Boot a VM into rescue mode",
                 "  restore        Restore a VM from rescue mode",
-                "  diagnose-boot  Diagnose VM boot issues (read-only)",
+                "  diagnose  Diagnose VM boot issues (read-only)",
                 "",
                 "Examples:",
                 "  $ gce-rescue-v2 rescue my-vm --zone=us-central1-a",
@@ -243,7 +243,7 @@ EXAMPLES
         $ gce-rescue-v2 rescue my-vm --zone=us-central1-a --quiet
 
     Diagnose boot issues:
-        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a
+        $ gce-rescue-v2 diagnose my-vm --zone=us-central1-a
 
 SUPPORTED OS
     - Linux (auto-detected): Boots Debian 12 rescue environment
@@ -322,20 +322,20 @@ NOTES
 
     # DIAGNOSE-BOOT COMMAND
     diagnose_parser = subparsers.add_parser(
-        'diagnose-boot',
+        'diagnose',
         help='Diagnose VM boot issues (read-only)',
         description='Analyze VM serial console output to detect boot errors.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 EXAMPLES
     Diagnose a VM:
-        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a
+        $ gce-rescue-v2 diagnose my-vm --zone=us-central1-a
 
     Diagnose and output as JSON:
-        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a --format=json
+        $ gce-rescue-v2 diagnose my-vm --zone=us-central1-a --format=json
 
     Diagnose and output as YAML:
-        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a --format=yaml
+        $ gce-rescue-v2 diagnose my-vm --zone=us-central1-a --format=yaml
 
 NOTES
     This is a read-only operation that does not modify the VM.
@@ -1217,7 +1217,7 @@ def main():
             return handle_rescue(args)
         elif args.command == 'restore':
             return handle_restore(args)
-        elif args.command == 'diagnose-boot':
+        elif args.command == 'diagnose':
             return handle_diagnose(args)
         else:
             print(f"{error_prefix()} (gce-rescue) Unknown command: {args.command}", file=sys.stderr)

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -125,8 +125,9 @@ class CustomArgumentParser(argparse.ArgumentParser):
                     lines.append("Usage: gce-rescue-v2 COMMAND VM_NAME --zone=ZONE [OPTIONS]")
                     lines.append("")
                     lines.append("Available commands:")
-                    lines.append("  rescue   Boot a VM into rescue mode")
-                    lines.append("  restore  Restore a VM from rescue mode")
+                    lines.append("  rescue         Boot a VM into rescue mode")
+                    lines.append("  restore        Restore a VM from rescue mode")
+                    lines.append("  diagnose-boot  Diagnose VM boot issues (read-only)")
                 else:
                     lines.append(f"{message}")
             else:
@@ -177,8 +178,9 @@ class CustomArgumentParser(argparse.ArgumentParser):
                 "Usage: gce-rescue-v2 COMMAND VM_NAME --zone=ZONE [OPTIONS]",
                 "",
                 "Commands:",
-                "  rescue   Boot a VM into rescue mode",
-                "  restore  Restore a VM from rescue mode",
+                "  rescue         Boot a VM into rescue mode",
+                "  restore        Restore a VM from rescue mode",
+                "  diagnose-boot  Diagnose VM boot issues (read-only)",
                 "",
                 "Examples:",
                 "  $ gce-rescue-v2 rescue my-vm --zone=us-central1-a",
@@ -238,6 +240,9 @@ EXAMPLES
 
     Automation (no prompts):
         $ gce-rescue-v2 rescue my-vm --zone=us-central1-a --quiet
+
+    Diagnose boot issues:
+        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a
 
 SUPPORTED OS
     - Linux (auto-detected): Boots Debian 12 rescue environment
@@ -313,6 +318,31 @@ NOTES
 
     _add_common_args(restore_parser)
     _add_restore_args(restore_parser)
+
+    # DIAGNOSE-BOOT COMMAND
+    diagnose_parser = subparsers.add_parser(
+        'diagnose-boot',
+        help='Diagnose VM boot issues (read-only)',
+        description='Analyze VM serial console output to detect boot errors.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+EXAMPLES
+    Diagnose a VM:
+        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a
+
+    Diagnose and output as JSON:
+        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a --format=json
+
+    Diagnose and output as YAML:
+        $ gce-rescue-v2 diagnose-boot my-vm --zone=us-central1-a --format=yaml
+
+NOTES
+    This is a read-only operation that does not modify the VM.
+    It analyzes serial console output for common boot error patterns.
+        """
+    )
+
+    _add_common_args(diagnose_parser)
 
     return parser
 
@@ -1078,6 +1108,136 @@ def handle_restore(args: argparse.Namespace) -> int:
     return 0 if success else 1
 
 
+def handle_diagnose(args: argparse.Namespace) -> int:
+    """Handle diagnose command."""
+    from .core.auth import AuthManager
+    from .operations import DiagnoseOperation
+    import logging
+
+    # Get project from args or gcloud config
+    project = args.project or get_gcloud_config('core/project')
+
+    # Validate project is set
+    if not project:
+        print(f"{error_prefix()} No project specified.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Please specify a project using one of these methods:", file=sys.stderr)
+        print("  1. --project=PROJECT_ID flag", file=sys.stderr)
+        print("  2. gcloud config set project PROJECT_ID", file=sys.stderr)
+        print("  3. Set CLOUDSDK_CORE_PROJECT environment variable", file=sys.stderr)
+        return 1
+
+    # Get compute client for API calls
+    try:
+        auth = AuthManager()
+        compute, project = auth.get_client(project)
+    except Exception as e:
+        print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
+        return 1
+
+    # Setup logging
+    debug = args.verbosity == 'debug'
+    log_level = logging.DEBUG if debug else logging.WARNING
+    logging.basicConfig(
+        level=log_level,
+        format='%(levelname)s: %(message)s'
+    )
+    logger = logging.getLogger(__name__)
+
+    # Create and execute diagnose operation
+    try:
+        diagnose_op = DiagnoseOperation(compute, project, args.zone, logger)
+        result = diagnose_op.execute(args.instance_name)
+
+        if not result.success:
+            # Operation failed (e.g., serial console disabled)
+            print(f"{error_prefix()} {result.message}", file=sys.stderr)
+
+            # Print recommendations if available
+            if result.rollback_data and result.rollback_data.get('recommendations'):
+                print("", file=sys.stderr)
+                for rec in result.rollback_data['recommendations']:
+                    print(f"  {rec}", file=sys.stderr)
+
+            return 1
+
+        # Operation succeeded - format and print results
+        diagnosis = result.rollback_data
+
+        # If format is json/yaml, use structured output
+        if args.format in ('json', 'yaml', 'table', 'value'):
+            print(OutputFormatter.format_output(diagnosis, args.format))
+            return 0
+
+        # Otherwise, print human-readable output
+        print(f"\n{'='*70}")
+        print(f"DIAGNOSIS REPORT: {diagnosis['vm_name']}")
+        print(f"{'='*70}")
+        print(f"Zone:              {diagnosis['zone']}")
+        print(f"VM Status:         {diagnosis['status']}")
+        print(f"Diagnosis Status:  {diagnosis['diagnosis_status'].replace('_', ' ').title()}")
+        print(f"{'='*70}\n")
+
+        # Print boot errors if any
+        if diagnosis['boot_errors']:
+            print(f"BOOT ERRORS DETECTED ({len(diagnosis['boot_errors'])}):\n")
+            for i, error in enumerate(diagnosis['boot_errors'], 1):
+                print(f"{i}. [{error['category'].upper()}] {error['severity'].upper()}")
+                print(f"   Description: {error['description']}\n")
+
+                # Show context from serial console
+                if error.get('context_lines'):
+                    print(f"   Serial Console Context:")
+                    for line in error['context_lines']:
+                        if line.strip():
+                            print(f"     | {line}")
+                    print()
+
+                # Format fixes with actual VM name and zone
+                print(f"   Suggested Fixes:")
+                for fix in error['suggested_fixes']:
+                    # Replace placeholders with actual values
+                    fix = fix.replace('VM_NAME', diagnosis['vm_name'])
+                    fix = fix.replace('ZONE', diagnosis['zone'])
+                    print(f"     - {fix}")
+                print()
+        else:
+            print("No boot errors detected\n")
+
+        # Print recommendations
+        if diagnosis['recommendations']:
+            print(f"{'='*70}")
+            print("RECOMMENDATIONS:\n")
+            for rec in diagnosis['recommendations']:
+                print(f"  - {rec}")
+            print(f"{'='*70}\n")
+
+        # Add NEXT STEPS section if errors were found
+        if diagnosis['boot_errors']:
+            print(f"{'='*70}")
+            print("NEXT STEPS:\n")
+            print(f"1. Enter rescue mode to fix the issue:")
+            print(f"   gce-rescue rescue {diagnosis['vm_name']} --zone={diagnosis['zone']}\n")
+
+            # Provide category-specific guidance
+            categories = set(err['category'] for err in diagnosis['boot_errors'])
+            if 'fstab' in categories:
+                print(f"2. Once in rescue mode, fix /etc/fstab:")
+                print(f"   sudo nano /mnt/sysroot/etc/fstab")
+                print(f"   # Comment out or fix broken mount entries\n")
+
+            print(f"3. Restore the VM after fixing:")
+            print(f"   gce-rescue restore {diagnosis['vm_name']} --zone={diagnosis['zone']}")
+            print(f"{'='*70}\n")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Unexpected error during diagnosis: {e}", exc_info=debug)
+        print(f"{error_prefix()} Unexpected error: {e}", file=sys.stderr)
+        return 1
+
+
 def main():
     """Main CLI entry point (gcloud-compatible)."""
 
@@ -1095,6 +1255,8 @@ def main():
             return handle_rescue(args)
         elif args.command == 'restore':
             return handle_restore(args)
+        elif args.command == 'diagnose-boot':
+            return handle_diagnose(args)
         else:
             print(f"{error_prefix()} (gce-rescue) Unknown command: {args.command}", file=sys.stderr)
             return 1

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -21,6 +21,7 @@ from typing import Optional, Dict, Any
 from .core.config import RescueConfig, RestoreConfig, VERSION
 from .main import rescue_vm, restore_vm
 from .utils.colors import error_prefix, warning_prefix, clear_lines
+from .utils.report_formatter import DiagnosisReportFormatter
 from .orchestration.checkpoint import CheckpointManager, CheckpointData
 
 
@@ -1112,6 +1113,11 @@ def handle_diagnose(args: argparse.Namespace) -> int:
     """Handle diagnose command."""
     from .core.auth import AuthManager
     from .operations import DiagnoseOperation
+    from .validators import (
+        ValidationRunner,
+        CredentialsValidator,
+        DiagnosePermissionsValidator,
+    )
     import logging
 
     # Get project from args or gcloud config
@@ -1144,6 +1150,19 @@ def handle_diagnose(args: argparse.Namespace) -> int:
     )
     logger = logging.getLogger(__name__)
 
+    # Pre-flight validation: credentials + permissions + VM exists
+    runner = ValidationRunner()
+    runner.add(CredentialsValidator(compute, project, args.zone))
+    runner.add(DiagnosePermissionsValidator(
+        compute, project, args.zone, args.instance_name,
+        tracking_label='diagnose-val-iam'
+    ))
+    results = runner.run_all(logger)
+
+    if not results.all_passed():
+        results.print_failures()
+        return 1
+
     # Create and execute diagnose operation
     try:
         diagnose_op = DiagnoseOperation(compute, project, args.zone, logger)
@@ -1170,65 +1189,8 @@ def handle_diagnose(args: argparse.Namespace) -> int:
             return 0
 
         # Otherwise, print human-readable output
-        print(f"\n{'='*70}")
-        print(f"DIAGNOSIS REPORT: {diagnosis['vm_name']}")
-        print(f"{'='*70}")
-        print(f"Zone:              {diagnosis['zone']}")
-        print(f"VM Status:         {diagnosis['status']}")
-        print(f"Diagnosis Status:  {diagnosis['diagnosis_status'].replace('_', ' ').title()}")
-        print(f"{'='*70}\n")
-
-        # Print boot errors if any
-        if diagnosis['boot_errors']:
-            print(f"BOOT ERRORS DETECTED ({len(diagnosis['boot_errors'])}):\n")
-            for i, error in enumerate(diagnosis['boot_errors'], 1):
-                print(f"{i}. [{error['category'].upper()}] {error['severity'].upper()}")
-                print(f"   Description: {error['description']}\n")
-
-                # Show context from serial console
-                if error.get('context_lines'):
-                    print(f"   Serial Console Context:")
-                    for line in error['context_lines']:
-                        if line.strip():
-                            print(f"     | {line}")
-                    print()
-
-                # Format fixes with actual VM name and zone
-                print(f"   Suggested Fixes:")
-                for fix in error['suggested_fixes']:
-                    # Replace placeholders with actual values
-                    fix = fix.replace('VM_NAME', diagnosis['vm_name'])
-                    fix = fix.replace('ZONE', diagnosis['zone'])
-                    print(f"     - {fix}")
-                print()
-        else:
-            print("No boot errors detected\n")
-
-        # Print recommendations
-        if diagnosis['recommendations']:
-            print(f"{'='*70}")
-            print("RECOMMENDATIONS:\n")
-            for rec in diagnosis['recommendations']:
-                print(f"  - {rec}")
-            print(f"{'='*70}\n")
-
-        # Add NEXT STEPS section if errors were found
-        if diagnosis['boot_errors']:
-            print(f"{'='*70}")
-            print("NEXT STEPS:\n")
-            print(f"1. Enter rescue mode to fix the issue:")
-            print(f"   gce-rescue rescue {diagnosis['vm_name']} --zone={diagnosis['zone']}\n")
-
-            # Provide category-specific guidance
-            categories = set(err['category'] for err in diagnosis['boot_errors'])
-            if 'fstab' in categories:
-                print(f"2. Once in rescue mode, fix /etc/fstab:")
-                print(f"   sudo nano /mnt/sysroot/etc/fstab")
-                print(f"   # Comment out or fix broken mount entries\n")
-
-            print(f"3. Restore the VM after fixing:")
-            print(f"   gce-rescue restore {diagnosis['vm_name']} --zone={diagnosis['zone']}")
-            print(f"{'='*70}\n")
+        formatter = DiagnosisReportFormatter()
+        print(formatter.format_report(diagnosis))
 
         return 0
 

--- a/gce_rescue_v2/core/boot_patterns.py
+++ b/gce_rescue_v2/core/boot_patterns.py
@@ -277,6 +277,20 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                 logger.error(f"Invalid regex pattern: {regex_pattern} - {e}")
                 continue
 
+    # Deduplicate: remove generic emergency mode if a specific root cause
+    # was already detected in the same category (e.g., device timeout
+    # already explains why emergency mode was entered).
+    if len(detected_errors) > 1:
+        has_specific = any(
+            e.description != "System entered emergency mode due to boot failure"
+            for e in detected_errors
+        )
+        if has_specific:
+            detected_errors = [
+                e for e in detected_errors
+                if e.description != "System entered emergency mode due to boot failure"
+            ]
+
     # Determine diagnosis status and recommendations
     if detected_errors:
         diagnosis_status = "boot_errors_detected"

--- a/gce_rescue_v2/core/boot_patterns.py
+++ b/gce_rescue_v2/core/boot_patterns.py
@@ -277,18 +277,34 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                 logger.error(f"Invalid regex pattern: {regex_pattern} - {e}")
                 continue
 
-    # Deduplicate: remove generic emergency mode if a specific root cause
-    # was already detected in the same category (e.g., device timeout
-    # already explains why emergency mode was entered).
+    # Deduplicate with two tiers:
+    # Tier 1 (catch-all): emergency mode - remove if ANY other error exists
+    # Tier 2 (generic symptom): mount failed, dependency failed - remove
+    #         only if a specific root cause error exists
+    _CATCH_ALL = {
+        "System entered emergency mode due to boot failure",
+    }
+    _GENERIC_SYMPTOM = {
+        "Failed to mount filesystem listed in /etc/fstab",
+        "Mount point dependency failed (device not available)",
+    }
     if len(detected_errors) > 1:
-        has_specific = any(
-            e.description != "System entered emergency mode due to boot failure"
-            for e in detected_errors
+        has_non_catchall = any(
+            e.description not in _CATCH_ALL for e in detected_errors
         )
-        if has_specific:
+        if has_non_catchall:
             detected_errors = [
                 e for e in detected_errors
-                if e.description != "System entered emergency mode due to boot failure"
+                if e.description not in _CATCH_ALL
+            ]
+    if len(detected_errors) > 1:
+        has_root_cause = any(
+            e.description not in _GENERIC_SYMPTOM for e in detected_errors
+        )
+        if has_root_cause:
+            detected_errors = [
+                e for e in detected_errors
+                if e.description not in _GENERIC_SYMPTOM
             ]
 
     # Determine diagnosis status and recommendations

--- a/gce_rescue_v2/core/boot_patterns.py
+++ b/gce_rescue_v2/core/boot_patterns.py
@@ -1,0 +1,273 @@
+"""Boot error pattern library and analysis engine for VM diagnostics.
+
+This module provides pattern matching and analysis for common boot failures
+detected in VM serial console output.
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BootErrorPattern:
+    """Defines a pattern for detecting specific boot error types."""
+    name: str
+    category: str  # fstab, grub, kernel, filesystem
+    patterns: List[str]  # Regex patterns to match
+    severity: str  # critical, error, warning
+    description: str
+    suggested_fixes: List[str]
+
+
+@dataclass
+class BootError:
+    """Represents a detected boot error."""
+    category: str
+    severity: str
+    description: str
+    detected_pattern: str
+    suggested_fixes: List[str]
+    context_lines: List[str] = field(default_factory=list)  # Lines around the error
+
+    def format_fixes(self, vm_name: str, zone: str) -> List[str]:
+        """Format suggested fixes with actual VM name and zone."""
+        formatted = []
+        for fix in self.suggested_fixes:
+            fix = fix.replace("VM_NAME", vm_name)
+            fix = fix.replace("ZONE", zone)
+            formatted.append(fix)
+        return formatted
+
+
+@dataclass
+class DiagnosisResult:
+    """Complete diagnosis result for a VM."""
+    vm_name: str
+    zone: str
+    status: str  # VM status (RUNNING, TERMINATED, etc.)
+    diagnosis_status: str  # healthy, boot_errors_detected, unable_to_diagnose
+    boot_errors: List[BootError] = field(default_factory=list)
+    recommendations: List[str] = field(default_factory=list)
+
+
+# MVP: Focus on fstab errors only
+BOOT_ERROR_PATTERNS = [
+    BootErrorPattern(
+        name="fstab_uuid_not_found",
+        category="fstab",
+        patterns=[
+            r"UUID=[\w-]+ does not exist",
+            r"can't find UUID=[\w-]+",
+            r"Timed out waiting for device.*UUID=",
+        ],
+        severity="critical",
+        description="UUID specified in /etc/fstab cannot be found",
+        suggested_fixes=[
+            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
+            "Check /mnt/sysroot/etc/fstab for invalid UUID entries",
+            "Run 'blkid' to see available UUIDs",
+            "Comment out or fix the invalid UUID entry in fstab"
+        ]
+    ),
+    BootErrorPattern(
+        name="fstab_device_not_exist",
+        category="fstab",
+        patterns=[
+            r"special device .* does not exist",
+            r"mount: .*: special device .* does not exist",
+            r"Device .* does not exist",
+        ],
+        severity="critical",
+        description="Device specified in /etc/fstab does not exist",
+        suggested_fixes=[
+            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
+            "Check /mnt/sysroot/etc/fstab for invalid device paths",
+            "Verify disk attachments in GCP Console",
+            "Comment out or fix the invalid device entry in fstab"
+        ]
+    ),
+    BootErrorPattern(
+        name="fstab_mount_failed",
+        category="fstab",
+        patterns=[
+            r"Dependency failed for .*\.mount",
+            r"Failed to mount .*\.mount",
+            r"mount.*failed",
+            r"systemd.*Failed to mount",
+        ],
+        severity="critical",
+        description="Failed to mount filesystem listed in /etc/fstab",
+        suggested_fixes=[
+            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
+            "Check /mnt/sysroot/etc/fstab for mount errors",
+            "Verify filesystem type and mount options are correct",
+            "Check serial console for specific error messages"
+        ]
+    ),
+    BootErrorPattern(
+        name="fstab_emergency_mode",
+        category="fstab",
+        patterns=[
+            r"You are now being dropped into an emergency shell",
+            r"You are in emergency mode",
+            r"Welcome to emergency mode",
+            r"Entering emergency mode",
+        ],
+        severity="critical",
+        description="System entered emergency mode due to boot failure",
+        suggested_fixes=[
+            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
+            "Common cause: invalid /etc/fstab entries",
+            "Check /mnt/sysroot/etc/fstab for errors",
+            "Review serial console for error messages leading to emergency mode"
+        ]
+    ),
+    BootErrorPattern(
+        name="fstab_fsck_failed",
+        category="fstab",
+        patterns=[
+            r"fsck.*failed",
+            r"fsck exited with status code",
+            r"FILE SYSTEM CHECK FAILED",
+            r"UNEXPECTED INCONSISTENCY",
+        ],
+        severity="critical",
+        description="Filesystem check (fsck) failed on a mounted partition",
+        suggested_fixes=[
+            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
+            "Run filesystem check: fsck -y /dev/sdb1 (replace with actual device)",
+            "May need to run: e2fsck -y /dev/sdb1 for ext4 filesystems",
+            "If persistent, check disk health in GCP Console"
+        ]
+    ),
+]
+
+
+def _extract_context_lines(serial_output: str, match_text: str, context_lines: int = 3) -> List[str]:
+    """Extract lines around a matched pattern for context.
+
+    Args:
+        serial_output: Full serial console output
+        match_text: The matched text to find context for
+        context_lines: Number of lines before and after to include
+
+    Returns:
+        List of context lines (cleaned of ANSI codes)
+    """
+    # Split output into lines
+    lines = serial_output.split('\n')
+
+    # Find the line containing the match
+    match_line_idx = -1
+    for i, line in enumerate(lines):
+        if match_text in line:
+            match_line_idx = i
+            break
+
+    if match_line_idx == -1:
+        return [match_text]  # Fallback if we can't find it
+
+    # Extract context lines
+    start_idx = max(0, match_line_idx - context_lines)
+    end_idx = min(len(lines), match_line_idx + context_lines + 1)
+
+    context = lines[start_idx:end_idx]
+
+    # Clean ANSI escape codes
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    context = [ansi_escape.sub('', line).strip() for line in context if line.strip()]
+
+    return context[:7]  # Limit to 7 lines max
+
+
+def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status: str) -> DiagnosisResult:
+    """Analyze serial console output for boot errors.
+
+    Args:
+        serial_output: Raw serial console output from VM
+        vm_name: Name of the VM
+        zone: Zone where VM is located
+        vm_status: Current VM status (RUNNING, TERMINATED, etc.)
+
+    Returns:
+        DiagnosisResult with detected errors and recommendations
+    """
+    logger.debug(f"Analyzing serial output for {vm_name} (status: {vm_status})")
+
+    # Check if serial output is empty or too short
+    if not serial_output or len(serial_output.strip()) < 50:
+        logger.warning("Serial output is empty or too short")
+        return DiagnosisResult(
+            vm_name=vm_name,
+            zone=zone,
+            status=vm_status,
+            diagnosis_status="unable_to_diagnose",
+            recommendations=[
+                "Serial console output is empty or too short to analyze",
+                "VM may be newly created or serial console may be disabled",
+                "Try again after VM has had time to boot and generate logs"
+            ]
+        )
+
+    detected_errors: List[BootError] = []
+
+    # Check each pattern
+    for pattern_def in BOOT_ERROR_PATTERNS:
+        for regex_pattern in pattern_def.patterns:
+            try:
+                match = re.search(regex_pattern, serial_output, re.MULTILINE | re.IGNORECASE)
+                if match:
+                    logger.info(f"Detected pattern: {pattern_def.name} - {match.group(0)}")
+
+                    # Avoid duplicate errors for the same category
+                    if not any(err.category == pattern_def.category and err.description == pattern_def.description
+                              for err in detected_errors):
+                        # Extract context around the error
+                        context = _extract_context_lines(serial_output, match.group(0))
+
+                        detected_errors.append(BootError(
+                            category=pattern_def.category,
+                            severity=pattern_def.severity,
+                            description=pattern_def.description,
+                            detected_pattern=match.group(0),
+                            suggested_fixes=pattern_def.suggested_fixes,
+                            context_lines=context
+                        ))
+                    break  # Move to next pattern_def after first match
+            except re.error as e:
+                logger.error(f"Invalid regex pattern: {regex_pattern} - {e}")
+                continue
+
+    # Determine diagnosis status and recommendations
+    if detected_errors:
+        diagnosis_status = "boot_errors_detected"
+        recommendations = [
+            f"Found {len(detected_errors)} boot error(s) in serial console output",
+            f"Use 'gce-rescue rescue {vm_name} --zone={zone}' to enter rescue mode",
+            "Review the suggested fixes above for each detected error"
+        ]
+    else:
+        diagnosis_status = "healthy"
+        recommendations = [
+            "No boot errors detected in serial console output",
+            "VM appears to be booting normally"
+        ]
+
+        # Additional context based on VM status
+        if vm_status == "TERMINATED":
+            recommendations.append("Note: VM is currently stopped")
+        elif vm_status == "RUNNING":
+            recommendations.append("VM is currently running")
+
+    return DiagnosisResult(
+        vm_name=vm_name,
+        zone=zone,
+        status=vm_status,
+        diagnosis_status=diagnosis_status,
+        boot_errors=detected_errors,
+        recommendations=recommendations
+    )

--- a/gce_rescue_v2/core/boot_patterns.py
+++ b/gce_rescue_v2/core/boot_patterns.py
@@ -312,7 +312,7 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         diagnosis_status = "boot_errors_detected"
         recommendations = [
             f"Found {len(detected_errors)} boot error(s) in serial console output",
-            f"Use 'gce-rescue rescue {vm_name} --zone={zone}' to enter rescue mode",
+            f"Use 'gce-rescue-v2 rescue {vm_name} --zone={zone}' to enter rescue mode",
             "Review the suggested fixes above for each detected error"
         ]
     else:

--- a/gce_rescue_v2/core/boot_patterns.py
+++ b/gce_rescue_v2/core/boot_patterns.py
@@ -1,15 +1,21 @@
 """Boot error pattern library and analysis engine for VM diagnostics.
 
 This module provides pattern matching and analysis for common boot failures
-detected in VM serial console output.
+detected in VM serial console output. Patterns are loaded from YAML files
+in the patterns/ directory.
 """
 
 from dataclasses import dataclass, field
-from typing import List
+from pathlib import Path
+from typing import Dict, List, Tuple
 import re
 import logging
 
+import yaml
+
 logger = logging.getLogger(__name__)
+
+VALID_SEVERITIES = {'critical', 'error', 'warning'}
 
 
 @dataclass
@@ -32,6 +38,7 @@ class BootError:
     detected_pattern: str
     suggested_fixes: List[str]
     context_lines: List[str] = field(default_factory=list)  # Lines around the error
+    matched_line_index: int = -1  # Index of the matched line within context_lines
 
     def format_fixes(self, vm_name: str, zone: str) -> List[str]:
         """Format suggested fixes with actual VM name and zone."""
@@ -54,100 +61,109 @@ class DiagnosisResult:
     recommendations: List[str] = field(default_factory=list)
 
 
-# MVP: Focus on fstab errors only
-BOOT_ERROR_PATTERNS = [
-    BootErrorPattern(
-        name="fstab_uuid_not_found",
-        category="fstab",
-        patterns=[
-            r"UUID=[\w-]+ does not exist",
-            r"can't find UUID=[\w-]+",
-            r"Timed out waiting for device.*UUID=",
-        ],
-        severity="critical",
-        description="UUID specified in /etc/fstab cannot be found",
-        suggested_fixes=[
-            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
-            "Check /mnt/sysroot/etc/fstab for invalid UUID entries",
-            "Run 'blkid' to see available UUIDs",
-            "Comment out or fix the invalid UUID entry in fstab"
-        ]
-    ),
-    BootErrorPattern(
-        name="fstab_device_not_exist",
-        category="fstab",
-        patterns=[
-            r"special device .* does not exist",
-            r"mount: .*: special device .* does not exist",
-            r"Device .* does not exist",
-        ],
-        severity="critical",
-        description="Device specified in /etc/fstab does not exist",
-        suggested_fixes=[
-            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
-            "Check /mnt/sysroot/etc/fstab for invalid device paths",
-            "Verify disk attachments in GCP Console",
-            "Comment out or fix the invalid device entry in fstab"
-        ]
-    ),
-    BootErrorPattern(
-        name="fstab_mount_failed",
-        category="fstab",
-        patterns=[
-            r"Dependency failed for .*\.mount",
-            r"Failed to mount .*\.mount",
-            r"mount.*failed",
-            r"systemd.*Failed to mount",
-        ],
-        severity="critical",
-        description="Failed to mount filesystem listed in /etc/fstab",
-        suggested_fixes=[
-            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
-            "Check /mnt/sysroot/etc/fstab for mount errors",
-            "Verify filesystem type and mount options are correct",
-            "Check serial console for specific error messages"
-        ]
-    ),
-    BootErrorPattern(
-        name="fstab_emergency_mode",
-        category="fstab",
-        patterns=[
-            r"You are now being dropped into an emergency shell",
-            r"You are in emergency mode",
-            r"Welcome to emergency mode",
-            r"Entering emergency mode",
-        ],
-        severity="critical",
-        description="System entered emergency mode due to boot failure",
-        suggested_fixes=[
-            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
-            "Common cause: invalid /etc/fstab entries",
-            "Check /mnt/sysroot/etc/fstab for errors",
-            "Review serial console for error messages leading to emergency mode"
-        ]
-    ),
-    BootErrorPattern(
-        name="fstab_fsck_failed",
-        category="fstab",
-        patterns=[
-            r"fsck.*failed",
-            r"fsck exited with status code",
-            r"FILE SYSTEM CHECK FAILED",
-            r"UNEXPECTED INCONSISTENCY",
-        ],
-        severity="critical",
-        description="Filesystem check (fsck) failed on a mounted partition",
-        suggested_fixes=[
-            "Boot into rescue mode: gce-rescue rescue VM_NAME --zone=ZONE",
-            "Run filesystem check: fsck -y /dev/sdb1 (replace with actual device)",
-            "May need to run: e2fsck -y /dev/sdb1 for ext4 filesystems",
-            "If persistent, check disk health in GCP Console"
-        ]
-    ),
-]
+# Severity ordering for sorted display (lower = higher priority)
+SEVERITY_ORDER = {'critical': 0, 'error': 1, 'warning': 2}
 
 
-def _extract_context_lines(serial_output: str, match_text: str, context_lines: int = 3) -> List[str]:
+def _validate_pattern_file(data: dict, filename: str) -> None:
+    """Validate YAML structure and regex syntax at load time.
+
+    Args:
+        data: Parsed YAML data
+        filename: Name of the YAML file (for error messages)
+
+    Raises:
+        ValueError: If the YAML structure is invalid
+    """
+    required_top_level = ['category', 'fix_guidance', 'patterns']
+    for key in required_top_level:
+        if key not in data:
+            raise ValueError(f"{filename}: missing required field '{key}'")
+
+    if not isinstance(data['patterns'], list) or len(data['patterns']) == 0:
+        raise ValueError(f"{filename}: 'patterns' must be a non-empty list")
+
+    required_pattern_fields = ['name', 'severity', 'description', 'regex', 'fixes']
+    for i, pattern in enumerate(data['patterns']):
+        for pf in required_pattern_fields:
+            if pf not in pattern:
+                raise ValueError(
+                    f"{filename}: pattern #{i + 1} missing required field '{pf}'"
+                )
+
+        if pattern['severity'] not in VALID_SEVERITIES:
+            raise ValueError(
+                f"{filename}: pattern '{pattern['name']}' has invalid severity "
+                f"'{pattern['severity']}' (must be one of: {', '.join(sorted(VALID_SEVERITIES))})"
+            )
+
+        if not isinstance(pattern['regex'], list) or len(pattern['regex']) == 0:
+            raise ValueError(
+                f"{filename}: pattern '{pattern['name']}' must have at least one regex"
+            )
+
+        for regex in pattern['regex']:
+            try:
+                re.compile(regex)
+            except re.error as e:
+                raise ValueError(
+                    f"{filename}: pattern '{pattern['name']}' has invalid regex "
+                    f"'{regex}': {e}"
+                ) from e
+
+
+def _load_patterns_from_yaml(
+    patterns_dir: Path = None,
+) -> Tuple[List[BootErrorPattern], Dict[str, str]]:
+    """Load patterns from YAML files in the patterns/ directory.
+
+    Args:
+        patterns_dir: Directory containing YAML pattern files.
+            Defaults to the patterns/ directory next to this module.
+
+    Returns:
+        Tuple of (list of BootErrorPattern, dict of category -> fix_guidance)
+
+    Raises:
+        ValueError: If no YAML files found or validation fails
+    """
+    if patterns_dir is None:
+        patterns_dir = Path(__file__).parent / 'patterns'
+
+    yaml_files = sorted(patterns_dir.glob('*.yaml'))
+    if not yaml_files:
+        raise ValueError(f"No pattern YAML files found in {patterns_dir}")
+
+    all_patterns: List[BootErrorPattern] = []
+    fix_guidance: Dict[str, str] = {}
+
+    for yaml_file in yaml_files:
+        data = yaml.safe_load(yaml_file.read_text(encoding='utf-8'))
+        _validate_pattern_file(data, yaml_file.name)
+
+        category = data['category']
+        fix_guidance[category] = data['fix_guidance']
+
+        for p in data['patterns']:
+            all_patterns.append(BootErrorPattern(
+                name=p['name'],
+                category=category,
+                patterns=p['regex'],
+                severity=p['severity'],
+                description=p['description'],
+                suggested_fixes=p['fixes'],
+            ))
+
+    return all_patterns, fix_guidance
+
+
+# Load patterns at module level (fail fast if patterns are broken)
+BOOT_ERROR_PATTERNS, CATEGORY_FIX_GUIDANCE = _load_patterns_from_yaml()
+
+
+def _extract_context_lines(
+    serial_output: str, match_text: str, context_lines: int = 3
+) -> Tuple[List[str], int]:
     """Extract lines around a matched pattern for context.
 
     Args:
@@ -156,7 +172,7 @@ def _extract_context_lines(serial_output: str, match_text: str, context_lines: i
         context_lines: Number of lines before and after to include
 
     Returns:
-        List of context lines (cleaned of ANSI codes)
+        Tuple of (context lines cleaned of ANSI codes, index of matched line)
     """
     # Split output into lines
     lines = serial_output.split('\n')
@@ -169,19 +185,35 @@ def _extract_context_lines(serial_output: str, match_text: str, context_lines: i
             break
 
     if match_line_idx == -1:
-        return [match_text]  # Fallback if we can't find it
+        return [match_text], 0  # Fallback: single line, index 0
 
-    # Extract context lines
+    # Extract context window
     start_idx = max(0, match_line_idx - context_lines)
     end_idx = min(len(lines), match_line_idx + context_lines + 1)
 
-    context = lines[start_idx:end_idx]
+    # Track matched line's position relative to the window
+    relative_match_idx = match_line_idx - start_idx
 
-    # Clean ANSI escape codes
+    raw_context = lines[start_idx:end_idx]
+
+    # Clean ANSI escape codes, filter empty lines, track index shift
     ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-    context = [ansi_escape.sub('', line).strip() for line in context if line.strip()]
+    cleaned = []
+    final_match_idx = -1
+    for i, line in enumerate(raw_context):
+        if not line.strip():
+            continue
+        cleaned_line = ansi_escape.sub('', line).strip()
+        if i == relative_match_idx:
+            final_match_idx = len(cleaned)
+        cleaned.append(cleaned_line)
 
-    return context[:7]  # Limit to 7 lines max
+    # Cap at 7 lines
+    cleaned = cleaned[:7]
+    if final_match_idx >= 7:
+        final_match_idx = -1  # Matched line got truncated
+
+    return cleaned, final_match_idx
 
 
 def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status: str) -> DiagnosisResult:
@@ -227,7 +259,9 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                     if not any(err.category == pattern_def.category and err.description == pattern_def.description
                               for err in detected_errors):
                         # Extract context around the error
-                        context = _extract_context_lines(serial_output, match.group(0))
+                        context, match_idx = _extract_context_lines(
+                            serial_output, match.group(0)
+                        )
 
                         detected_errors.append(BootError(
                             category=pattern_def.category,
@@ -235,7 +269,8 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                             description=pattern_def.description,
                             detected_pattern=match.group(0),
                             suggested_fixes=pattern_def.suggested_fixes,
-                            context_lines=context
+                            context_lines=context,
+                            matched_line_index=match_idx
                         ))
                     break  # Move to next pattern_def after first match
             except re.error as e:

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -43,6 +43,10 @@ class RescueConfig:
     windows_rescue_image_project: str = 'windows-cloud'
     windows_rescue_disk_size_gb: int = 50  # Windows needs more space
 
+    # ARM64 Linux rescue image (auto-selected for ARM64/T2A VMs)
+    arm64_rescue_image_family: str = 'debian-12-arm64'
+    arm64_rescue_image_project: str = 'debian-cloud'
+
     # Snapshot settings (safety feature)
     create_snapshot: bool = True  # DEFAULT: Create snapshot for safety
     require_snapshot: bool = False  # Abort if snapshot creation fails

--- a/gce_rescue_v2/core/error_messages.py
+++ b/gce_rescue_v2/core/error_messages.py
@@ -137,7 +137,7 @@ VM_ALREADY_IN_RESCUE = ErrorSuggestion(
         "Or use --force to re-rescue (not recommended)",
     ],
     commands=[
-        "gce-rescue-v2 restore {vm_name} --zone={zone}",
+        "gce-rescue-v2 restore {vm_name} --zone={zone} --project={project}",
     ]
 )
 

--- a/gce_rescue_v2/core/patterns/README.md
+++ b/gce_rescue_v2/core/patterns/README.md
@@ -64,7 +64,7 @@ entry under `patterns:`.
 python -m pytest gce_rescue_v2/tests/test_pattern_loader.py -v
 
 # Test against a real VM
-python -m gce_rescue_v2.cli diagnose-boot VM_NAME --zone=ZONE --project=PROJECT
+python -m gce_rescue_v2.cli diagnose VM_NAME --zone=ZONE --project=PROJECT
 ```
 
 ## File Naming

--- a/gce_rescue_v2/core/patterns/README.md
+++ b/gce_rescue_v2/core/patterns/README.md
@@ -1,0 +1,73 @@
+# Boot Error Patterns
+
+Add new boot error patterns by creating or editing YAML files in this directory.
+
+## Quick Start
+
+To add patterns for a new category (e.g., kernel errors), create `kernel.yaml`:
+
+```yaml
+category: kernel
+fix_guidance: "Check kernel: ls /mnt/sysroot/boot/vmlinuz-*"
+
+patterns:
+  - name: kernel_panic
+    severity: critical
+    description: "Kernel panic - not syncing"
+    regex:
+      - 'Kernel panic - not syncing'
+    fixes:
+      - "Check if kernel exists: ls /mnt/sysroot/boot/vmlinuz-*"
+      - "Reinstall kernel from rescue mode"
+```
+
+To add a pattern to an existing category, edit the corresponding YAML file and add a new
+entry under `patterns:`.
+
+## YAML Schema
+
+### Top-level fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `category` | Yes | Category name (e.g., `fstab`, `grub`, `kernel`, `filesystem`, `initramfs`) |
+| `fix_guidance` | Yes | One-line summary shown in the consolidated fix section |
+| `patterns` | Yes | List of pattern definitions |
+
+### Pattern fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier (snake_case, prefixed with category) |
+| `severity` | Yes | One of: `critical`, `error`, `warning` |
+| `description` | Yes | Human-readable description of the error |
+| `regex` | Yes | List of regex patterns to match in serial console output |
+| `fixes` | Yes | List of suggested fix steps |
+
+### Severity levels
+
+- **critical** - VM cannot boot (e.g., missing root filesystem, kernel panic)
+- **error** - Boot is impaired (e.g., non-root mount failure)
+- **warning** - Potential issue detected (e.g., slow fsck)
+
+## Regex Tips
+
+- Patterns are matched with `re.MULTILINE | re.IGNORECASE`
+- Use `.*` for wildcards, `[\w-]+` for word characters with hyphens
+- Escape backslashes in YAML strings: use `\\w` in double-quoted strings, or `\w` in single-quoted strings
+- Test your regex against real serial console output before submitting
+
+## Testing a New Pattern
+
+```bash
+# Run the pattern loader tests to validate all YAML files
+python -m pytest gce_rescue_v2/tests/test_pattern_loader.py -v
+
+# Test against a real VM
+python -m gce_rescue_v2.cli diagnose-boot VM_NAME --zone=ZONE --project=PROJECT
+```
+
+## File Naming
+
+- One file per category: `fstab.yaml`, `grub.yaml`, `kernel.yaml`, etc.
+- Files are loaded alphabetically; order does not affect matching.

--- a/gce_rescue_v2/core/patterns/fstab.yaml
+++ b/gce_rescue_v2/core/patterns/fstab.yaml
@@ -1,0 +1,65 @@
+category: fstab
+fix_guidance: "Fix /etc/fstab: sudo nano /mnt/sysroot/etc/fstab"
+
+patterns:
+  - name: fstab_uuid_not_found
+    severity: critical
+    description: "UUID specified in /etc/fstab cannot be found"
+    regex:
+      - 'UUID=[\w-]+ does not exist'
+      - "can't find UUID=[\\w-]+"
+      - 'Timed out waiting for device.*UUID='
+    fixes:
+      - "Check /mnt/sysroot/etc/fstab for invalid UUID entries"
+      - "Run 'blkid' to see available UUIDs"
+      - "Comment out or fix the invalid UUID entry"
+
+  - name: fstab_device_not_exist
+    severity: critical
+    description: "Device specified in /etc/fstab does not exist"
+    regex:
+      - 'special device .* does not exist'
+      - 'mount: .*: special device .* does not exist'
+      - 'Device .* does not exist'
+    fixes:
+      - "Check /mnt/sysroot/etc/fstab for invalid device paths"
+      - "Verify disk attachments in GCP Console"
+      - "Comment out or fix the invalid device entry"
+
+  - name: fstab_mount_failed
+    severity: critical
+    description: "Failed to mount filesystem listed in /etc/fstab"
+    regex:
+      - 'Dependency failed for .*\.mount'
+      - 'Failed to mount .*\.mount'
+      - 'mount.*failed'
+      - 'systemd.*Failed to mount'
+    fixes:
+      - "Check /mnt/sysroot/etc/fstab for mount errors"
+      - "Verify filesystem type and mount options are correct"
+      - "Check serial console for specific error messages"
+
+  - name: fstab_emergency_mode
+    severity: critical
+    description: "System entered emergency mode due to boot failure"
+    regex:
+      - 'You are now being dropped into an emergency shell'
+      - 'You are in emergency mode'
+      - 'Welcome to emergency mode'
+      - 'Entering emergency mode'
+    fixes:
+      - "Check /mnt/sysroot/etc/fstab for errors"
+      - "Review serial console for preceding error messages"
+
+  - name: fstab_fsck_failed
+    severity: critical
+    description: "Filesystem check (fsck) failed on a mounted partition"
+    regex:
+      - 'fsck.*failed'
+      - 'fsck exited with status code'
+      - 'FILE SYSTEM CHECK FAILED'
+      - 'UNEXPECTED INCONSISTENCY'
+    fixes:
+      - "Run filesystem check: fsck -y /dev/sdb1 (replace with actual device)"
+      - "May need to run: e2fsck -y /dev/sdb1 for ext4 filesystems"
+      - "If persistent, check disk health in GCP Console"

--- a/gce_rescue_v2/core/patterns/fstab.yaml
+++ b/gce_rescue_v2/core/patterns/fstab.yaml
@@ -1,5 +1,5 @@
 category: fstab
-fix_guidance: "Fix /etc/fstab: sudo nano /mnt/sysroot/etc/fstab"
+fix_guidance: "sudo nano /mnt/sysroot/etc/fstab"
 
 patterns:
   - name: fstab_uuid_not_found

--- a/gce_rescue_v2/core/patterns/fstab.yaml
+++ b/gce_rescue_v2/core/patterns/fstab.yaml
@@ -9,6 +9,7 @@ patterns:
       - 'UUID=[\w-]+ does not exist'
       - "can't find UUID=[\\w-]+"
       - 'Timed out waiting for device.*UUID='
+      - 'Expecting device.*/dev/disk/by-uuid/'
     fixes:
       - "Check /mnt/sysroot/etc/fstab for invalid UUID entries"
       - "Run 'blkid' to see available UUIDs"

--- a/gce_rescue_v2/core/patterns/fstab.yaml
+++ b/gce_rescue_v2/core/patterns/fstab.yaml
@@ -14,6 +14,16 @@ patterns:
       - "Run 'blkid' to see available UUIDs"
       - "Comment out or fix the invalid UUID entry"
 
+  - name: fstab_device_timeout
+    severity: critical
+    description: "Device referenced in /etc/fstab timed out waiting"
+    regex:
+      - 'Timed out waiting for device.*/dev/'
+    fixes:
+      - "Check /mnt/sysroot/etc/fstab for missing or invalid devices"
+      - "Verify disk is attached: gcloud compute instances describe VM_NAME --zone=ZONE"
+      - "Comment out or fix the invalid entry in /etc/fstab"
+
   - name: fstab_device_not_exist
     severity: critical
     description: "Device specified in /etc/fstab does not exist"
@@ -38,6 +48,17 @@ patterns:
       - "Check /mnt/sysroot/etc/fstab for mount errors"
       - "Verify filesystem type and mount options are correct"
       - "Check serial console for specific error messages"
+
+  - name: fstab_dependency_failed
+    severity: critical
+    description: "Mount point dependency failed (device not available)"
+    regex:
+      - 'Dependency failed for /[a-zA-Z]'
+      - 'Dependency failed for File System Check'
+    fixes:
+      - "Check /mnt/sysroot/etc/fstab for entries referencing missing devices"
+      - "Run 'blkid' to list available devices and UUIDs"
+      - "Comment out or fix the problematic entry"
 
   - name: fstab_emergency_mode
     severity: critical

--- a/gce_rescue_v2/main.py
+++ b/gce_rescue_v2/main.py
@@ -20,7 +20,7 @@ from .core.config import RescueConfig, RestoreConfig, OS_TYPE_WINDOWS
 from .core.error_messages import get_error_suggestion
 from .utils.logger import setup_logging
 from .utils.colors import note_prefix
-from .orchestration import RescueOrchestrator, RestoreOrchestrator
+from .orchestration import RescueOrchestrator, RestoreOrchestrator, RepairOrchestrator
 
 
 def rescue_vm(vm_name: str, zone: str, project: str = None,
@@ -281,6 +281,24 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
             logger.error("Restore failed.")
             return False
 
+        # Look up safety snapshot from rescue phase
+        snapshot_name = None
+        if orchestrator.original_disk_name:
+            try:
+                snap_resp = compute.snapshots().list(
+                    project=project,
+                    filter=f'name:pre-rescue-{orchestrator.original_disk_name}-*'
+                ).execute()
+                snap_items = snap_resp.get('items', [])
+                if snap_items:
+                    snap_items.sort(
+                        key=lambda s: s.get('creationTimestamp', ''),
+                        reverse=True
+                    )
+                    snapshot_name = snap_items[0].get('name')
+            except Exception:
+                pass  # Non-critical, skip if lookup fails
+
         # Success! Show OS-appropriate instructions
         # Check metadata for OS type (stored during rescue)
         os_type = None
@@ -333,6 +351,11 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
             logger.info("  b. Using Google Cloud Console:")
             logger.info(f"     https://ssh.cloud.google.com/v2/ssh/projects/{project}/zones/{zone}/instances/{vm_name}?authuser=0&hl=en_US&useAdminProxy=true")
 
+        if snapshot_name:
+            logger.info(f"Safety snapshot still exists: {snapshot_name}")
+            logger.info(f"  Delete when no longer needed:")
+            logger.info(f"  $ gcloud compute snapshots delete {snapshot_name} --project={project}")
+
         logger.info("")
         return True
 
@@ -351,26 +374,122 @@ def restore_vm(vm_name: str, zone: str, project: str = None,
         return False
 
 
+def repair_vm(vm_name: str, zone: str, project: str = None,
+              config: RescueConfig = None, debug: bool = False,
+              log_file: str = None) -> bool:
+    """
+    Repair a VM (diagnose + rescue with fix + restore).
+
+    This will:
+    1. Diagnose boot issues via serial console
+    2. Enter rescue mode with embedded fix script
+    3. Fix detected issues (e.g., invalid fstab entries)
+    4. Restore VM to normal operation
+
+    Linux only. On failure during rescue/restore, automatic rollback applies.
+
+    Args:
+        vm_name: Name of VM to repair
+        zone: GCP zone (e.g., 'us-central1-a')
+        project: GCP project ID (optional, uses default if not provided)
+        config: Optional RescueConfig for advanced settings
+        debug: Enable debug logging (default: False)
+        log_file: Optional log file path
+
+    Returns:
+        True if repair succeeded, False if failed
+    """
+    # Setup logging
+    if not log_file:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_file = f"{vm_name}-repair-{timestamp}.log"
+    logger = setup_logging(
+        level='DEBUG' if debug else 'INFO',
+        log_file=log_file,
+        debug=debug
+    )
+
+    logger.debug(f"GCE Rescue V2 - Repair")
+    logger.debug(f"Log file: {log_file}")
+    logger.debug(
+        f"VM: {vm_name}, Zone: {zone}"
+        + (f", Project: {project}" if project else "")
+    )
+
+    try:
+        auth = AuthManager()
+        compute, project = auth.get_client(project)
+        logger.debug(f"Authenticated to project: {project}")
+
+        if config is None:
+            config = RescueConfig()
+
+        orchestrator = RepairOrchestrator(
+            compute=compute, project=project, zone=zone,
+            vm_name=vm_name, config=config, logger=logger,
+            log_file=log_file
+        )
+
+        if not orchestrator.validate():
+            logger.error("Validation failed.")
+            return False
+
+        diagnosis = orchestrator.diagnose()
+        if diagnosis is None:
+            logger.error("Diagnosis failed.")
+            return False
+
+        boot_errors = diagnosis.get('boot_errors', [])
+        if not boot_errors:
+            logger.info("No boot issues found. Repair not needed.")
+            return True
+
+        fixable = orchestrator.get_fixable_categories(diagnosis)
+        if not fixable:
+            logger.info("No automated fix available for detected issues.")
+            return False
+
+        result = orchestrator.execute(diagnosis)
+        return result.get('status') in ('success', 'no_issues')
+
+    except Exception as e:
+        error_msg = str(e)
+        suggestion = get_error_suggestion(error_msg)
+
+        if suggestion:
+            logger.error(
+                suggestion.format(vm_name=vm_name, zone=zone, project=project)
+            )
+        else:
+            logger.error(f"Unexpected error: {error_msg}")
+
+        if debug:
+            logger.exception("Full traceback:")
+        return False
+
+
 if __name__ == '__main__':
     # Quick test - you can run this file directly for testing
     import sys
-    
+
     if len(sys.argv) < 4:
-        print("Usage: python main.py <rescue|restore> <vm_name> <zone> [project]")
+        print("Usage: python main.py <rescue|restore|repair> <vm_name> <zone> [project]")
         print("Example: python main.py rescue my-vm us-central1-a my-project")
         sys.exit(1)
-    
+
     mode = sys.argv[1]
     vm_name = sys.argv[2]
     zone = sys.argv[3]
     project = sys.argv[4] if len(sys.argv) > 4 else None
-    
+
     if mode == 'rescue':
         success = rescue_vm(vm_name, zone, project, debug=True)
     elif mode == 'restore':
         success = restore_vm(vm_name, zone, project, debug=True)
+    elif mode == 'repair':
+        success = repair_vm(vm_name, zone, project, debug=True)
     else:
-        print(f"Unknown mode: {mode}. Use 'rescue' or 'restore'")
+        print(f"Unknown mode: {mode}. Use 'rescue', 'restore', or 'repair'")
         sys.exit(1)
-    
+
     sys.exit(0 if success else 1)

--- a/gce_rescue_v2/operations/__init__.py
+++ b/gce_rescue_v2/operations/__init__.py
@@ -41,6 +41,7 @@ from .set_metadata import SetMetadataOperation
 from .delete_disk import DeleteDiskOperation
 from .create_snapshot import CreateSnapshotOperation
 from .verify_startup import VerifyStartupOperation
+from .diagnose import DiagnoseOperation
 
 __all__ = [
     # Base classes
@@ -57,4 +58,5 @@ __all__ = [
     'DeleteDiskOperation',
     'CreateSnapshotOperation',
     'VerifyStartupOperation',
+    'DiagnoseOperation',
 ]

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -1,0 +1,200 @@
+"""Diagnose VM boot issues by analyzing serial console output.
+
+This operation is read-only and does not modify the VM in any way.
+"""
+
+from typing import Optional
+import logging
+
+from googleapiclient.errors import HttpError
+
+from ..core.boot_patterns import analyze_serial_output, DiagnosisResult
+from .base import BaseOperation, OperationResult, extract_error_message
+
+logger = logging.getLogger(__name__)
+
+
+class DiagnoseOperation(BaseOperation):
+    """Diagnose VM boot issues by analyzing serial console output."""
+
+    @property
+    def name(self) -> str:
+        """Return the operation name."""
+        return "Diagnose VM"
+
+    def execute(self, vm_name: str) -> OperationResult:
+        """Execute diagnosis by fetching and analyzing serial console output.
+
+        Args:
+            vm_name: Name of the VM to diagnose
+
+        Returns:
+            OperationResult with diagnosis data in rollback_data field
+        """
+        try:
+            self._log_info(f"Starting diagnosis for VM: {vm_name}")
+
+            # Get VM status
+            self._log_debug("Fetching VM instance details")
+            vm_instance = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=vm_name
+            ).execute()
+
+            vm_status = vm_instance.get('status', 'UNKNOWN')
+            self._log_info(f"VM status: {vm_status}")
+
+            # Fetch serial console output
+            self._log_debug("Fetching serial console output")
+            try:
+                serial_response = self.compute.instances().getSerialPortOutput(
+                    project=self.project,
+                    zone=self.zone,
+                    instance=vm_name,
+                    port=1
+                ).execute()
+
+                serial_output = serial_response.get('contents', '')
+                self._log_debug(f"Retrieved {len(serial_output)} bytes of serial output")
+
+            except HttpError as e:
+                error_msg = extract_error_message(e)
+                self._log_warning(f"Failed to fetch serial console: {error_msg}")
+
+                # Handle specific error cases
+                if e.resp.status == 403:
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message="Serial console is disabled for this VM",
+                        rollback_data={
+                            'vm_name': vm_name,
+                            'zone': self.zone,
+                            'status': vm_status,
+                            'diagnosis_status': 'unable_to_diagnose',
+                            'boot_errors': [],
+                            'recommendations': [
+                                "Serial console is disabled for this VM",
+                                "Enable it with: gcloud compute instances add-metadata VM_NAME --metadata serial-port-enable=TRUE",
+                                "Then wait a few minutes for logs to accumulate and try diagnosis again"
+                            ]
+                        }
+                    )
+                else:
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message=f"Failed to fetch serial console: {error_msg}",
+                        rollback_data={
+                            'vm_name': vm_name,
+                            'zone': self.zone,
+                            'status': vm_status,
+                            'diagnosis_status': 'unable_to_diagnose',
+                            'boot_errors': [],
+                            'recommendations': [
+                                f"Unable to fetch serial console output: {error_msg}",
+                                "Check VM permissions and try again"
+                            ]
+                        }
+                    )
+
+            # Analyze serial output
+            self._log_info("Analyzing serial console output for boot errors")
+            diagnosis: DiagnosisResult = analyze_serial_output(
+                serial_output=serial_output,
+                vm_name=vm_name,
+                zone=self.zone,
+                vm_status=vm_status
+            )
+
+            # Convert diagnosis to dict for rollback_data
+            diagnosis_dict = {
+                'vm_name': diagnosis.vm_name,
+                'zone': diagnosis.zone,
+                'status': diagnosis.status,
+                'diagnosis_status': diagnosis.diagnosis_status,
+                'boot_errors': [
+                    {
+                        'category': err.category,
+                        'severity': err.severity,
+                        'description': err.description,
+                        'detected_pattern': err.detected_pattern,
+                        'suggested_fixes': err.suggested_fixes,
+                        'context_lines': err.context_lines
+                    }
+                    for err in diagnosis.boot_errors
+                ],
+                'recommendations': diagnosis.recommendations
+            }
+
+            # Determine success based on diagnosis status
+            if diagnosis.diagnosis_status == "boot_errors_detected":
+                message = f"Found {len(diagnosis.boot_errors)} boot error(s)"
+                success = True  # Operation succeeded, even though errors were found
+            elif diagnosis.diagnosis_status == "healthy":
+                message = "No boot errors detected"
+                success = True
+            else:  # unable_to_diagnose
+                message = "Unable to complete diagnosis"
+                success = False
+
+            self._log_info(f"Diagnosis complete: {message}")
+
+            return OperationResult(
+                operation_name=self.name,
+                success=success,
+                message=message,
+                rollback_data=diagnosis_dict
+            )
+
+        except HttpError as e:
+            error_msg = extract_error_message(e)
+            self._log_error(f"HTTP error during diagnosis: {error_msg}")
+            return OperationResult(
+                operation_name=self.name,
+                success=False,
+                message=f"Failed to diagnose VM: {error_msg}",
+                rollback_data={
+                    'vm_name': vm_name,
+                    'zone': self.zone,
+                    'status': 'UNKNOWN',
+                    'diagnosis_status': 'unable_to_diagnose',
+                    'boot_errors': [],
+                    'recommendations': [
+                        f"Error: {error_msg}",
+                        "Check VM exists and you have necessary permissions"
+                    ]
+                }
+            )
+
+        except Exception as e:
+            self._log_error(f"Unexpected error during diagnosis: {e}")
+            return OperationResult(
+                operation_name=self.name,
+                success=False,
+                message=f"Unexpected error: {str(e)}",
+                rollback_data={
+                    'vm_name': vm_name,
+                    'zone': self.zone,
+                    'status': 'UNKNOWN',
+                    'diagnosis_status': 'unable_to_diagnose',
+                    'boot_errors': [],
+                    'recommendations': [
+                        f"Unexpected error occurred: {str(e)}",
+                        "Check logs for details"
+                    ]
+                }
+            )
+
+    def rollback(self, rollback_data: dict) -> bool:
+        """No rollback needed for read-only diagnosis operation.
+
+        Args:
+            rollback_data: Unused (diagnosis is read-only)
+
+        Returns:
+            Always returns True
+        """
+        self._log_debug("Diagnose operation is read-only, no rollback needed")
+        return True

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -64,10 +64,13 @@ class DiagnoseOperation(BaseOperation):
 
                 # Handle specific error cases
                 if e.resp.status == 403:
+                    # Pre-flight validation already checked IAM permissions,
+                    # so a 403 here means serial console access is disabled
+                    # at the project or VM level.
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
-                        message="Serial console is disabled for this VM",
+                        message="Serial console access is disabled",
                         rollback_data={
                             'vm_name': vm_name,
                             'zone': self.zone,
@@ -75,9 +78,12 @@ class DiagnoseOperation(BaseOperation):
                             'diagnosis_status': 'unable_to_diagnose',
                             'boot_errors': [],
                             'recommendations': [
-                                "Serial console is disabled for this VM",
-                                "Enable it with: gcloud compute instances add-metadata VM_NAME --metadata serial-port-enable=TRUE",
-                                "Then wait a few minutes for logs to accumulate and try diagnosis again"
+                                "Serial console access is disabled for this VM or project",
+                                "Enable on VM: gcloud compute instances add-metadata "
+                                f"{vm_name} --zone={self.zone} --metadata serial-port-enable=TRUE",
+                                "Enable on project: gcloud compute project-info add-metadata "
+                                "--metadata serial-port-enable=TRUE",
+                                "Then wait a few minutes for logs to accumulate and try again"
                             ]
                         }
                     )
@@ -121,7 +127,8 @@ class DiagnoseOperation(BaseOperation):
                         'description': err.description,
                         'detected_pattern': err.detected_pattern,
                         'suggested_fixes': err.suggested_fixes,
-                        'context_lines': err.context_lines
+                        'context_lines': err.context_lines,
+                        'matched_line_index': err.matched_line_index
                     }
                     for err in diagnosis.boot_errors
                 ],

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -157,7 +157,7 @@ class DiagnoseOperation(BaseOperation):
 
         except HttpError as e:
             error_msg = extract_error_message(e)
-            self._log_error(f"HTTP error during diagnosis: {error_msg}")
+            self._log_debug(f"HTTP error during diagnosis: {error_msg}")
 
             if e.resp.status == 403:
                 message = f"Permission denied on project '{self.project}'"

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -60,7 +60,7 @@ class DiagnoseOperation(BaseOperation):
 
             except HttpError as e:
                 error_msg = extract_error_message(e)
-                self._log_warning(f"Failed to fetch serial console: {error_msg}")
+                self._log_error(f"Failed to fetch serial console: {error_msg}")
 
                 # Handle specific error cases
                 if e.resp.status == 403:

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -6,9 +6,14 @@ This operation is read-only and does not modify the VM in any way.
 from typing import Optional
 import logging
 
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
 from googleapiclient.errors import HttpError
 
 from ..core.boot_patterns import analyze_serial_output, DiagnosisResult
+from ..core.config import VERSION
 from ..utils.os_detection import (
     detect_os_type, detect_os_flavor, detect_architecture, detect_license_type,
 )
@@ -25,17 +30,23 @@ class DiagnoseOperation(BaseOperation):
         """Return the operation name."""
         return "Diagnose VM"
 
-    def execute(self, vm_name: str) -> OperationResult:
+    def execute(self, vm_name: str, tracking_label: str = None) -> OperationResult:
         """Execute diagnosis by fetching and analyzing serial console output.
 
         Args:
             vm_name: Name of the VM to diagnose
+            tracking_label: Optional tracking label for usage analytics.
 
         Returns:
             OperationResult with diagnosis data in rollback_data field
         """
         try:
             self._log_info(f"Starting diagnosis for VM: {vm_name}")
+            if tracking_label:
+                self._log_debug(f"  Operation tracking: {tracking_label}")
+
+            # Use tracked client if tracking_label provided
+            compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
 
             # Get VM status and OS info (non-fatal if 403 - user may only
             # have serial console read permission on this project)
@@ -46,7 +57,7 @@ class DiagnoseOperation(BaseOperation):
             license_type = 'unknown'
             try:
                 self._log_debug("Fetching VM instance details")
-                vm_instance = self.compute.instances().get(
+                vm_instance = compute.instances().get(
                     project=self.project,
                     zone=self.zone,
                     instance=vm_name
@@ -86,7 +97,7 @@ class DiagnoseOperation(BaseOperation):
             # Fetch serial console output
             self._log_debug("Fetching serial console output")
             try:
-                serial_response = self.compute.instances().getSerialPortOutput(
+                serial_response = compute.instances().getSerialPortOutput(
                     project=self.project,
                     zone=self.zone,
                     instance=vm_name,
@@ -261,6 +272,31 @@ class DiagnoseOperation(BaseOperation):
                     ]
                 }
             )
+
+    def _create_tracked_client(self, tracking_label: str):
+        """Create a compute client with unique User-Agent for usage tracking.
+
+        Args:
+            tracking_label: Tracking label for the User-Agent header.
+
+        Returns:
+            Compute API client with custom User-Agent header
+        """
+        credentials = self.compute._http.credentials
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials, http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        return discovery.build(
+            'compute', 'v1', credentials=credentials,
+            cache_discovery=False, requestBuilder=_request_builder
+        )
 
     def rollback(self, rollback_data: dict) -> bool:
         """No rollback needed for read-only diagnosis operation.

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -158,20 +158,41 @@ class DiagnoseOperation(BaseOperation):
         except HttpError as e:
             error_msg = extract_error_message(e)
             self._log_error(f"HTTP error during diagnosis: {error_msg}")
+
+            if e.resp.status == 403:
+                message = f"Permission denied on project '{self.project}'"
+                recommendations = [
+                    "Required permission: compute.instances.get",
+                    "",
+                    "To check your current access:",
+                    "  gcloud auth list",
+                    "",
+                    "To request access, ask the project owner to grant:",
+                    "  roles/compute.viewer",
+                ]
+            elif e.resp.status == 404:
+                message = f"Instance '{vm_name}' not found in zone '{self.zone}'"
+                recommendations = [
+                    "Verify the instance name and zone are correct:",
+                    f"  gcloud compute instances list --project={self.project}",
+                ]
+            else:
+                message = f"Failed to diagnose VM: {error_msg}"
+                recommendations = [
+                    "Check VM exists and you have necessary permissions",
+                ]
+
             return OperationResult(
                 operation_name=self.name,
                 success=False,
-                message=f"Failed to diagnose VM: {error_msg}",
+                message=message,
                 rollback_data={
                     'vm_name': vm_name,
                     'zone': self.zone,
                     'status': 'UNKNOWN',
                     'diagnosis_status': 'unable_to_diagnose',
                     'boot_errors': [],
-                    'recommendations': [
-                        f"Error: {error_msg}",
-                        "Check VM exists and you have necessary permissions"
-                    ]
+                    'recommendations': recommendations
                 }
             )
 

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -22,111 +22,6 @@ class DiagnoseOperation(BaseOperation):
         """Return the operation name."""
         return "Diagnose VM"
 
-    def _get_vm_status(self, vm_name: str) -> str:
-        """Fetch VM status. Returns 'UNKNOWN' if permission denied.
-
-        Args:
-            vm_name: Name of the VM
-
-        Returns:
-            VM status string (e.g., 'RUNNING', 'TERMINATED', 'UNKNOWN')
-        """
-        try:
-            self._log_debug("Fetching VM instance details")
-            vm_instance = self.compute.instances().get(
-                project=self.project,
-                zone=self.zone,
-                instance=vm_name
-            ).execute()
-
-            vm_status = vm_instance.get('status', 'UNKNOWN')
-            self._log_info(f"VM status: {vm_status}")
-            return vm_status
-
-        except HttpError as e:
-            if e.resp.status == 403:
-                self._log_debug(
-                    "No compute.instances.get permission, "
-                    "continuing with serial console only"
-                )
-                return 'UNKNOWN'
-            # 404 and other errors should stop execution
-            raise
-
-    def _get_serial_output(self, vm_name: str, vm_status: str) -> OperationResult:
-        """Fetch serial console output.
-
-        Args:
-            vm_name: Name of the VM
-            vm_status: VM status (for error reporting)
-
-        Returns:
-            OperationResult on failure, None on success (serial_output set as side effect)
-
-        Raises:
-            Sets self._serial_output on success.
-        """
-        try:
-            self._log_debug("Fetching serial console output")
-            serial_response = self.compute.instances().getSerialPortOutput(
-                project=self.project,
-                zone=self.zone,
-                instance=vm_name,
-                port=1
-            ).execute()
-
-            self._serial_output = serial_response.get('contents', '')
-            self._log_debug(f"Retrieved {len(self._serial_output)} bytes of serial output")
-            return None  # Success
-
-        except HttpError as e:
-            error_msg = extract_error_message(e)
-
-            if e.resp.status == 403:
-                return OperationResult(
-                    operation_name=self.name,
-                    success=False,
-                    message="Serial console access is disabled or permission denied",
-                    rollback_data={
-                        'vm_name': vm_name,
-                        'zone': self.zone,
-                        'status': vm_status,
-                        'diagnosis_status': 'unable_to_diagnose',
-                        'boot_errors': [],
-                        'recommendations': [
-                            "Could not read serial console output.",
-                            "",
-                            "Possible causes:",
-                            "  1. Serial port access is disabled for this VM or project",
-                            "  2. Missing permission: compute.instances.getSerialPortOutput",
-                            "",
-                            "To enable serial console on the VM:",
-                            f"  gcloud compute instances add-metadata {vm_name} "
-                            f"--zone={self.zone} --metadata serial-port-enable=TRUE",
-                            "",
-                            "To enable serial console on the project:",
-                            "  gcloud compute project-info add-metadata "
-                            "--metadata serial-port-enable=TRUE",
-                        ]
-                    }
-                )
-            else:
-                return OperationResult(
-                    operation_name=self.name,
-                    success=False,
-                    message=f"Failed to fetch serial console: {error_msg}",
-                    rollback_data={
-                        'vm_name': vm_name,
-                        'zone': self.zone,
-                        'status': vm_status,
-                        'diagnosis_status': 'unable_to_diagnose',
-                        'boot_errors': [],
-                        'recommendations': [
-                            f"Unable to fetch serial console output: {error_msg}",
-                        ]
-                    }
-                )
-
     def execute(self, vm_name: str) -> OperationResult:
         """Execute diagnosis by fetching and analyzing serial console output.
 
@@ -139,19 +34,81 @@ class DiagnoseOperation(BaseOperation):
         try:
             self._log_info(f"Starting diagnosis for VM: {vm_name}")
 
-            # Step 1: Try to get VM status (non-fatal if 403)
-            vm_status = self._get_vm_status(vm_name)
+            # Get VM status
+            self._log_debug("Fetching VM instance details")
+            vm_instance = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=vm_name
+            ).execute()
 
-            # Step 2: Fetch serial console output (required)
-            self._serial_output = ''
-            error_result = self._get_serial_output(vm_name, vm_status)
-            if error_result is not None:
-                return error_result
+            vm_status = vm_instance.get('status', 'UNKNOWN')
+            self._log_info(f"VM status: {vm_status}")
 
-            # Step 3: Analyze serial output
+            # Fetch serial console output
+            self._log_debug("Fetching serial console output")
+            try:
+                serial_response = self.compute.instances().getSerialPortOutput(
+                    project=self.project,
+                    zone=self.zone,
+                    instance=vm_name,
+                    port=1
+                ).execute()
+
+                serial_output = serial_response.get('contents', '')
+                self._log_debug(f"Retrieved {len(serial_output)} bytes of serial output")
+
+            except HttpError as e:
+                error_msg = extract_error_message(e)
+                self._log_error(f"Failed to fetch serial console: {error_msg}")
+
+                # Handle specific error cases
+                if e.resp.status == 403:
+                    # Pre-flight validation already checked IAM permissions,
+                    # so a 403 here means serial console access is disabled
+                    # at the project or VM level.
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message="Serial console access is disabled",
+                        rollback_data={
+                            'vm_name': vm_name,
+                            'zone': self.zone,
+                            'status': vm_status,
+                            'diagnosis_status': 'unable_to_diagnose',
+                            'boot_errors': [],
+                            'recommendations': [
+                                "Serial console access is disabled for this VM or project",
+                                "Enable on VM: gcloud compute instances add-metadata "
+                                f"{vm_name} --zone={self.zone} --metadata serial-port-enable=TRUE",
+                                "Enable on project: gcloud compute project-info add-metadata "
+                                "--metadata serial-port-enable=TRUE",
+                                "Then wait a few minutes for logs to accumulate and try again"
+                            ]
+                        }
+                    )
+                else:
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message=f"Failed to fetch serial console: {error_msg}",
+                        rollback_data={
+                            'vm_name': vm_name,
+                            'zone': self.zone,
+                            'status': vm_status,
+                            'diagnosis_status': 'unable_to_diagnose',
+                            'boot_errors': [],
+                            'recommendations': [
+                                f"Unable to fetch serial console output: {error_msg}",
+                                "Check VM permissions and try again"
+                            ]
+                        }
+                    )
+
+            # Analyze serial output
             self._log_info("Analyzing serial console output for boot errors")
             diagnosis: DiagnosisResult = analyze_serial_output(
-                serial_output=self._serial_output,
+                serial_output=serial_output,
                 vm_name=vm_name,
                 zone=self.zone,
                 vm_status=vm_status
@@ -202,7 +159,18 @@ class DiagnoseOperation(BaseOperation):
             error_msg = extract_error_message(e)
             self._log_debug(f"HTTP error during diagnosis: {error_msg}")
 
-            if e.resp.status == 404:
+            if e.resp.status == 403:
+                message = f"Permission denied on project '{self.project}'"
+                recommendations = [
+                    "Required permission: compute.instances.get",
+                    "",
+                    "To check your current access:",
+                    "  gcloud auth list",
+                    "",
+                    "To request access, ask the project owner to grant:",
+                    "  roles/compute.viewer",
+                ]
+            elif e.resp.status == 404:
                 message = f"Instance '{vm_name}' not found in zone '{self.zone}'"
                 recommendations = [
                     "Verify the instance name and zone are correct:",

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -34,16 +34,26 @@ class DiagnoseOperation(BaseOperation):
         try:
             self._log_info(f"Starting diagnosis for VM: {vm_name}")
 
-            # Get VM status
-            self._log_debug("Fetching VM instance details")
-            vm_instance = self.compute.instances().get(
-                project=self.project,
-                zone=self.zone,
-                instance=vm_name
-            ).execute()
-
-            vm_status = vm_instance.get('status', 'UNKNOWN')
-            self._log_info(f"VM status: {vm_status}")
+            # Get VM status (non-fatal if 403 - user may only have
+            # serial console read permission on this project)
+            vm_status = 'UNKNOWN'
+            try:
+                self._log_debug("Fetching VM instance details")
+                vm_instance = self.compute.instances().get(
+                    project=self.project,
+                    zone=self.zone,
+                    instance=vm_name
+                ).execute()
+                vm_status = vm_instance.get('status', 'UNKNOWN')
+                self._log_info(f"VM status: {vm_status}")
+            except HttpError as e:
+                if e.resp.status == 403:
+                    self._log_debug(
+                        "No compute.instances.get permission, "
+                        "continuing with serial console only"
+                    )
+                else:
+                    raise
 
             # Fetch serial console output
             self._log_debug("Fetching serial console output")
@@ -159,18 +169,7 @@ class DiagnoseOperation(BaseOperation):
             error_msg = extract_error_message(e)
             self._log_debug(f"HTTP error during diagnosis: {error_msg}")
 
-            if e.resp.status == 403:
-                message = f"Permission denied on project '{self.project}'"
-                recommendations = [
-                    "Required permission: compute.instances.get",
-                    "",
-                    "To check your current access:",
-                    "  gcloud auth list",
-                    "",
-                    "To request access, ask the project owner to grant:",
-                    "  roles/compute.viewer",
-                ]
-            elif e.resp.status == 404:
+            if e.resp.status == 404:
                 message = f"Instance '{vm_name}' not found in zone '{self.zone}'"
                 recommendations = [
                     "Verify the instance name and zone are correct:",

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -9,6 +9,9 @@ import logging
 from googleapiclient.errors import HttpError
 
 from ..core.boot_patterns import analyze_serial_output, DiagnosisResult
+from ..utils.os_detection import (
+    detect_os_type, detect_os_flavor, detect_architecture, detect_license_type,
+)
 from .base import BaseOperation, OperationResult, extract_error_message
 
 logger = logging.getLogger(__name__)
@@ -34,9 +37,13 @@ class DiagnoseOperation(BaseOperation):
         try:
             self._log_info(f"Starting diagnosis for VM: {vm_name}")
 
-            # Get VM status (non-fatal if 403 - user may only have
-            # serial console read permission on this project)
+            # Get VM status and OS info (non-fatal if 403 - user may only
+            # have serial console read permission on this project)
             vm_status = 'UNKNOWN'
+            os_type = 'unknown'
+            os_flavor = 'unknown'
+            architecture = 'unknown'
+            license_type = 'unknown'
             try:
                 self._log_debug("Fetching VM instance details")
                 vm_instance = self.compute.instances().get(
@@ -46,6 +53,16 @@ class DiagnoseOperation(BaseOperation):
                 ).execute()
                 vm_status = vm_instance.get('status', 'UNKNOWN')
                 self._log_info(f"VM status: {vm_status}")
+
+                # Detect OS info
+                os_type = detect_os_type(vm_instance)
+                os_flavor = detect_os_flavor(vm_instance)
+                architecture = detect_architecture(vm_instance)
+                license_type = detect_license_type(vm_instance)
+                self._log_info(
+                    f"OS: {os_type}, flavor: {os_flavor}, "
+                    f"arch: {architecture}, license: {license_type}"
+                )
             except HttpError as e:
                 if e.resp.status == 403:
                     self._log_debug(
@@ -54,6 +71,17 @@ class DiagnoseOperation(BaseOperation):
                     )
                 else:
                     raise
+
+            # Status-aware warnings
+            if vm_status == 'SUSPENDED':
+                self._log_info(
+                    "VM is suspended, serial logs may not contain "
+                    "recent boot activity"
+                )
+            elif vm_status in ('STAGING', 'PROVISIONING'):
+                self._log_info(
+                    "VM is still starting, serial output may be incomplete"
+                )
 
             # Fetch serial console output
             self._log_debug("Fetching serial console output")
@@ -85,6 +113,10 @@ class DiagnoseOperation(BaseOperation):
                             'vm_name': vm_name,
                             'zone': self.zone,
                             'status': vm_status,
+                            'os_type': os_type,
+                            'os_flavor': os_flavor,
+                            'architecture': architecture,
+                            'license_type': license_type,
                             'diagnosis_status': 'unable_to_diagnose',
                             'boot_errors': [],
                             'recommendations': [
@@ -106,6 +138,10 @@ class DiagnoseOperation(BaseOperation):
                             'vm_name': vm_name,
                             'zone': self.zone,
                             'status': vm_status,
+                            'os_type': os_type,
+                            'os_flavor': os_flavor,
+                            'architecture': architecture,
+                            'license_type': license_type,
                             'diagnosis_status': 'unable_to_diagnose',
                             'boot_errors': [],
                             'recommendations': [
@@ -129,6 +165,10 @@ class DiagnoseOperation(BaseOperation):
                 'vm_name': diagnosis.vm_name,
                 'zone': diagnosis.zone,
                 'status': diagnosis.status,
+                'os_type': os_type,
+                'os_flavor': os_flavor,
+                'architecture': architecture,
+                'license_type': license_type,
                 'diagnosis_status': diagnosis.diagnosis_status,
                 'boot_errors': [
                     {
@@ -189,6 +229,10 @@ class DiagnoseOperation(BaseOperation):
                     'vm_name': vm_name,
                     'zone': self.zone,
                     'status': 'UNKNOWN',
+                    'os_type': 'unknown',
+                    'os_flavor': 'unknown',
+                    'architecture': 'unknown',
+                    'license_type': 'unknown',
                     'diagnosis_status': 'unable_to_diagnose',
                     'boot_errors': [],
                     'recommendations': recommendations
@@ -205,6 +249,10 @@ class DiagnoseOperation(BaseOperation):
                     'vm_name': vm_name,
                     'zone': self.zone,
                     'status': 'UNKNOWN',
+                    'os_type': 'unknown',
+                    'os_flavor': 'unknown',
+                    'architecture': 'unknown',
+                    'license_type': 'unknown',
                     'diagnosis_status': 'unable_to_diagnose',
                     'boot_errors': [],
                     'recommendations': [

--- a/gce_rescue_v2/operations/diagnose.py
+++ b/gce_rescue_v2/operations/diagnose.py
@@ -22,6 +22,111 @@ class DiagnoseOperation(BaseOperation):
         """Return the operation name."""
         return "Diagnose VM"
 
+    def _get_vm_status(self, vm_name: str) -> str:
+        """Fetch VM status. Returns 'UNKNOWN' if permission denied.
+
+        Args:
+            vm_name: Name of the VM
+
+        Returns:
+            VM status string (e.g., 'RUNNING', 'TERMINATED', 'UNKNOWN')
+        """
+        try:
+            self._log_debug("Fetching VM instance details")
+            vm_instance = self.compute.instances().get(
+                project=self.project,
+                zone=self.zone,
+                instance=vm_name
+            ).execute()
+
+            vm_status = vm_instance.get('status', 'UNKNOWN')
+            self._log_info(f"VM status: {vm_status}")
+            return vm_status
+
+        except HttpError as e:
+            if e.resp.status == 403:
+                self._log_debug(
+                    "No compute.instances.get permission, "
+                    "continuing with serial console only"
+                )
+                return 'UNKNOWN'
+            # 404 and other errors should stop execution
+            raise
+
+    def _get_serial_output(self, vm_name: str, vm_status: str) -> OperationResult:
+        """Fetch serial console output.
+
+        Args:
+            vm_name: Name of the VM
+            vm_status: VM status (for error reporting)
+
+        Returns:
+            OperationResult on failure, None on success (serial_output set as side effect)
+
+        Raises:
+            Sets self._serial_output on success.
+        """
+        try:
+            self._log_debug("Fetching serial console output")
+            serial_response = self.compute.instances().getSerialPortOutput(
+                project=self.project,
+                zone=self.zone,
+                instance=vm_name,
+                port=1
+            ).execute()
+
+            self._serial_output = serial_response.get('contents', '')
+            self._log_debug(f"Retrieved {len(self._serial_output)} bytes of serial output")
+            return None  # Success
+
+        except HttpError as e:
+            error_msg = extract_error_message(e)
+
+            if e.resp.status == 403:
+                return OperationResult(
+                    operation_name=self.name,
+                    success=False,
+                    message="Serial console access is disabled or permission denied",
+                    rollback_data={
+                        'vm_name': vm_name,
+                        'zone': self.zone,
+                        'status': vm_status,
+                        'diagnosis_status': 'unable_to_diagnose',
+                        'boot_errors': [],
+                        'recommendations': [
+                            "Could not read serial console output.",
+                            "",
+                            "Possible causes:",
+                            "  1. Serial port access is disabled for this VM or project",
+                            "  2. Missing permission: compute.instances.getSerialPortOutput",
+                            "",
+                            "To enable serial console on the VM:",
+                            f"  gcloud compute instances add-metadata {vm_name} "
+                            f"--zone={self.zone} --metadata serial-port-enable=TRUE",
+                            "",
+                            "To enable serial console on the project:",
+                            "  gcloud compute project-info add-metadata "
+                            "--metadata serial-port-enable=TRUE",
+                        ]
+                    }
+                )
+            else:
+                return OperationResult(
+                    operation_name=self.name,
+                    success=False,
+                    message=f"Failed to fetch serial console: {error_msg}",
+                    rollback_data={
+                        'vm_name': vm_name,
+                        'zone': self.zone,
+                        'status': vm_status,
+                        'diagnosis_status': 'unable_to_diagnose',
+                        'boot_errors': [],
+                        'recommendations': [
+                            f"Unable to fetch serial console output: {error_msg}",
+                        ]
+                    }
+                )
+
     def execute(self, vm_name: str) -> OperationResult:
         """Execute diagnosis by fetching and analyzing serial console output.
 
@@ -34,81 +139,19 @@ class DiagnoseOperation(BaseOperation):
         try:
             self._log_info(f"Starting diagnosis for VM: {vm_name}")
 
-            # Get VM status
-            self._log_debug("Fetching VM instance details")
-            vm_instance = self.compute.instances().get(
-                project=self.project,
-                zone=self.zone,
-                instance=vm_name
-            ).execute()
+            # Step 1: Try to get VM status (non-fatal if 403)
+            vm_status = self._get_vm_status(vm_name)
 
-            vm_status = vm_instance.get('status', 'UNKNOWN')
-            self._log_info(f"VM status: {vm_status}")
+            # Step 2: Fetch serial console output (required)
+            self._serial_output = ''
+            error_result = self._get_serial_output(vm_name, vm_status)
+            if error_result is not None:
+                return error_result
 
-            # Fetch serial console output
-            self._log_debug("Fetching serial console output")
-            try:
-                serial_response = self.compute.instances().getSerialPortOutput(
-                    project=self.project,
-                    zone=self.zone,
-                    instance=vm_name,
-                    port=1
-                ).execute()
-
-                serial_output = serial_response.get('contents', '')
-                self._log_debug(f"Retrieved {len(serial_output)} bytes of serial output")
-
-            except HttpError as e:
-                error_msg = extract_error_message(e)
-                self._log_error(f"Failed to fetch serial console: {error_msg}")
-
-                # Handle specific error cases
-                if e.resp.status == 403:
-                    # Pre-flight validation already checked IAM permissions,
-                    # so a 403 here means serial console access is disabled
-                    # at the project or VM level.
-                    return OperationResult(
-                        operation_name=self.name,
-                        success=False,
-                        message="Serial console access is disabled",
-                        rollback_data={
-                            'vm_name': vm_name,
-                            'zone': self.zone,
-                            'status': vm_status,
-                            'diagnosis_status': 'unable_to_diagnose',
-                            'boot_errors': [],
-                            'recommendations': [
-                                "Serial console access is disabled for this VM or project",
-                                "Enable on VM: gcloud compute instances add-metadata "
-                                f"{vm_name} --zone={self.zone} --metadata serial-port-enable=TRUE",
-                                "Enable on project: gcloud compute project-info add-metadata "
-                                "--metadata serial-port-enable=TRUE",
-                                "Then wait a few minutes for logs to accumulate and try again"
-                            ]
-                        }
-                    )
-                else:
-                    return OperationResult(
-                        operation_name=self.name,
-                        success=False,
-                        message=f"Failed to fetch serial console: {error_msg}",
-                        rollback_data={
-                            'vm_name': vm_name,
-                            'zone': self.zone,
-                            'status': vm_status,
-                            'diagnosis_status': 'unable_to_diagnose',
-                            'boot_errors': [],
-                            'recommendations': [
-                                f"Unable to fetch serial console output: {error_msg}",
-                                "Check VM permissions and try again"
-                            ]
-                        }
-                    )
-
-            # Analyze serial output
+            # Step 3: Analyze serial output
             self._log_info("Analyzing serial console output for boot errors")
             diagnosis: DiagnosisResult = analyze_serial_output(
-                serial_output=serial_output,
+                serial_output=self._serial_output,
                 vm_name=vm_name,
                 zone=self.zone,
                 vm_status=vm_status
@@ -159,18 +202,7 @@ class DiagnoseOperation(BaseOperation):
             error_msg = extract_error_message(e)
             self._log_debug(f"HTTP error during diagnosis: {error_msg}")
 
-            if e.resp.status == 403:
-                message = f"Permission denied on project '{self.project}'"
-                recommendations = [
-                    "Required permission: compute.instances.get",
-                    "",
-                    "To check your current access:",
-                    "  gcloud auth list",
-                    "",
-                    "To request access, ask the project owner to grant:",
-                    "  roles/compute.viewer",
-                ]
-            elif e.resp.status == 404:
+            if e.resp.status == 404:
                 message = f"Instance '{vm_name}' not found in zone '{self.zone}'"
                 recommendations = [
                     "Verify the instance name and zone are correct:",

--- a/gce_rescue_v2/orchestration/__init__.py
+++ b/gce_rescue_v2/orchestration/__init__.py
@@ -1,17 +1,19 @@
 """
 GCE Rescue - Orchestration Module
 
-Coordinates rescue and restore workflows.
+Coordinates rescue, restore, and repair workflows.
 """
 
 from .rescue import RescueOrchestrator
 from .restore import RestoreOrchestrator
+from .repair import RepairOrchestrator
 from .state import StateTracker, OperationState
 from .rollback import RollbackHandler
 
 __all__ = [
     'RescueOrchestrator',
     'RestoreOrchestrator',
+    'RepairOrchestrator',
     'StateTracker',
     'OperationState',
     'RollbackHandler'

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -1,0 +1,731 @@
+"""
+GCE Rescue - Repair Orchestrator
+
+Automates the full repair flow: diagnose -> rescue (with embedded fix) -> restore.
+Fix scripts are embedded directly in the startup script - no SSH, no external tools.
+
+Supported fix categories:
+    - fstab: Comments out invalid UUID/device/label entries
+
+Usage:
+    orchestrator = RepairOrchestrator(compute, project, zone, vm_name, config, logger)
+    orchestrator.validate()
+    diagnosis = orchestrator.diagnose()
+    orchestrator.execute(diagnosis)
+"""
+
+import sys
+import threading
+import time
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Set
+
+from googleapiclient import discovery
+import googleapiclient.http
+import google_auth_httplib2
+import httplib2
+
+from ..core.config import RescueConfig, RestoreConfig, VERSION
+from ..operations import DiagnoseOperation
+from .rescue import RescueOrchestrator
+from .restore import RestoreOrchestrator
+
+# Categories that have automated fix scripts
+SUPPORTED_FIX_CATEGORIES: Set[str] = {'fstab'}
+
+# Marker prefixes emitted by fix scripts to serial console
+REPAIR_LINE_MARKER = 'GCE-REPAIR-LINE:'
+REPAIR_RESULT_MARKER = 'GCE-REPAIR-RESULT:'
+
+# Completion marker used by rescue startup script
+RESCUE_COMPLETE_MARKER = 'GCE-RESCUE-COMPLETE'
+
+# Maps raw rescue/restore step labels to user-friendly display names
+RESCUE_SUBSTEP_LABELS = {
+    'Stopping': 'Stopping VM',
+    'Snapshotting': 'Creating snapshot',
+    'Creating rescue disk': 'Creating rescue disk',
+    'Starting': 'Starting rescue VM',
+    'Attaching affected disk': 'Mounting disk',
+}
+RESTORE_SUBSTEP_LABELS = {
+    'Stopping': 'Stopping VM',
+    'Restoring affected disk': 'Restoring boot disk',
+    'Starting': 'Starting VM',
+}
+
+
+class RepairOrchestrator:
+    """Orchestrates diagnose -> rescue (with fix) -> restore."""
+
+    def __init__(self, compute, project: str, zone: str, vm_name: str,
+                 config: RescueConfig = None, logger=None, log_file: str = None):
+        self.compute = compute
+        self.project = project
+        self.zone = zone
+        self.vm_name = vm_name
+        self.config = config or RescueConfig()
+        self.logger = logger
+        self.log_file = log_file
+
+        # Progress tracking
+        self._spinner_thread = None
+        self._spinner_stop = False
+        self._is_debug_mode = False
+        self._progress_started = False
+        self._progress_phases = []
+        self._progress_lock = threading.Lock()
+        self._total_steps = 3  # Rescue, Repair, Restore
+
+        # Substep tracking (updated by progress callbacks from sub-orchestrators)
+        self._current_phase = ''
+        self._current_substep = ''
+        self._current_line_substeps: List[str] = []
+
+    def _log_info(self, message: str):
+        if self.logger:
+            self.logger.info(message)
+
+    def _log_debug(self, message: str):
+        if self.logger:
+            self.logger.debug(f"[Repair] {message}", stacklevel=2)
+
+    def _log_error(self, message: str):
+        if self.logger:
+            self.logger.error(message)
+
+    def _create_tracked_client(self, tracking_label: str):
+        """Create a compute client with unique User-Agent for usage tracking."""
+        credentials = self.compute._http.credentials
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials, http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        return discovery.build(
+            'compute', 'v1', credentials=credentials,
+            cache_discovery=False, requestBuilder=_request_builder
+        )
+
+    def validate(self) -> bool:
+        """Run pre-flight validation (credentials, IAM, VM state) + Linux-only check."""
+        # Create a temporary rescue orchestrator to reuse its validation
+        rescue = RescueOrchestrator(
+            compute=self.compute, project=self.project, zone=self.zone,
+            vm_name=self.vm_name, config=self.config, logger=self.logger,
+            suppress_progress=True
+        )
+        if not rescue.validate():
+            return False
+
+        # Check Linux-only
+        from ..utils.os_detection import detect_os_type
+        compute = self._create_tracked_client('repair-val-os')
+        vm_info = compute.instances().get(
+            project=self.project, zone=self.zone, instance=self.vm_name
+        ).execute()
+        os_type = detect_os_type(vm_info)
+        if os_type == 'windows':
+            self._log_error("Repair is only supported for Linux VMs.")
+            self._log_error("")
+            self._log_error("For Windows VMs, use rescue mode for manual repair:")
+            self._log_error(
+                f"  $ gce-rescue-v2 rescue {self.vm_name} "
+                f"--zone={self.zone} --project={self.project}"
+            )
+            return False
+
+        self._log_debug("Validation passed")
+        return True
+
+    def diagnose(self) -> Optional[Dict[str, Any]]:
+        """Run diagnosis and return the diagnosis dict (or None on failure)."""
+        diagnose_op = DiagnoseOperation(
+            self.compute, self.project, self.zone, self.logger
+        )
+        result = diagnose_op.execute(self.vm_name, tracking_label='repair-diagnose')
+
+        if not result.success:
+            self._log_error(f"Diagnosis failed: {result.message}")
+            return None
+
+        return result.rollback_data
+
+    def get_fixable_categories(self, diagnosis: Dict[str, Any]) -> List[str]:
+        """Return list of categories from diagnosis that have fix scripts."""
+        categories = []
+        seen = set()
+        for err in diagnosis.get('boot_errors', []):
+            cat = err.get('category', '')
+            if cat in SUPPORTED_FIX_CATEGORIES and cat not in seen:
+                seen.add(cat)
+                categories.append(cat)
+        return categories
+
+    def get_unfixable_categories(self, diagnosis: Dict[str, Any]) -> List[str]:
+        """Return list of categories from diagnosis that lack fix scripts."""
+        categories = []
+        seen = set()
+        for err in diagnosis.get('boot_errors', []):
+            cat = err.get('category', '')
+            if cat not in SUPPORTED_FIX_CATEGORIES and cat not in seen:
+                seen.add(cat)
+                categories.append(cat)
+        return categories
+
+    def execute(self, diagnosis: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the full repair: rescue (with fix script) -> parse results -> restore.
+
+        Args:
+            diagnosis: Diagnosis dict from diagnose()
+
+        Returns:
+            Dict with keys: status, fixed_count, fix_lines, error,
+            snapshot_name, duration_seconds
+        """
+        fixable = self.get_fixable_categories(diagnosis)
+        if not fixable:
+            return {'status': 'no_fix', 'fixed_count': 0, 'fix_lines': [],
+                    'error': None, 'snapshot_name': None, 'duration_seconds': 0}
+
+        # Generate repair startup script
+        repair_script = self._generate_repair_script(diagnosis)
+        self._log_debug(f"Generated repair script ({len(repair_script)} bytes)")
+
+        # Initialize progress display
+        self._init_progress()
+        start_time = time.time()
+
+        try:
+            # Phase 1: Rescue with embedded fix script
+            self._update_progress("Rescue")
+            rescue_config = RescueConfig()
+            rescue_config.create_snapshot = self.config.create_snapshot
+            rescue_config.force = self.config.force
+
+            rescue = RescueOrchestrator(
+                compute=self.compute, project=self.project, zone=self.zone,
+                vm_name=self.vm_name, config=rescue_config, logger=self.logger,
+                log_file=self.log_file, startup_script_override=repair_script,
+                suppress_progress=True,
+                progress_callback=self._make_progress_callback(
+                    "Rescue", RESCUE_SUBSTEP_LABELS
+                )
+            )
+            # Skip validation (already done)
+            if not rescue.execute():
+                self._finish_progress(False)
+                self._log_error("Rescue phase failed. Check logs for details.")
+                return {
+                    'status': 'rescue_failed', 'fixed_count': 0,
+                    'fix_lines': [], 'error': 'Rescue phase failed',
+                    'snapshot_name': rescue.snapshot_name,
+                    'duration_seconds': time.time() - start_time
+                }
+
+            snapshot_name = rescue.snapshot_name
+
+            # Phase 2: Parse repair results from serial console
+            self._update_progress("Repair")
+            with self._progress_lock:
+                self._current_substep = 'Applying fix'
+            repair_results = self._parse_repair_results()
+            with self._progress_lock:
+                if (self._current_line_substeps
+                        and self._current_line_substeps[-1]
+                        != 'Applying fix'):
+                    self._current_line_substeps.append('Applying fix')
+                elif not self._current_line_substeps:
+                    self._current_line_substeps.append('Applying fix')
+                self._current_substep = 'Verifying fix'
+            self._log_debug(f"Repair results: {repair_results}")
+
+            # If mount failed (no completion marker found by verify), don't restore
+            if not rescue.verification_succeeded:
+                self._finish_progress(False)
+                self._log_error(
+                    "Startup script did not complete. The disk may not have mounted."
+                )
+                self._log_error(
+                    "VM is in rescue mode for manual investigation."
+                )
+                self._log_error("")
+                self._log_error("Connect to investigate:")
+                self._log_error(
+                    f"  $ gcloud compute ssh {self.vm_name} "
+                    f"--zone={self.zone} --project={self.project}"
+                )
+                self._log_error("")
+                self._log_error("When done, restore with:")
+                self._log_error(
+                    f"  $ gce-rescue-v2 restore {self.vm_name} "
+                    f"--zone={self.zone} --project={self.project}"
+                )
+                return {
+                    'status': 'mount_failed', 'fixed_count': 0,
+                    'fix_lines': [], 'error': 'Disk mount did not complete',
+                    'snapshot_name': snapshot_name,
+                    'duration_seconds': time.time() - start_time
+                }
+
+            # Phase 3: Restore
+            self._update_progress("Restore")
+            restore_config = RestoreConfig()
+            restore_config.delete_rescue_disk = True
+
+            restore = RestoreOrchestrator(
+                compute=self.compute, project=self.project, zone=self.zone,
+                vm_name=self.vm_name, config=restore_config, logger=self.logger,
+                log_file=self.log_file, suppress_progress=True,
+                progress_callback=self._make_progress_callback(
+                    "Restore", RESTORE_SUBSTEP_LABELS
+                )
+            )
+            if not restore.execute():
+                self._finish_progress(False)
+                self._log_error("Restore phase failed.")
+                self._log_error(
+                    "VM may be in rescue mode. Try restoring manually:"
+                )
+                self._log_error(
+                    f"  $ gce-rescue-v2 restore {self.vm_name} "
+                    f"--zone={self.zone} --project={self.project}"
+                )
+                return {
+                    'status': 'restore_failed',
+                    'fixed_count': repair_results.get('fixed_count', 0),
+                    'fix_lines': repair_results.get('fix_lines', []),
+                    'error': 'Restore phase failed',
+                    'snapshot_name': snapshot_name,
+                    'duration_seconds': time.time() - start_time
+                }
+
+            self._finish_progress(True)
+            repair_results['snapshot_name'] = snapshot_name
+            repair_results['duration_seconds'] = time.time() - start_time
+            return repair_results
+
+        except Exception as e:
+            self._finish_progress(False)
+            self._log_error(f"Unexpected error during repair: {e}")
+            return {
+                'status': 'error', 'fixed_count': 0,
+                'fix_lines': [], 'error': str(e),
+                'snapshot_name': None,
+                'duration_seconds': time.time() - start_time
+            }
+
+    def _find_rescue_snapshot(self) -> Optional[str]:
+        """Find the pre-rescue snapshot name from VM metadata.
+
+        During rescue, the original disk name is stored in metadata as
+        'rescue-original-disk'. Snapshots follow the naming pattern
+        'pre-rescue-{disk_name}-{timestamp}'.
+
+        Returns:
+            Snapshot name if found, None otherwise.
+        """
+        try:
+            compute = self._create_tracked_client('repair-snapshot-lookup')
+            vm_info = compute.instances().get(
+                project=self.project, zone=self.zone, instance=self.vm_name
+            ).execute()
+
+            # Get original disk name from rescue metadata
+            original_disk = None
+            for item in vm_info.get('metadata', {}).get('items', []):
+                if item.get('key') == 'rescue-original-disk':
+                    original_disk = item.get('value')
+                    break
+
+            if not original_disk:
+                self._log_debug("No rescue-original-disk in metadata")
+                return None
+
+            # Find matching snapshot (most recent first)
+            snapshots = compute.snapshots().list(
+                project=self.project,
+                filter=f'name:pre-rescue-{original_disk}-*'
+            ).execute()
+
+            items = snapshots.get('items', [])
+            if not items:
+                self._log_debug(f"No snapshots found matching pre-rescue-{original_disk}-*")
+                return None
+
+            # Return the most recent one (highest timestamp suffix)
+            items.sort(key=lambda s: s.get('creationTimestamp', ''), reverse=True)
+            name = items[0].get('name')
+            self._log_debug(f"Found rescue snapshot: {name}")
+            return name
+
+        except Exception as e:
+            self._log_debug(f"Could not find rescue snapshot: {e}")
+            return None
+
+    def resume(self) -> Dict[str, Any]:
+        """Resume an interrupted repair: parse results from serial console + restore.
+
+        Called when the VM is already in rescue mode from a previous repair attempt.
+        Skips the rescue phase entirely.
+
+        Returns:
+            Dict with keys: status, fixed_count, fix_lines, error,
+            snapshot_name, duration_seconds
+        """
+        self._total_steps = 2  # Repair, Restore (rescue already done)
+
+        # Look up snapshot from the original rescue phase
+        snapshot_name = self._find_rescue_snapshot()
+
+        self._init_progress()
+        start_time = time.time()
+
+        try:
+            # Phase 1: Parse repair results from serial console
+            self._update_progress("Repair")
+            with self._progress_lock:
+                self._current_substep = 'Verifying fix'
+            repair_results = self._parse_repair_results()
+            self._log_debug(f"Repair results: {repair_results}")
+
+            # Phase 2: Restore
+            self._update_progress("Restore")
+            restore_config = RestoreConfig()
+            restore_config.delete_rescue_disk = True
+
+            restore = RestoreOrchestrator(
+                compute=self.compute, project=self.project, zone=self.zone,
+                vm_name=self.vm_name, config=restore_config, logger=self.logger,
+                log_file=self.log_file, suppress_progress=True,
+                progress_callback=self._make_progress_callback(
+                    "Restore", RESTORE_SUBSTEP_LABELS
+                )
+            )
+            if not restore.execute():
+                self._finish_progress(False)
+                self._log_error("Restore phase failed.")
+                self._log_error(
+                    "VM may be in rescue mode. Try restoring manually:"
+                )
+                self._log_error(
+                    f"  $ gce-rescue-v2 restore {self.vm_name} "
+                    f"--zone={self.zone} --project={self.project}"
+                )
+                return {
+                    'status': 'restore_failed',
+                    'fixed_count': repair_results.get('fixed_count', 0),
+                    'fix_lines': repair_results.get('fix_lines', []),
+                    'error': 'Restore phase failed',
+                    'snapshot_name': snapshot_name,
+                    'duration_seconds': time.time() - start_time
+                }
+
+            self._finish_progress(True)
+            repair_results['snapshot_name'] = snapshot_name
+            repair_results['duration_seconds'] = time.time() - start_time
+            return repair_results
+
+        except Exception as e:
+            self._finish_progress(False)
+            self._log_error(f"Unexpected error during resume: {e}")
+            return {
+                'status': 'error', 'fixed_count': 0,
+                'fix_lines': [], 'error': str(e),
+                'snapshot_name': snapshot_name,
+                'duration_seconds': time.time() - start_time
+            }
+
+    def _generate_repair_script(self, diagnosis: Dict[str, Any]) -> str:
+        """Generate combined startup script: rescue_mount.sh + fix script(s).
+
+        Loads rescue_mount.sh, replaces the completion marker with a comment,
+        appends fix script(s), then appends the completion marker at the end.
+        """
+        # Load base rescue mount script
+        script_dir = Path(__file__).parent.parent / 'startup_scripts'
+        base_script_path = script_dir / 'rescue_mount.sh'
+
+        with open(base_script_path, 'r') as f:
+            base_script = f.read()
+
+        # Get original disk name for placeholder replacement
+        compute = self._create_tracked_client('repair-script-vm-info')
+        vm_info = compute.instances().get(
+            project=self.project, zone=self.zone, instance=self.vm_name
+        ).execute()
+        original_disk = None
+        for disk in vm_info.get('disks', []):
+            if disk.get('boot'):
+                original_disk = disk['source'].split('/')[-1]
+                break
+
+        if not original_disk:
+            raise ValueError("Could not determine original boot disk name")
+
+        # Validate disk name
+        if not re.match(r'^[a-z]([-a-z0-9]*[a-z0-9])?$', original_disk):
+            raise ValueError(f"Disk name contains invalid characters: {original_disk}")
+
+        # Replace disk placeholder
+        base_script = base_script.replace('DISK_NAME_PLACEHOLDER', original_disk)
+
+        # Remove the completion marker line (we'll add it at the very end)
+        # The marker is: echo "GCE-RESCUE-COMPLETE" >&2
+        base_script = base_script.replace(
+            f'echo "{RESCUE_COMPLETE_MARKER}" >&2',
+            f'# GCE-RESCUE-COMPLETE marker moved to end (repair mode)'
+        )
+
+        # Get fix scripts for fixable categories
+        fixable = self.get_fixable_categories(diagnosis)
+        fix_scripts = []
+        for category in fixable:
+            fix_script = self._get_fix_script(category)
+            if fix_script:
+                fix_scripts.append(fix_script)
+
+        # Combine: base script + fix scripts + completion marker
+        combined = base_script + '\n'
+        combined += '\n# === GCE Repair Fix Scripts ===\n'
+        combined += 'log "=== Starting repair fixes ==="\n\n'
+
+        for fix_script in fix_scripts:
+            combined += fix_script + '\n\n'
+
+        combined += 'log "=== Repair fixes completed ==="\n'
+        combined += f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
+        combined += 'log "=== Startup script completed successfully ==="\n'
+
+        return combined
+
+    def _get_fix_script(self, category: str) -> Optional[str]:
+        """Load fix script template for a category."""
+        fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
+        script_path = fixes_dir / f'{category}_fix.sh'
+
+        if not script_path.exists():
+            self._log_debug(f"No fix script found for category: {category}")
+            return None
+
+        with open(script_path, 'r') as f:
+            content = f.read()
+
+        # Remove shebang line if present (already in base script)
+        if content.startswith('#!/bin/bash'):
+            content = content.split('\n', 1)[1]
+
+        return content
+
+    def _parse_repair_results(self) -> Dict[str, Any]:
+        """Parse repair results from serial console output.
+
+        Looks for GCE-REPAIR-LINE: and GCE-REPAIR-RESULT: markers.
+
+        Returns:
+            Dict with: status, fixed_count, fix_lines, error
+        """
+        try:
+            compute = self._create_tracked_client('repair-serial-parse')
+            serial_response = compute.instances().getSerialPortOutput(
+                project=self.project, zone=self.zone,
+                instance=self.vm_name, port=1
+            ).execute()
+            serial_output = serial_response.get('contents', '')
+        except Exception as e:
+            self._log_debug(f"Could not fetch serial console: {e}")
+            return {
+                'status': 'unknown', 'fixed_count': 0,
+                'fix_lines': [], 'error': f'Could not read serial console: {e}'
+            }
+
+        # Extract repair lines
+        fix_lines = []
+        for line in serial_output.split('\n'):
+            if REPAIR_LINE_MARKER in line:
+                idx = line.index(REPAIR_LINE_MARKER)
+                fix_lines.append(line[idx + len(REPAIR_LINE_MARKER):].strip())
+
+        # Extract repair result
+        status = 'unknown'
+        fixed_count = 0
+        error = None
+
+        for line in serial_output.split('\n'):
+            if REPAIR_RESULT_MARKER in line:
+                idx = line.index(REPAIR_RESULT_MARKER)
+                result_str = line[idx + len(REPAIR_RESULT_MARKER):].strip()
+
+                if result_str.startswith('SUCCESS:'):
+                    status = 'success'
+                    try:
+                        fixed_count = int(result_str.split(':')[1])
+                    except (ValueError, IndexError):
+                        fixed_count = len(fix_lines)
+                elif result_str.startswith('NO_ISSUES:'):
+                    status = 'no_issues'
+                    fixed_count = 0
+                elif result_str.startswith('FAILED:'):
+                    status = 'failed'
+                    error = result_str.split(':', 1)[1] if ':' in result_str else 'Unknown'
+
+        return {
+            'status': status, 'fixed_count': fixed_count,
+            'fix_lines': fix_lines, 'error': error
+        }
+
+    # --- Progress display ---
+
+    def _make_progress_callback(self, phase: str, label_map: Dict[str, str]):
+        """Return a callback that updates the current substep display.
+
+        Args:
+            phase: Phase name shown to user (e.g. "Rescue", "Restore")
+            label_map: Maps raw step labels to user-friendly names
+        """
+        def callback(raw_label: str):
+            display_label = label_map.get(raw_label, raw_label)
+            with self._progress_lock:
+                self._current_phase = phase
+                # Record previous substep in trail before moving to next
+                if (self._current_substep
+                        and self._current_substep != display_label
+                        and (not self._current_line_substeps
+                             or self._current_line_substeps[-1]
+                             != self._current_substep)):
+                    self._current_line_substeps.append(
+                        self._current_substep
+                    )
+                self._current_substep = display_label
+        return callback
+
+    def _init_progress(self):
+        """Initialize multi-line progress display."""
+        console_level = getattr(
+            self.logger, 'console_level', self.logger.level
+        ) if self.logger else logging.INFO
+        self._is_debug_mode = console_level <= logging.DEBUG
+        self._progress_phases = []
+        self._progress_lock = threading.Lock()
+        self._current_phase = ''
+        self._current_substep = ''
+        self._current_line_substeps: List[str] = []
+
+        if not self._is_debug_mode:
+            sys.stdout.write(f"Repairing instance [{self.vm_name}]:\n")
+            sys.stdout.flush()
+            self._spinner_stop = False
+            self._spinner_thread = threading.Thread(
+                target=self._run_spinner, daemon=True
+            )
+            self._spinner_thread.start()
+
+        self._progress_started = True
+
+    def _run_spinner(self):
+        """Run spinner showing current phase line with substep trail.
+
+        Output format per phase:
+          Rescue:  Stopping VM -> Creating snapshot -> Creating rescue disk..\\
+        When phase completes:
+          Rescue:  Stopping VM -> Creating snapshot -> Creating rescue disk  done.
+        """
+        spinner_chars = ['|', '/', '-', '\\']
+        idx = 0
+
+        while not self._spinner_stop:
+            with self._progress_lock:
+                phase = self._current_phase
+                substep = self._current_substep
+                substeps = list(self._current_line_substeps)
+
+            if not phase:
+                time.sleep(0.1)
+                continue
+
+            # Build the substep trail for the current phase line
+            trail = " -> ".join(substeps) if substeps else ""
+            if substep and (not substeps or substeps[-1] != substep):
+                if trail:
+                    trail += f" -> {substep}"
+                else:
+                    trail = substep
+
+            prefix = f"  {phase + ':':<9}"
+            if trail:
+                line = f"\r{prefix} {trail}..{spinner_chars[idx]}"
+            else:
+                line = f"\r{prefix} {spinner_chars[idx]}"
+
+            sys.stdout.write(f"{line:<120}")
+            sys.stdout.flush()
+            idx = (idx + 1) % len(spinner_chars)
+            time.sleep(0.1)
+
+    def _update_progress(self, phase: str):
+        """Start a new phase, finalizing the previous phase line."""
+        with self._progress_lock:
+            prev_phase = self._current_phase
+            prev_substeps = list(self._current_line_substeps)
+            prev_substep = self._current_substep
+
+            self._progress_phases.append(phase)
+            self._current_phase = phase
+            self._current_substep = ''
+            self._current_line_substeps = []
+
+        # Include last active substep in the trail
+        if prev_substep and (not prev_substeps
+                             or prev_substeps[-1] != prev_substep):
+            prev_substeps.append(prev_substep)
+
+        # Finalize previous phase line (if any) as "done."
+        if prev_phase and not self._is_debug_mode:
+            trail = " -> ".join(prev_substeps) if prev_substeps else ""
+            prefix = f"  {prev_phase + ':':<9}"
+            if trail:
+                final = f"\r{prefix} {trail}  done."
+            else:
+                final = f"\r{prefix} done."
+            sys.stdout.write(f"{final:<120}\n")
+            sys.stdout.flush()
+
+        self._log_debug(f"Phase: {phase}")
+
+    def _finish_progress(self, success: bool = True):
+        """Finalize the last active phase line with done./FAILED."""
+        if not self._progress_started:
+            return
+
+        self._spinner_stop = True
+        if self._spinner_thread:
+            self._spinner_thread.join(timeout=0.5)
+
+        if not self._is_debug_mode:
+            with self._progress_lock:
+                phase = self._current_phase
+                substeps = list(self._current_line_substeps)
+                substep = self._current_substep
+
+            # Include current substep if not already recorded
+            if substep and (not substeps or substeps[-1] != substep):
+                substeps.append(substep)
+
+            trail = " -> ".join(substeps) if substeps else ""
+            prefix = f"  {phase + ':':<9}" if phase else "  "
+            status_label = "done." if success else "FAILED."
+
+            if trail:
+                final = f"\r{prefix} {trail}  {status_label}"
+            else:
+                final = f"\r{prefix} {status_label}"
+
+            sys.stdout.write(f"{final:<120}\n")
+            sys.stdout.flush()

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -71,7 +71,9 @@ class RescueOrchestrator:
     """
 
     def __init__(self, compute, project: str, zone: str, vm_name: str,
-                 config: RescueConfig = None, logger=None, log_file: str = None):
+                 config: RescueConfig = None, logger=None, log_file: str = None,
+                 startup_script_override: str = None, suppress_progress: bool = False,
+                 progress_callback=None):
         """
         Initialize rescue orchestrator.
 
@@ -83,6 +85,9 @@ class RescueOrchestrator:
             config: Optional rescue configuration
             logger: Optional logger
             log_file: Log file path (for checkpoint persistence)
+            startup_script_override: Custom startup script (replaces default)
+            suppress_progress: Suppress progress spinner (for embedding in repair)
+            progress_callback: Optional callback(phase_label) invoked on each step
         """
         self.compute = compute
         self.project = project
@@ -91,6 +96,9 @@ class RescueOrchestrator:
         self.config = config or RescueConfig()
         self.logger = logger
         self.log_file = log_file
+        self._startup_script_override = startup_script_override
+        self._suppress_progress = suppress_progress
+        self._progress_callback = progress_callback
 
         # State tracking
         self.state_tracker = StateTracker()
@@ -119,12 +127,13 @@ class RescueOrchestrator:
         self.rescue_disk_name = None
 
         # Progress tracking for spinner with phases
+        import threading
         self._spinner_thread = None
         self._spinner_stop = False
         self._is_debug_mode = False
         self._progress_started = False
         self._progress_phases = []
-        self._progress_lock = None
+        self._progress_lock = threading.Lock()
         self._total_steps = 5  # Stopping, Snapshotting, Creating rescue disk, Starting, Attaching
 
         # Checkpoint manager for resumable operations
@@ -141,6 +150,10 @@ class RescueOrchestrator:
         import sys
         import logging
         import threading
+
+        if self._suppress_progress:
+            self._progress_started = False
+            return
 
         # Check if we're in debug mode (use console_level if available, fallback to logger.level)
         console_level = getattr(self.logger, 'console_level', self.logger.level) if self.logger else logging.INFO
@@ -207,6 +220,8 @@ class RescueOrchestrator:
         """Add a new phase to the progress display."""
         with self._progress_lock:
             self._progress_phases.append(phase)
+        if self._progress_callback:
+            self._progress_callback(phase)
         self._log_debug(f"Phase: {phase}")
 
     def _finish_progress(self, success: bool = True):
@@ -767,6 +782,15 @@ class RescueOrchestrator:
             self._finish_progress(True)
             return True
 
+        except KeyboardInterrupt:
+            self._finish_progress(False)
+            self._log_error(
+                "\nOperation interrupted. Progress has been saved."
+            )
+            self._log_error(
+                "Run the same command again to resume or rollback."
+            )
+            raise
         except Exception as e:
             self._finish_progress(False)
             self._log_error(f"Unexpected error during rescue: {str(e)}")
@@ -799,6 +823,10 @@ class RescueOrchestrator:
         import secrets
         import string
         from pathlib import Path
+
+        # Use override if provided (e.g., repair command injects fix scripts)
+        if self._startup_script_override:
+            return self._startup_script_override
 
         # Validate disk name to prevent injection (defense in depth)
         # GCP disk names must match: [a-z]([-a-z0-9]*[a-z0-9])?

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -11,7 +11,9 @@ Coordinates the rescue workflow:
 
 import time
 from ..core.config import RescueConfig, OS_TYPE_WINDOWS, OS_TYPE_LINUX
-from ..utils.os_detection import detect_os_type, get_os_display_name
+from ..utils.os_detection import (
+    detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64
+)
 from ..validators import (
     ValidationRunner,
     CredentialsValidator,
@@ -99,8 +101,9 @@ class RescueOrchestrator:
         self.original_disk_name = None
         self.original_device_name = None
 
-        # OS detection (will be set during execution)
+        # OS and architecture detection (will be set during execution)
         self.os_type = None
+        self.architecture = None
         self.vm_info = None
 
         # Windows rescue credentials (generated for RDP access)
@@ -263,6 +266,7 @@ class RescueOrchestrator:
             self.original_device_name = self._resumed_context.get('original_device_name')
             self.rescue_disk_name = self._resumed_context.get('rescue_disk_name')
             self.os_type = self._resumed_context.get('os_type')
+            self.architecture = self._resumed_context.get('architecture')
 
         self._log_debug(f"Resume state set: continuing from step {self._resume_from_step + 1}")
 
@@ -318,6 +322,7 @@ class RescueOrchestrator:
             'original_device_name': self.original_device_name,
             'rescue_disk_name': self.rescue_disk_name,
             'os_type': self.os_type,
+            'architecture': self.architecture,
             'log_file': self.log_file
         }
 
@@ -523,12 +528,18 @@ class RescueOrchestrator:
                         rescue_image_project = self.config.windows_rescue_image_project
                         rescue_image_family = self.config.windows_rescue_image_family
                         rescue_disk_size = self.config.windows_rescue_disk_size_gb
+                    elif self.architecture == ARCH_ARM64:
+                        # ARM64 Linux (T2A instances)
+                        rescue_image_project = self.config.arm64_rescue_image_project
+                        rescue_image_family = self.config.arm64_rescue_image_family
+                        rescue_disk_size = self.config.rescue_disk_size_gb
                     else:
+                        # x86_64 Linux (default)
                         rescue_image_project = self.config.rescue_image_project
                         rescue_image_family = self.config.rescue_image_family
                         rescue_disk_size = self.config.rescue_disk_size_gb
 
-                    self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB)...")
+                    self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
                     result = create_disk.execute(
                         disk_name=rescue_disk_name,
                         size_gb=rescue_disk_size,
@@ -770,9 +781,10 @@ class RescueOrchestrator:
             instance=self.vm_name
         ).execute()
 
-        # Detect OS type
+        # Detect OS type and architecture
         self.os_type = detect_os_type(self.vm_info)
-        self._log_debug(f"Detected OS: {get_os_display_name(self.os_type)}")
+        self.architecture = detect_architecture(self.vm_info)
+        self._log_debug(f"Detected OS: {get_os_display_name(self.os_type)}, Architecture: {self.architecture}")
 
         for disk in self.vm_info.get('disks', []):
             if disk.get('boot'):

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -63,7 +63,8 @@ class RestoreOrchestrator:
     """
 
     def __init__(self, compute, project: str, zone: str, vm_name: str,
-                 config: RestoreConfig = None, logger=None, log_file: str = None):
+                 config: RestoreConfig = None, logger=None, log_file: str = None,
+                 suppress_progress: bool = False, progress_callback=None):
         """
         Initialize restore orchestrator.
 
@@ -75,6 +76,8 @@ class RestoreOrchestrator:
             config: Optional restore configuration
             logger: Optional logger
             log_file: Log file path (for checkpoint persistence)
+            suppress_progress: Suppress progress spinner (for embedding in repair)
+            progress_callback: Optional callback(phase_label) invoked on each step
         """
         self.compute = compute
         self.project = project
@@ -83,6 +86,8 @@ class RestoreOrchestrator:
         self.config = config or RestoreConfig()
         self.logger = logger
         self.log_file = log_file
+        self._suppress_progress = suppress_progress
+        self._progress_callback = progress_callback
 
         # State tracking
         self.state_tracker = StateTracker()
@@ -96,12 +101,13 @@ class RestoreOrchestrator:
         self.original_device_name = None
 
         # Progress tracking for spinner with phases
+        import threading
         self._spinner_thread = None
         self._spinner_stop = False
         self._is_debug_mode = False
         self._progress_started = False
         self._progress_phases = []
-        self._progress_lock = None
+        self._progress_lock = threading.Lock()
         self._total_steps = 3  # Stopping, Restoring affected disk, Starting
 
         # Checkpoint manager for resumable operations
@@ -118,6 +124,10 @@ class RestoreOrchestrator:
         import sys
         import logging
         import threading
+
+        if self._suppress_progress:
+            self._progress_started = False
+            return
 
         # Check if we're in debug mode (use console_level if available, fallback to logger.level)
         console_level = getattr(self.logger, 'console_level', self.logger.level) if self.logger else logging.INFO
@@ -181,6 +191,8 @@ class RestoreOrchestrator:
         """Add a new phase to the progress display."""
         with self._progress_lock:
             self._progress_phases.append(phase)
+        if self._progress_callback:
+            self._progress_callback(phase)
         self._log_debug(f"Phase: {phase}")
 
     def _finish_progress(self, success: bool = True):
@@ -597,6 +609,15 @@ class RestoreOrchestrator:
             self._finish_progress(True)
             return True
 
+        except KeyboardInterrupt:
+            self._finish_progress(False)
+            self._log_error(
+                "\nOperation interrupted. Progress has been saved."
+            )
+            self._log_error(
+                "Run the same command again to resume or rollback."
+            )
+            raise
         except Exception as e:
             self._finish_progress(False)
             self._log_error(f"Unexpected error during restore: {str(e)}")

--- a/gce_rescue_v2/pyproject.toml
+++ b/gce_rescue_v2/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
 ]
 
 [project.scripts]
-gce-rescue = "gce_rescue_v2.cli:main"
+gce-rescue-v2 = "gce_rescue_v2.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/gokulr94/gce-rescue"

--- a/gce_rescue_v2/startup_scripts/fixes/fstab_fix.sh
+++ b/gce_rescue_v2/startup_scripts/fixes/fstab_fix.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+# GCE Repair - fstab fix script
+#
+# Runs after disk is mounted at /mnt/sysroot.
+# Scans /etc/fstab for invalid entries and comments them out.
+# Emits structured markers to stderr (serial console) for orchestrator parsing.
+#
+# Checks performed:
+#   - UUID= entries: verified against blkid output
+#   - LABEL= entries: verified against blkid output
+#   - PARTUUID= entries: verified against blkid output
+#   - /dev/ entries: mapped to target disk, checked existence + fstype match
+#   - Malformed entries: fewer than 3 fields
+#   - Virtual filesystems (proc, tmpfs, etc.): always skipped
+
+SYSROOT="/mnt/sysroot"
+FSTAB="$SYSROOT/etc/fstab"
+BACKUP="$SYSROOT/etc/fstab.gce-repair-backup"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [REPAIR] $1" | tee -a "$LOGFILE"
+}
+
+repair_line() {
+    echo "GCE-REPAIR-LINE:$1" >&2
+    log "$1"
+}
+
+repair_result() {
+    echo "GCE-REPAIR-RESULT:$1" >&2
+    log "Repair result: $1"
+}
+
+# Virtual filesystem types that are always valid (no device check needed)
+VIRTUAL_FS="proc sysfs tmpfs devtmpfs devpts securityfs cgroup cgroup2 pstore efivarfs bpf debugfs tracefs fusectl configfs ramfs hugetlbfs mqueue systemd-1 autofs binfmt_misc swap"
+
+is_virtual_fs() {
+    local fstype="$1"
+    for vfs in $VIRTUAL_FS; do
+        if [ "$fstype" = "$vfs" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+log "=== fstab repair started ==="
+
+# Verify fstab exists
+if [ ! -f "$FSTAB" ]; then
+    repair_result "FAILED:fstab not found at $FSTAB"
+    exit 1
+fi
+
+# Create backup
+cp "$FSTAB" "$BACKUP"
+if [ $? -ne 0 ]; then
+    repair_result "FAILED:could not create backup"
+    exit 1
+fi
+log "Backup created: $BACKUP"
+
+# Get available UUIDs, PARTUUIDs, and LABELs from all block devices
+AVAILABLE_UUIDS=$(blkid -o value -s UUID 2>/dev/null | sort -u)
+AVAILABLE_PARTUUIDS=$(blkid -o value -s PARTUUID 2>/dev/null | sort -u)
+AVAILABLE_LABELS=$(blkid -o value -s LABEL 2>/dev/null | sort -u)
+log "Found $(echo "$AVAILABLE_UUIDS" | grep -c .) UUIDs on system"
+
+# --- Device mapping for /dev/ entries ---
+# Find the target disk's device on the rescue VM.
+# The rescue_mount.sh script uses: /dev/disk/by-id/google-${disk}
+# 'disk' variable is set by rescue_mount.sh before this script runs.
+TARGET_DISK_DEV=""
+TARGET_DISK_BASE=""
+if [ -n "$disk" ] && [ -e "/dev/disk/by-id/google-${disk}" ]; then
+    TARGET_DISK_DEV=$(readlink -f "/dev/disk/by-id/google-${disk}")
+    # Extract base device (e.g., /dev/sdb from /dev/sdb1 or /dev/sdb)
+    TARGET_DISK_BASE=$(echo "$TARGET_DISK_DEV" | sed 's/[0-9]*$//')
+    log "Target disk on rescue VM: $TARGET_DISK_DEV (base: $TARGET_DISK_BASE)"
+else
+    log "WARNING: Could not determine target disk device (disk=$disk)"
+fi
+
+# Build a map of target disk partitions and their filesystem types
+# e.g., "1:ext4" "2:vfat" (partition_number:fstype)
+declare -A TARGET_PART_FSTYPE
+TARGET_DISK_SHORT=$(basename "$TARGET_DISK_BASE")  # e.g., "sdb"
+if [ -n "$TARGET_DISK_BASE" ]; then
+    while IFS= read -r bline; do
+        part_dev=$(echo "$bline" | awk '{print $1}')
+        part_fstype=$(echo "$bline" | awk '{print $2}')
+        if [ -n "$part_dev" ] && [ -n "$part_fstype" ]; then
+            # Extract partition number from short device name
+            # lsblk outputs short names like "sdb1", strip the base "sdb" to get "1"
+            part_num=$(echo "$part_dev" | sed "s|^${TARGET_DISK_SHORT}||")
+            if [ -n "$part_num" ]; then
+                TARGET_PART_FSTYPE["$part_num"]="$part_fstype"
+                log "  Target partition ${part_num}: ${part_fstype} (${part_dev})"
+            fi
+        fi
+    done < <(lsblk -rno NAME,FSTYPE "$TARGET_DISK_BASE" 2>/dev/null | grep -v "^${TARGET_DISK_SHORT} ")
+fi
+
+# Function to check /dev/ device entries by mapping to target disk
+check_dev_entry() {
+    local device="$1"
+    local fstab_fstype="$2"
+    local mountpoint="$3"
+
+    # Skip /dev/disk/by-* entries (handled by UUID/LABEL/PARTUUID checks)
+    if echo "$device" | grep -q '^/dev/disk/by-'; then
+        return 0  # valid
+    fi
+
+    # Skip swap entries
+    if [ "$fstab_fstype" = "swap" ]; then
+        return 0  # handled separately
+    fi
+
+    # Extract device base and partition number
+    # e.g., /dev/sda1 -> base=sda, partnum=1
+    local dev_basename=$(basename "$device")
+    local dev_base=$(echo "$dev_basename" | sed 's/[0-9]*$//')
+    local dev_partnum=$(echo "$dev_basename" | sed "s/^${dev_base}//")
+
+    # If this is a root mount (/) or /boot/efi, don't touch it
+    if [ "$mountpoint" = "/" ]; then
+        return 0  # never comment out root
+    fi
+
+    # If we have target disk info, do a mapped check
+    if [ -n "$TARGET_DISK_BASE" ] && [ -n "$dev_partnum" ]; then
+        # Check if this partition exists on the target disk
+        local mapped_dev="${TARGET_DISK_BASE}${dev_partnum}"
+        if [ ! -e "$mapped_dev" ]; then
+            log "Device $device -> mapped to $mapped_dev (not found)"
+            return 1  # invalid: partition doesn't exist on target disk
+        fi
+
+        # Check filesystem type matches
+        local actual_fstype="${TARGET_PART_FSTYPE[$dev_partnum]}"
+        if [ -n "$actual_fstype" ] && [ -n "$fstab_fstype" ] && [ "$actual_fstype" != "$fstab_fstype" ]; then
+            log "Device $device -> mapped to $mapped_dev (fstype mismatch: fstab=$fstab_fstype, actual=$actual_fstype)"
+            return 2  # invalid: filesystem type mismatch
+        fi
+
+        log "Device $device -> mapped to $mapped_dev (OK, fstype=$actual_fstype)"
+        return 0  # valid
+    fi
+
+    # Fallback: if no target disk mapping available, check device existence
+    if [ ! -e "$device" ] && [ ! -e "$SYSROOT$device" ]; then
+        return 1  # device not found
+    fi
+
+    return 0  # assume valid
+}
+
+fixes=0
+line_num=0
+tmpfile=$(mktemp)
+
+while IFS= read -r line; do
+    line_num=$((line_num + 1))
+
+    # Pass through empty lines and comments unchanged
+    if echo "$line" | grep -qE '^\s*$|^\s*#'; then
+        echo "$line" >> "$tmpfile"
+        continue
+    fi
+
+    # Parse fstab fields: device mountpoint fstype options dump pass
+    device=$(echo "$line" | awk '{print $1}')
+    mountpoint=$(echo "$line" | awk '{print $2}')
+    fstype=$(echo "$line" | awk '{print $3}')
+    field_count=$(echo "$line" | awk '{print NF}')
+
+    # Check for malformed entries (need at least device, mountpoint, fstype)
+    if [ "$field_count" -lt 3 ]; then
+        echo "# GCE-REPAIR: commented out malformed entry (${field_count} fields)" >> "$tmpfile"
+        echo "#$line" >> "$tmpfile"
+        fixes=$((fixes + 1))
+        repair_line "[FIXED] fstab: Commented out malformed entry on line $line_num"
+        continue
+    fi
+
+    # Skip virtual filesystems - they don't need device validation
+    if is_virtual_fs "$fstype"; then
+        echo "$line" >> "$tmpfile"
+        continue
+    fi
+
+    # Check UUID= entries
+    if echo "$device" | grep -q '^UUID='; then
+        uuid=$(echo "$device" | sed 's/UUID=//')
+        if ! echo "$AVAILABLE_UUIDS" | grep -qF "$uuid"; then
+            short_uuid="${uuid:0:12}..."
+            echo "# GCE-REPAIR: commented out invalid UUID entry (UUID not found on disk)" >> "$tmpfile"
+            echo "#$line" >> "$tmpfile"
+            fixes=$((fixes + 1))
+            repair_line "[FIXED] fstab: Commented out invalid UUID entry for $mountpoint ($short_uuid)"
+            continue
+        fi
+    fi
+
+    # Check PARTUUID= entries
+    if echo "$device" | grep -q '^PARTUUID='; then
+        partuuid=$(echo "$device" | sed 's/PARTUUID=//')
+        if ! echo "$AVAILABLE_PARTUUIDS" | grep -qF "$partuuid"; then
+            short_partuuid="${partuuid:0:12}..."
+            echo "# GCE-REPAIR: commented out invalid PARTUUID entry (PARTUUID not found)" >> "$tmpfile"
+            echo "#$line" >> "$tmpfile"
+            fixes=$((fixes + 1))
+            repair_line "[FIXED] fstab: Commented out invalid PARTUUID entry for $mountpoint ($short_partuuid)"
+            continue
+        fi
+    fi
+
+    # Check LABEL= entries
+    if echo "$device" | grep -q '^LABEL='; then
+        label=$(echo "$device" | sed 's/LABEL=//')
+        if ! echo "$AVAILABLE_LABELS" | grep -qF "$label"; then
+            echo "# GCE-REPAIR: commented out invalid LABEL entry (label not found)" >> "$tmpfile"
+            echo "#$line" >> "$tmpfile"
+            fixes=$((fixes + 1))
+            repair_line "[FIXED] fstab: Commented out invalid LABEL entry for $mountpoint ($label)"
+            continue
+        fi
+    fi
+
+    # Check /dev/ entries with device mapping
+    if echo "$device" | grep -q '^/dev/'; then
+        check_dev_entry "$device" "$fstype" "$mountpoint"
+        check_result=$?
+        if [ $check_result -eq 1 ]; then
+            echo "# GCE-REPAIR: commented out missing device entry" >> "$tmpfile"
+            echo "#$line" >> "$tmpfile"
+            fixes=$((fixes + 1))
+            repair_line "[FIXED] fstab: Commented out missing device entry for $mountpoint ($device)"
+            continue
+        elif [ $check_result -eq 2 ]; then
+            # Get the actual filesystem type for the error message
+            local_dev_basename=$(basename "$device")
+            local_dev_base=$(echo "$local_dev_basename" | sed 's/[0-9]*$//')
+            local_dev_partnum=$(echo "$local_dev_basename" | sed "s/^${local_dev_base}//")
+            actual_fs="${TARGET_PART_FSTYPE[$local_dev_partnum]}"
+            echo "# GCE-REPAIR: commented out wrong filesystem type (fstab=$fstype, actual=$actual_fs)" >> "$tmpfile"
+            echo "#$line" >> "$tmpfile"
+            fixes=$((fixes + 1))
+            repair_line "[FIXED] fstab: Commented out wrong fstype for $mountpoint ($device: fstab=$fstype, actual=$actual_fs)"
+            continue
+        fi
+    fi
+
+    # Entry looks valid, keep it
+    echo "$line" >> "$tmpfile"
+
+done < "$FSTAB"
+
+# Replace fstab with fixed version
+cp "$tmpfile" "$FSTAB"
+rm -f "$tmpfile"
+
+log "=== fstab repair completed: $fixes issues fixed ==="
+
+if [ $fixes -gt 0 ]; then
+    repair_result "SUCCESS:$fixes"
+else
+    repair_result "NO_ISSUES:0"
+fi

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -7,6 +7,7 @@ Tests:
 - Output formatting
 """
 
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -91,4 +92,286 @@ class TestCLIOutput:
         out = cli.OutputFormatter.format_output(data, "csv")
         assert "a,b" in out
         assert "1,2" in out
+
+
+# ---------------------------------------------------------------------------
+# TestFormatDuration
+# ---------------------------------------------------------------------------
+
+class TestFormatDuration:
+    """Tests for _format_duration() helper function."""
+
+    def test_format_duration_less_than_60_seconds(self):
+        """Seconds less than 60 should format as 'Ns'."""
+        assert cli._format_duration(0) == "0s"
+        assert cli._format_duration(1) == "1s"
+        assert cli._format_duration(42) == "42s"
+        assert cli._format_duration(59) == "59s"
+
+    def test_format_duration_exactly_60_seconds(self):
+        """60 seconds should format as '1m'."""
+        assert cli._format_duration(60) == "1m"
+
+    def test_format_duration_1_minute_30_seconds(self):
+        """90 seconds should format as '1m 30s'."""
+        assert cli._format_duration(90) == "1m 30s"
+
+    def test_format_duration_multiple_minutes(self):
+        """Multiple minutes should format correctly."""
+        assert cli._format_duration(120) == "2m"
+        assert cli._format_duration(121) == "2m 1s"
+        assert cli._format_duration(180) == "3m"
+        assert cli._format_duration(200) == "3m 20s"
+
+    def test_format_duration_large_values(self):
+        """Large durations should format correctly."""
+        assert cli._format_duration(3600) == "60m"
+        assert cli._format_duration(3661) == "61m 1s"
+
+    def test_format_duration_float_input(self):
+        """Should handle float input (truncates to int)."""
+        assert cli._format_duration(42.9) == "42s"
+        assert cli._format_duration(60.5) == "1m"
+        assert cli._format_duration(90.1) == "1m 30s"
+
+    def test_format_duration_no_trailing_zero_seconds(self):
+        """When seconds are 0, should not append ' 0s'."""
+        assert cli._format_duration(60) == "1m"
+        assert cli._format_duration(120) == "2m"
+        assert "0s" not in cli._format_duration(60)
+
+
+# ---------------------------------------------------------------------------
+# TestSpinner
+# ---------------------------------------------------------------------------
+
+class TestSpinner:
+    """Tests for _Spinner class."""
+
+    def test_spinner_init(self):
+        """_Spinner should initialize with a message."""
+        spinner = cli._Spinner("Loading")
+        assert spinner._message == "Loading"
+        assert spinner._stop is False
+        assert spinner._thread is None
+
+    def test_spinner_start(self):
+        """start() should create and start a daemon thread."""
+        spinner = cli._Spinner("Loading")
+        spinner.start()
+        assert spinner._thread is not None
+        assert spinner._thread.daemon is True
+        spinner.stop()
+
+    def test_spinner_stop(self):
+        """stop() should set _stop flag and wait for thread."""
+        spinner = cli._Spinner("Loading")
+        spinner.start()
+        time.sleep(0.2)  # Let spinner run a bit
+        spinner.stop()
+        assert spinner._stop is True
+        # Thread should have finished
+        spinner._thread.join(timeout=1)
+        assert not spinner._thread.is_alive()
+
+    def test_spinner_stop_clears_output(self):
+        """stop() with clear=True should print clearing characters."""
+        import sys
+        from io import StringIO
+
+        spinner = cli._Spinner("Loading")
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        try:
+            spinner.start()
+            time.sleep(0.2)
+            spinner.stop(clear=True)
+            output = sys.stdout.getvalue()
+            # Should contain carriage return for clearing
+            assert "\r" in output
+        finally:
+            sys.stdout = old_stdout
+
+    def test_spinner_stop_no_clear(self):
+        """stop() with clear=False should not clear output."""
+        spinner = cli._Spinner("Loading")
+        spinner.start()
+        time.sleep(0.1)
+        # Should not raise with clear=False
+        spinner.stop(clear=False)
+        assert spinner._stop is True
+
+    def test_spinner_multiple_start_stop(self):
+        """Multiple start/stop cycles should work."""
+        spinner = cli._Spinner("Loading")
+        for _ in range(3):
+            spinner.start()
+            time.sleep(0.1)
+            spinner.stop()
+
+    def test_spinner_message_in_output(self):
+        """Spinner output should contain the message."""
+        import sys
+        from io import StringIO
+
+        spinner = cli._Spinner("Checking")
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        try:
+            spinner.start()
+            time.sleep(0.2)
+            spinner.stop(clear=False)
+            output = sys.stdout.getvalue()
+            assert "Checking" in output
+        finally:
+            sys.stdout = old_stdout
+
+
+# ---------------------------------------------------------------------------
+# TestShowRepairResults
+# ---------------------------------------------------------------------------
+
+class TestShowRepairResults:
+    """Tests for _show_repair_results() function."""
+
+    def test_show_repair_results_success(self, capsys):
+        """Success status should show fixed count and snapshot."""
+        result = {
+            'status': 'success',
+            'fixed_count': 2,
+            'fix_lines': ['Fixed UUID for /data', 'Fixed device /dev/sdb1'],
+            'error': None,
+            'snapshot_name': 'backup-disk-12345',
+            'duration_seconds': 45.5,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert 'Repair results:' in captured.out
+        assert '2 issues fixed' in captured.out
+        assert 'backup-disk-12345' in captured.out
+        assert '45s' in captured.out
+
+    def test_show_repair_results_no_issues(self, capsys):
+        """no_issues status should indicate no fix was needed."""
+        result = {
+            'status': 'no_issues',
+            'fixed_count': 0,
+            'fix_lines': [],
+            'error': None,
+            'snapshot_name': 'backup-disk-12345',
+            'duration_seconds': 60,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert 'already valid' in captured.out.lower()
+
+    def test_show_repair_results_no_fix_available(self, capsys):
+        """no_fix status should indicate no automated fix."""
+        result = {
+            'status': 'no_fix',
+            'fixed_count': 0,
+            'fix_lines': [],
+            'error': None,
+            'snapshot_name': None,
+            'duration_seconds': 0,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert 'No automated fix' in captured.out
+
+    def test_show_repair_results_failed(self, capsys):
+        """failed status should show error."""
+        result = {
+            'status': 'failed',
+            'fixed_count': 1,
+            'fix_lines': ['Fixed one issue'],
+            'error': 'Script error: invalid fstab format',
+            'snapshot_name': None,
+            'duration_seconds': 30,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert 'Script error' in captured.err
+
+    def test_show_repair_results_mount_failed(self, capsys):
+        """mount_failed status should show error and rescue mode message."""
+        result = {
+            'status': 'mount_failed',
+            'fixed_count': 0,
+            'fix_lines': [],
+            'error': 'Disk mount did not complete',
+            'snapshot_name': None,
+            'duration_seconds': 45,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert 'rescue mode' in captured.err.lower()
+
+    def test_show_repair_results_restore_failed(self, capsys):
+        """restore_failed status should show restore instructions."""
+        result = {
+            'status': 'restore_failed',
+            'fixed_count': 1,
+            'fix_lines': ['Fixed UUID'],
+            'error': None,
+            'snapshot_name': None,
+            'duration_seconds': 60,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert 'restore' in captured.err.lower()
+
+    def test_show_repair_results_includes_duration(self, capsys):
+        """Results should include formatted duration."""
+        result = {
+            'status': 'success',
+            'fixed_count': 1,
+            'fix_lines': ['Fixed'],
+            'error': None,
+            'snapshot_name': 'backup',
+            'duration_seconds': 123,  # 2m 3s
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert '2m 3s' in captured.out
+
+    def test_show_repair_results_single_vs_plural(self, capsys):
+        """Should use singular/plural for issue count."""
+        result_single = {
+            'status': 'success',
+            'fixed_count': 1,
+            'fix_lines': ['One fix'],
+            'error': None,
+            'snapshot_name': 'backup',
+            'duration_seconds': 30,
+        }
+        exit_code = cli._show_repair_results(result_single, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert '1 issue fixed' in captured.out
+
+        # Reset capsys
+        capsys.readouterr()
+
+        result_plural = {
+            'status': 'success',
+            'fixed_count': 3,
+            'fix_lines': ['Fix 1', 'Fix 2', 'Fix 3'],
+            'error': None,
+            'snapshot_name': 'backup',
+            'duration_seconds': 45,
+        }
+        exit_code = cli._show_repair_results(result_plural, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert '3 issues fixed' in captured.out
 

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -1,0 +1,333 @@
+"""Tests for DiagnoseOperation: serial console analysis, error handling, edge cases."""
+
+import logging
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from gce_rescue_v2.operations.diagnose import DiagnoseOperation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _Exec:
+    """Fake .execute() return wrapper."""
+    def __init__(self, value=None):
+        self._value = value
+
+    def execute(self):
+        return self._value
+
+
+def _make_compute(vm_info=None, serial_output=''):
+    """Create a minimal fake compute client."""
+    compute = Mock()
+
+    if vm_info is None:
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/boot-disk',
+                'deviceName': 'boot-disk',
+                'licenses': ['projects/debian-cloud/global/licenses/debian-12'],
+            }],
+            'machineType': 'zones/z/machineTypes/e2-micro',
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+
+    compute.instances.return_value.get.return_value.execute.return_value = vm_info
+    compute.instances.return_value.getSerialPortOutput.return_value.execute.return_value = {
+        'contents': serial_output
+    }
+    return compute
+
+
+def _make_logger():
+    logger = logging.getLogger('test_diagnose')
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def _make_http_error(status_code, message="error"):
+    """Create a fake HttpError with given status code."""
+    resp = Mock()
+    resp.status = status_code
+    return HttpError(resp, f'{{"error": {{"message": "{message}"}}}}'.encode())
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseBasic
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseBasic:
+    """Basic execution and return values."""
+
+    def test_healthy_vm_returns_success(self):
+        """Healthy VM with no boot errors should return success."""
+        serial = "Linux version 5.15.0-100-generic (builder@server)\n[    0.000000] Booting Linux on physical CPU\nlogin: "
+        compute = _make_compute(serial_output=serial)
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is True
+        assert result.rollback_data['diagnosis_status'] == 'healthy'
+        assert result.rollback_data['boot_errors'] == []
+
+    def test_fstab_error_detected(self):
+        """VM with fstab error should return boot_errors_detected."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "emergency mode\n"
+        )
+        compute = _make_compute(serial_output=serial)
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is True
+        assert result.rollback_data['diagnosis_status'] == 'boot_errors_detected'
+        assert len(result.rollback_data['boot_errors']) > 0
+
+    def test_empty_serial_output(self):
+        """Empty serial output should return unable_to_diagnose."""
+        compute = _make_compute(serial_output='')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is False
+        assert result.rollback_data['diagnosis_status'] == 'unable_to_diagnose'
+
+    def test_short_serial_output(self):
+        """Very short serial output should return unable_to_diagnose."""
+        compute = _make_compute(serial_output='boot')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is False
+        assert result.rollback_data['diagnosis_status'] == 'unable_to_diagnose'
+
+    def test_operation_name(self):
+        """Operation should have correct name."""
+        compute = _make_compute()
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+        assert op.name == "Diagnose VM"
+
+    def test_rollback_is_noop(self):
+        """Rollback should always return True (read-only operation)."""
+        compute = _make_compute()
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+        assert op.rollback({}) is True
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseOSDetection
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseOSDetection:
+    """OS type, flavor, architecture detection in diagnosis results."""
+
+    def test_linux_vm_detected(self):
+        """Linux VM should be detected from licenses."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/boot-disk',
+                'licenses': ['projects/debian-cloud/global/licenses/debian-12'],
+            }],
+            'machineType': 'zones/z/machineTypes/e2-micro',
+            'metadata': {'items': []},
+        }
+        compute = _make_compute(vm_info=vm_info, serial_output='Linux version 5.15.0-100-generic\n[    0.000000] Booting Linux\nlogin: ')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.rollback_data['os_type'] == 'linux'
+
+    def test_vm_status_included(self):
+        """VM status should be included in diagnosis results."""
+        compute = _make_compute(serial_output='Linux version 5.15.0-100-generic\n[    0.000000] Booting Linux\nlogin: ')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.rollback_data['status'] == 'RUNNING'
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseErrorHandling
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseErrorHandling:
+    """Error handling for various API failure modes."""
+
+    def test_vm_not_found_404(self):
+        """404 from instances.get should return clear not-found message."""
+        compute = Mock()
+        compute.instances.return_value.get.return_value.execute.side_effect = (
+            _make_http_error(404, "Instance not found")
+        )
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('nonexistent-vm')
+        assert result.success is False
+        assert 'not found' in result.message.lower()
+        assert result.rollback_data['diagnosis_status'] == 'unable_to_diagnose'
+
+    def test_instances_get_403_graceful_degradation(self):
+        """403 from instances.get should continue with serial console only."""
+        compute = Mock()
+        compute.instances.return_value.get.return_value.execute.side_effect = (
+            _make_http_error(403, "Permission denied")
+        )
+        # Serial console should still work
+        compute.instances.return_value.getSerialPortOutput.return_value.execute.return_value = {
+            'contents': 'Linux version 5.15.0-100-generic\n[    0.000000] Booting Linux\nlogin: '
+        }
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        # Should succeed despite 403 on instances.get
+        assert result.success is True
+        assert result.rollback_data['os_type'] == 'unknown'
+        assert result.rollback_data['status'] == 'UNKNOWN'
+
+    def test_serial_console_disabled_403(self):
+        """403 from getSerialPortOutput should return serial-disabled message."""
+        compute = _make_compute()
+        compute.instances.return_value.getSerialPortOutput.return_value.execute.side_effect = (
+            _make_http_error(403, "Serial port output disabled")
+        )
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is False
+        assert 'serial console' in result.message.lower()
+        assert result.rollback_data['diagnosis_status'] == 'unable_to_diagnose'
+        # Should suggest enabling serial console
+        recs = result.rollback_data['recommendations']
+        assert any('serial-port-enable' in r for r in recs)
+
+    def test_serial_console_other_error(self):
+        """Non-403 error from getSerialPortOutput should return error message."""
+        compute = _make_compute()
+        compute.instances.return_value.getSerialPortOutput.return_value.execute.side_effect = (
+            _make_http_error(500, "Internal error")
+        )
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is False
+        assert result.rollback_data['diagnosis_status'] == 'unable_to_diagnose'
+
+    def test_unexpected_exception(self):
+        """Unexpected exception should return error gracefully."""
+        compute = Mock()
+        compute.instances.return_value.get.return_value.execute.side_effect = (
+            RuntimeError("Unexpected failure")
+        )
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is False
+        assert 'Unexpected' in result.message
+        assert result.rollback_data['diagnosis_status'] == 'unable_to_diagnose'
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseTracking
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseTracking:
+    """User-Agent tracking label support."""
+
+    def test_no_tracking_uses_base_compute(self):
+        """Without tracking_label, should use base compute client."""
+        compute = _make_compute(serial_output='Linux version 5.15.0-100-generic\n[    0.000000] Booting Linux\nlogin: ')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        assert result.success is True
+        # Verify base compute was used (instances().get() was called)
+        compute.instances.return_value.get.assert_called()
+
+    def test_tracking_label_creates_tracked_client(self):
+        """With tracking_label, should call _create_tracked_client."""
+        compute = _make_compute(serial_output='Linux version 5.15.0-100-generic\n[    0.000000] Booting Linux\nlogin: ')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        # Patch _create_tracked_client to return the mock compute
+        with patch.object(op, '_create_tracked_client', return_value=compute) as mock_create:
+            result = op.execute('test-vm', tracking_label='diagnose')
+            mock_create.assert_called_once_with('diagnose')
+            assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseResultStructure
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseResultStructure:
+    """Verify result dict contains all required fields."""
+
+    def test_success_result_has_all_fields(self):
+        """Successful diagnosis should include all expected fields."""
+        compute = _make_compute(serial_output='Linux version 5.15.0-100-generic\n[    0.000000] Booting Linux\nlogin: ')
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        data = result.rollback_data
+
+        required_fields = [
+            'vm_name', 'zone', 'status', 'os_type', 'os_flavor',
+            'architecture', 'license_type', 'diagnosis_status',
+            'boot_errors', 'recommendations'
+        ]
+        for field in required_fields:
+            assert field in data, f"Missing field: {field}"
+
+    def test_error_result_has_all_fields(self):
+        """Failed diagnosis should still include all expected fields."""
+        compute = Mock()
+        compute.instances.return_value.get.return_value.execute.side_effect = (
+            _make_http_error(404, "Not found")
+        )
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        data = result.rollback_data
+
+        required_fields = [
+            'vm_name', 'zone', 'status', 'os_type', 'os_flavor',
+            'architecture', 'license_type', 'diagnosis_status',
+            'boot_errors', 'recommendations'
+        ]
+        for field in required_fields:
+            assert field in data, f"Missing field in error result: {field}"
+
+    def test_boot_error_dict_structure(self):
+        """Boot errors should have correct dict structure."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "emergency mode\n"
+        )
+        compute = _make_compute(serial_output=serial)
+        op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+
+        result = op.execute('test-vm')
+        errors = result.rollback_data['boot_errors']
+        assert len(errors) > 0
+
+        error_fields = [
+            'category', 'severity', 'description', 'detected_pattern',
+            'suggested_fixes', 'context_lines', 'matched_line_index'
+        ]
+        for err in errors:
+            for field in error_fields:
+                assert field in err, f"Missing field in boot error: {field}"

--- a/gce_rescue_v2/tests/test_integration.py
+++ b/gce_rescue_v2/tests/test_integration.py
@@ -49,6 +49,8 @@ def test_full_rescue_restore_cycle(monkeypatch):
             self.zone = zone
             self.vm_name = vm_name
             self.log_file = log_file
+            # Required attributes for main.py success message
+            self.original_disk_name = 'test-boot-disk'
 
         def validate(self):
             state["calls"].append("restore-validate")

--- a/gce_rescue_v2/tests/test_interrupt_recovery.py
+++ b/gce_rescue_v2/tests/test_interrupt_recovery.py
@@ -1,0 +1,439 @@
+"""Tests for Ctrl+C interrupt recovery and VM state reconciliation."""
+
+import logging
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+
+from gce_rescue_v2.orchestration.rescue import RescueOrchestrator
+from gce_rescue_v2.orchestration.restore import RestoreOrchestrator
+from gce_rescue_v2.orchestration.state import StateTracker
+from gce_rescue_v2.orchestration.checkpoint import CheckpointData, CompletedOperation
+from gce_rescue_v2.core.config import RescueConfig
+from gce_rescue_v2.cli import _reconcile_rescue_state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_compute(vm_info=None):
+    """Create a minimal fake compute client."""
+    compute = Mock()
+    if vm_info is None:
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/proj/zones/zone-a/disks/original-boot',
+                'deviceName': 'original-boot',
+                'licenses': ['projects/debian-cloud/global/licenses/debian-12'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+    compute.instances.return_value.get.return_value.execute.return_value = vm_info
+    return compute
+
+
+def _make_logger():
+    logger = logging.getLogger('test_interrupt')
+    logger.setLevel(logging.DEBUG)
+    logger.console_level = logging.WARNING
+    return logger
+
+
+def _make_checkpoint(step=1, operations=None, context=None):
+    """Create a CheckpointData with defaults."""
+    if operations is None:
+        operations = [
+            CompletedOperation(
+                name='Stop VM', step=1,
+                rollback_data={'vm_name': 'test-vm', 'original_status': 'RUNNING'}
+            )
+        ]
+    if context is None:
+        context = {
+            'vm_name': 'test-vm',
+            'zone': 'zone-a',
+            'original_disk_name': 'original-boot',
+            'original_device_name': 'original-boot',
+            'rescue_disk_name': 'rescue-disk-12345',
+        }
+    return CheckpointData(
+        version=1,
+        operation='rescue',
+        session_id='abcd1234',
+        started_at='2026-01-01T00:00:00Z',
+        updated_at='2026-01-01T00:01:00Z',
+        current_step=step,
+        total_steps=9,
+        completed_operations=operations,
+        context=context,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: KeyboardInterrupt triggers in-memory rollback
+# ---------------------------------------------------------------------------
+
+class TestKeyboardInterruptRollback:
+    """Verify KeyboardInterrupt in execute() triggers rollback and re-raises."""
+
+    def test_rescue_keyboard_interrupt_triggers_rollback(self):
+        """Ctrl+C during rescue should rollback completed ops and re-raise."""
+        compute = _make_compute()
+        logger = _make_logger()
+        orch = RescueOrchestrator(
+            compute, 'proj', 'zone-a', 'test-vm',
+            config=RescueConfig(), logger=logger,
+            suppress_progress=True
+        )
+
+        # Mock StopVMOperation to succeed, then DetachDiskOperation to raise
+        with patch.object(orch, '_get_original_disk_info'), \
+             patch.object(orch, 'checkpoint_manager') as mock_cp:
+            mock_cp.create_checkpoint.return_value = 'sess-1'
+            mock_cp.update_checkpoint.return_value = True
+            mock_cp.load_checkpoint.return_value = None
+
+            # Make step 1 succeed, step 2 raise KeyboardInterrupt
+            call_count = [0]
+            original_execute = None
+
+            def stop_vm_execute(**kwargs):
+                from gce_rescue_v2.operations.base import OperationResult
+                return OperationResult(
+                    operation_name='Stop VM', success=True,
+                    message='Stopped',
+                    rollback_data={'vm_name': 'test-vm', 'original_status': 'RUNNING'}
+                )
+
+            def detach_execute(**kwargs):
+                raise KeyboardInterrupt()
+
+            with patch('gce_rescue_v2.orchestration.rescue.StopVMOperation') as MockStop, \
+                 patch('gce_rescue_v2.orchestration.rescue.DetachDiskOperation') as MockDetach, \
+                 patch('gce_rescue_v2.orchestration.rescue.CreateSnapshotOperation'), \
+                 patch('gce_rescue_v2.orchestration.rescue.CreateDiskOperation'), \
+                 patch('gce_rescue_v2.orchestration.rescue.AttachDiskOperation'), \
+                 patch('gce_rescue_v2.orchestration.rescue.SetMetadataOperation'), \
+                 patch('gce_rescue_v2.orchestration.rescue.StartVMOperation'), \
+                 patch('gce_rescue_v2.orchestration.rescue.VerifyStartupOperation'):
+
+                MockStop.return_value.execute.side_effect = stop_vm_execute
+                MockDetach.return_value.execute.side_effect = detach_execute
+
+                with pytest.raises(KeyboardInterrupt):
+                    orch.execute()
+
+                # Verify rollback was called on the stop operation
+                assert len(orch.state_tracker.get_successful_operations()) == 1
+                assert orch.state_tracker.get_successful_operations()[0].operation_name == 'Stop VM'
+
+    def test_restore_keyboard_interrupt_triggers_rollback(self):
+        """Ctrl+C during restore should rollback completed ops and re-raise."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [
+                {
+                    'boot': True,
+                    'source': 'projects/proj/zones/zone-a/disks/rescue-disk-123',
+                    'deviceName': 'rescue-disk-123',
+                },
+                {
+                    'boot': False,
+                    'source': 'projects/proj/zones/zone-a/disks/original-boot',
+                    'deviceName': 'original-boot',
+                }
+            ],
+            'metadata': {
+                'items': [
+                    {'key': 'rescue-mode', 'value': '123'},
+                    {'key': 'rescue-original-disk', 'value': 'original-boot'},
+                ],
+                'fingerprint': 'abc'
+            },
+        }
+        compute = _make_compute(vm_info)
+        logger = _make_logger()
+        orch = RestoreOrchestrator(
+            compute, 'proj', 'zone-a', 'test-vm',
+            logger=logger, suppress_progress=True
+        )
+
+        with patch.object(orch, 'checkpoint_manager') as mock_cp:
+            mock_cp.create_checkpoint.return_value = 'sess-1'
+            mock_cp.update_checkpoint.return_value = True
+            mock_cp.load_checkpoint.return_value = None
+
+            def stop_vm_execute(**kwargs):
+                from gce_rescue_v2.operations.base import OperationResult
+                return OperationResult(
+                    operation_name='Stop VM', success=True,
+                    message='Stopped',
+                    rollback_data={'vm_name': 'test-vm', 'original_status': 'RUNNING'}
+                )
+
+            def detach_execute(**kwargs):
+                raise KeyboardInterrupt()
+
+            with patch('gce_rescue_v2.orchestration.restore.StopVMOperation') as MockStop, \
+                 patch('gce_rescue_v2.orchestration.restore.DetachDiskOperation') as MockDetach, \
+                 patch('gce_rescue_v2.orchestration.restore.AttachDiskOperation'), \
+                 patch('gce_rescue_v2.orchestration.restore.SetMetadataOperation'), \
+                 patch('gce_rescue_v2.orchestration.restore.StartVMOperation'), \
+                 patch('gce_rescue_v2.orchestration.restore.DeleteDiskOperation'):
+
+                MockStop.return_value.execute.side_effect = stop_vm_execute
+                MockDetach.return_value.execute.side_effect = detach_execute
+
+                with pytest.raises(KeyboardInterrupt):
+                    orch.execute()
+
+                assert len(orch.state_tracker.get_successful_operations()) == 1
+                assert orch.state_tracker.get_successful_operations()[0].operation_name == 'Stop VM'
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: VM state reconciliation
+# ---------------------------------------------------------------------------
+
+class TestReconcileRescueState:
+    """Verify _reconcile_rescue_state detects uncheckpointed operations."""
+
+    def test_reconcile_finds_detached_boot_disk(self):
+        """Boot disk detached but not checkpointed should be added to rollback."""
+        # VM has no boot disk attached (it was detached)
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+
+        # Checkpoint only has step 1 (Stop VM)
+        checkpoint = _make_checkpoint(step=1)
+
+        state_tracker = StateTracker()
+        state_tracker.add_operation(
+            'Stop VM', True, 'Stopped',
+            {'vm_name': 'test-vm', 'original_status': 'RUNNING'}, step_number=1
+        )
+
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+
+        # Should have added "Detach Boot Disk" for rollback
+        op_names = [op.operation_name for op in state_tracker.operations]
+        assert 'Detach Boot Disk' in op_names
+
+        detach_op = [op for op in state_tracker.operations
+                     if op.operation_name == 'Detach Boot Disk'][0]
+        assert detach_op.rollback_data['disk_info']['boot'] is True
+        assert 'original-boot' in detach_op.rollback_data['disk_info']['source']
+
+    def test_reconcile_noop_when_consistent(self):
+        """When checkpoint and VM state match, no extra operations added."""
+        # VM still has boot disk attached (consistent with checkpoint at step 1)
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/proj/zones/zone-a/disks/original-boot',
+                'deviceName': 'original-boot',
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+        # Rescue disk should NOT exist in this consistent state
+        compute.disks.return_value.get.return_value.execute.side_effect = Exception(
+            "notFound: Resource 'rescue-disk-12345' was not found"
+        )
+
+        checkpoint = _make_checkpoint(step=1)
+
+        state_tracker = StateTracker()
+        state_tracker.add_operation(
+            'Stop VM', True, 'Stopped',
+            {'vm_name': 'test-vm', 'original_status': 'RUNNING'}, step_number=1
+        )
+
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+
+        # Should NOT have added any extra operations
+        op_names = [op.operation_name for op in state_tracker.operations]
+        assert op_names == ['Stop VM']
+
+    def test_reconcile_finds_rescue_disk_attached(self):
+        """Rescue disk attached but not checkpointed should be added to rollback."""
+        # VM has rescue disk attached but no boot disk
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/proj/zones/zone-a/disks/rescue-disk-12345',
+                'deviceName': 'rescue-disk-12345',
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+        # Also make disks().get() work for the rescue disk existence check
+        compute.disks.return_value.get.return_value.execute.return_value = {
+            'name': 'rescue-disk-12345'
+        }
+
+        checkpoint = _make_checkpoint(step=1)
+
+        state_tracker = StateTracker()
+        state_tracker.add_operation(
+            'Stop VM', True, 'Stopped',
+            {'vm_name': 'test-vm', 'original_status': 'RUNNING'}, step_number=1
+        )
+
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+
+        op_names = [op.operation_name for op in state_tracker.operations]
+        # Should detect: boot disk detached + rescue disk created + rescue disk attached
+        assert 'Detach Boot Disk' in op_names
+        assert 'Create Rescue Disk' in op_names
+        assert 'Attach Rescue Disk' in op_names
+
+    def test_reconcile_finds_rescue_metadata(self):
+        """Rescue metadata set but not checkpointed should be added to rollback."""
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/proj/zones/zone-a/disks/rescue-disk-12345',
+                'deviceName': 'rescue-disk-12345',
+            }],
+            'metadata': {
+                'items': [
+                    {'key': 'rescue-mode', 'value': '12345'},
+                    {'key': 'startup-script', 'value': '#!/bin/bash\necho test'},
+                    {'key': 'rescue-original-disk', 'value': 'original-boot'},
+                    {'key': 'rescue-backup-startup-script', 'value': 'original script'},
+                ],
+                'fingerprint': 'xyz'
+            },
+        }
+        compute = _make_compute(vm_info)
+
+        checkpoint = _make_checkpoint(step=1)
+
+        state_tracker = StateTracker()
+        state_tracker.add_operation(
+            'Stop VM', True, 'Stopped',
+            {'vm_name': 'test-vm', 'original_status': 'RUNNING'}, step_number=1
+        )
+
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+
+        op_names = [op.operation_name for op in state_tracker.operations]
+        assert 'Set Metadata' in op_names
+
+        meta_op = [op for op in state_tracker.operations
+                   if op.operation_name == 'Set Metadata'][0]
+        # Verify the reconstructed original_metadata removes rescue keys
+        original_items = meta_op.rollback_data['original_metadata']['items']
+        original_keys = [item['key'] for item in original_items]
+        assert 'rescue-mode' not in original_keys
+        assert 'rescue-original-disk' not in original_keys
+        # Verify backup key was restored
+        assert 'startup-script' in original_keys
+        startup_item = [i for i in original_items if i['key'] == 'startup-script'][0]
+        assert startup_item['value'] == 'original script'
+
+    def test_reconcile_skips_when_no_original_disk_in_context(self):
+        """Reconciliation should skip if checkpoint has no original_disk_name."""
+        compute = _make_compute()
+        checkpoint = _make_checkpoint(
+            step=1,
+            context={'vm_name': 'test-vm', 'zone': 'zone-a'}
+        )
+        state_tracker = StateTracker()
+
+        # Should not raise
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+        assert len(state_tracker.operations) == 0
+
+    def test_reconcile_skips_already_checkpointed_operations(self):
+        """Operations already in checkpoint should not be duplicated."""
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+
+        # Checkpoint has both Stop VM and Detach Boot Disk already
+        checkpoint = _make_checkpoint(
+            step=2,
+            operations=[
+                CompletedOperation(
+                    name='Stop VM', step=1,
+                    rollback_data={'vm_name': 'test-vm', 'original_status': 'RUNNING'}
+                ),
+                CompletedOperation(
+                    name='Detach Boot Disk', step=2,
+                    rollback_data={
+                        'vm_name': 'test-vm',
+                        'disk_info': {
+                            'source': 'projects/proj/zones/zone-a/disks/original-boot',
+                            'boot': True, 'autoDelete': True,
+                            'deviceName': 'original-boot', 'mode': 'READ_WRITE'
+                        }
+                    }
+                )
+            ]
+        )
+
+        state_tracker = StateTracker()
+        state_tracker.add_operation(
+            'Stop VM', True, 'Stopped',
+            {'vm_name': 'test-vm', 'original_status': 'RUNNING'}, step_number=1
+        )
+        state_tracker.add_operation(
+            'Detach Boot Disk', True, 'Detached',
+            {'vm_name': 'test-vm', 'disk_info': {}}, step_number=2
+        )
+
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+
+        # Should NOT have added another Detach Boot Disk
+        detach_ops = [op for op in state_tracker.operations
+                      if op.operation_name == 'Detach Boot Disk']
+        assert len(detach_ops) == 1
+
+    def test_reconcile_handles_api_error_gracefully(self):
+        """If VM API call fails, reconciliation should not raise."""
+        compute = Mock()
+        compute.instances.return_value.get.return_value.execute.side_effect = Exception("API error")
+
+        checkpoint = _make_checkpoint(step=1)
+        state_tracker = StateTracker()
+
+        # Should not raise
+        _reconcile_rescue_state(
+            compute, 'proj', 'zone-a', 'test-vm',
+            checkpoint, state_tracker, _make_logger()
+        )
+        # No operations added due to API failure
+        assert len(state_tracker.operations) == 0

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -255,7 +255,7 @@ class TestShippedPatterns:
 
     def test_fstab_patterns_present(self):
         fstab_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'fstab']
-        assert len(fstab_patterns) == 5
+        assert len(fstab_patterns) == 7
 
     def test_fstab_fix_guidance_present(self):
         assert 'fstab' in CATEGORY_FIX_GUIDANCE

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -1,0 +1,271 @@
+"""Tests for YAML pattern loader and validator."""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from gce_rescue_v2.core.boot_patterns import (
+    _load_patterns_from_yaml,
+    _validate_pattern_file,
+    BootErrorPattern,
+    BOOT_ERROR_PATTERNS,
+    CATEGORY_FIX_GUIDANCE,
+)
+
+VALID_YAML = """\
+category: test_category
+fix_guidance: "Test fix guidance"
+
+patterns:
+  - name: test_pattern
+    severity: critical
+    description: "Test pattern description"
+    regex:
+      - 'test regex .*'
+    fixes:
+      - "Test fix 1"
+      - "Test fix 2"
+"""
+
+MULTI_PATTERN_YAML = """\
+category: multi
+fix_guidance: "Multi fix guidance"
+
+patterns:
+  - name: multi_first
+    severity: critical
+    description: "First pattern"
+    regex:
+      - 'first.*match'
+    fixes:
+      - "Fix first"
+  - name: multi_second
+    severity: warning
+    description: "Second pattern"
+    regex:
+      - 'second.*match'
+      - 'alternate.*second'
+    fixes:
+      - "Fix second"
+"""
+
+
+def _write_yaml(tmp_dir: Path, filename: str, content: str) -> Path:
+    """Write a YAML file to a temp directory."""
+    filepath = tmp_dir / filename
+    filepath.write_text(content, encoding='utf-8')
+    return filepath
+
+
+class TestLoadPatternsFromYaml:
+    """Tests for _load_patterns_from_yaml."""
+
+    def test_valid_yaml_produces_correct_patterns(self, tmp_path):
+        _write_yaml(tmp_path, 'test.yaml', VALID_YAML)
+        patterns, fix_guidance = _load_patterns_from_yaml(tmp_path)
+
+        assert len(patterns) == 1
+        assert isinstance(patterns[0], BootErrorPattern)
+        assert patterns[0].name == 'test_pattern'
+        assert patterns[0].category == 'test_category'
+        assert patterns[0].severity == 'critical'
+        assert patterns[0].description == 'Test pattern description'
+        assert patterns[0].patterns == ['test regex .*']
+        assert patterns[0].suggested_fixes == ['Test fix 1', 'Test fix 2']
+
+    def test_fix_guidance_loaded(self, tmp_path):
+        _write_yaml(tmp_path, 'test.yaml', VALID_YAML)
+        _, fix_guidance = _load_patterns_from_yaml(tmp_path)
+
+        assert fix_guidance == {'test_category': 'Test fix guidance'}
+
+    def test_multiple_patterns_in_one_file(self, tmp_path):
+        _write_yaml(tmp_path, 'multi.yaml', MULTI_PATTERN_YAML)
+        patterns, _ = _load_patterns_from_yaml(tmp_path)
+
+        assert len(patterns) == 2
+        assert patterns[0].name == 'multi_first'
+        assert patterns[0].severity == 'critical'
+        assert patterns[1].name == 'multi_second'
+        assert patterns[1].severity == 'warning'
+        assert len(patterns[1].patterns) == 2
+
+    def test_multiple_yaml_files(self, tmp_path):
+        _write_yaml(tmp_path, 'a_first.yaml', VALID_YAML)
+        _write_yaml(tmp_path, 'b_second.yaml', MULTI_PATTERN_YAML)
+        patterns, fix_guidance = _load_patterns_from_yaml(tmp_path)
+
+        assert len(patterns) == 3
+        assert len(fix_guidance) == 2
+        assert 'test_category' in fix_guidance
+        assert 'multi' in fix_guidance
+
+    def test_empty_directory_raises_error(self, tmp_path):
+        with pytest.raises(ValueError, match="No pattern YAML files found"):
+            _load_patterns_from_yaml(tmp_path)
+
+
+class TestValidatePatternFile:
+    """Tests for _validate_pattern_file."""
+
+    def test_missing_category(self):
+        data = {'fix_guidance': 'x', 'patterns': []}
+        with pytest.raises(ValueError, match="missing required field 'category'"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_missing_fix_guidance(self):
+        data = {'category': 'x', 'patterns': []}
+        with pytest.raises(ValueError, match="missing required field 'fix_guidance'"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_missing_patterns(self):
+        data = {'category': 'x', 'fix_guidance': 'x'}
+        with pytest.raises(ValueError, match="missing required field 'patterns'"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_empty_patterns_list(self):
+        data = {'category': 'x', 'fix_guidance': 'x', 'patterns': []}
+        with pytest.raises(ValueError, match="'patterns' must be a non-empty list"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_missing_pattern_field_name(self):
+        data = {
+            'category': 'x',
+            'fix_guidance': 'x',
+            'patterns': [{'severity': 'critical', 'description': 'd', 'regex': ['r'], 'fixes': ['f']}],
+        }
+        with pytest.raises(ValueError, match="pattern #1 missing required field 'name'"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_missing_pattern_field_regex(self):
+        data = {
+            'category': 'x',
+            'fix_guidance': 'x',
+            'patterns': [{'name': 'n', 'severity': 'critical', 'description': 'd', 'fixes': ['f']}],
+        }
+        with pytest.raises(ValueError, match="pattern #1 missing required field 'regex'"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_invalid_severity(self):
+        data = {
+            'category': 'x',
+            'fix_guidance': 'x',
+            'patterns': [{'name': 'n', 'severity': 'fatal', 'description': 'd', 'regex': ['r'], 'fixes': ['f']}],
+        }
+        with pytest.raises(ValueError, match="invalid severity 'fatal'"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_invalid_regex_syntax(self):
+        data = {
+            'category': 'x',
+            'fix_guidance': 'x',
+            'patterns': [{'name': 'n', 'severity': 'critical', 'description': 'd', 'regex': ['[invalid'], 'fixes': ['f']}],
+        }
+        with pytest.raises(ValueError, match="invalid regex"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_empty_regex_list(self):
+        data = {
+            'category': 'x',
+            'fix_guidance': 'x',
+            'patterns': [{'name': 'n', 'severity': 'critical', 'description': 'd', 'regex': [], 'fixes': ['f']}],
+        }
+        with pytest.raises(ValueError, match="must have at least one regex"):
+            _validate_pattern_file(data, 'test.yaml')
+
+    def test_all_valid_severities_accepted(self):
+        for severity in ['critical', 'error', 'warning']:
+            data = {
+                'category': 'x',
+                'fix_guidance': 'x',
+                'patterns': [{'name': 'n', 'severity': severity, 'description': 'd', 'regex': ['r'], 'fixes': ['f']}],
+            }
+            _validate_pattern_file(data, 'test.yaml')  # Should not raise
+
+
+class TestInvalidYamlLoading:
+    """Tests that invalid YAML files produce clear errors during loading."""
+
+    def test_invalid_regex_in_yaml(self, tmp_path):
+        bad_yaml = """\
+category: bad
+fix_guidance: "x"
+
+patterns:
+  - name: bad_regex
+    severity: critical
+    description: "Bad regex"
+    regex:
+      - '[invalid'
+    fixes:
+      - "Fix"
+"""
+        _write_yaml(tmp_path, 'bad.yaml', bad_yaml)
+        with pytest.raises(ValueError, match="invalid regex"):
+            _load_patterns_from_yaml(tmp_path)
+
+    def test_missing_field_in_yaml(self, tmp_path):
+        bad_yaml = """\
+category: bad
+fix_guidance: "x"
+
+patterns:
+  - name: no_severity
+    description: "Missing severity"
+    regex:
+      - 'test'
+    fixes:
+      - "Fix"
+"""
+        _write_yaml(tmp_path, 'bad.yaml', bad_yaml)
+        with pytest.raises(ValueError, match="missing required field 'severity'"):
+            _load_patterns_from_yaml(tmp_path)
+
+    def test_invalid_severity_in_yaml(self, tmp_path):
+        bad_yaml = """\
+category: bad
+fix_guidance: "x"
+
+patterns:
+  - name: bad_sev
+    severity: fatal
+    description: "Bad severity"
+    regex:
+      - 'test'
+    fixes:
+      - "Fix"
+"""
+        _write_yaml(tmp_path, 'bad.yaml', bad_yaml)
+        with pytest.raises(ValueError, match="invalid severity 'fatal'"):
+            _load_patterns_from_yaml(tmp_path)
+
+
+class TestShippedPatterns:
+    """Integration tests for the actual shipped YAML pattern files."""
+
+    def test_patterns_loaded_successfully(self):
+        assert len(BOOT_ERROR_PATTERNS) > 0
+
+    def test_all_patterns_are_boot_error_pattern(self):
+        for pattern in BOOT_ERROR_PATTERNS:
+            assert isinstance(pattern, BootErrorPattern)
+
+    def test_fix_guidance_has_entries(self):
+        assert len(CATEGORY_FIX_GUIDANCE) > 0
+
+    def test_fstab_patterns_present(self):
+        fstab_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'fstab']
+        assert len(fstab_patterns) == 5
+
+    def test_fstab_fix_guidance_present(self):
+        assert 'fstab' in CATEGORY_FIX_GUIDANCE
+
+    def test_all_patterns_have_valid_severity(self):
+        for pattern in BOOT_ERROR_PATTERNS:
+            assert pattern.severity in {'critical', 'error', 'warning'}
+
+    def test_all_patterns_have_compilable_regex(self):
+        import re
+        for pattern in BOOT_ERROR_PATTERNS:
+            for regex in pattern.patterns:
+                re.compile(regex)  # Should not raise

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -1,0 +1,1087 @@
+"""Tests for the repair command: orchestrator, CLI, script generation, result parsing."""
+
+import time
+import logging
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+
+from gce_rescue_v2.orchestration.repair import (
+    RepairOrchestrator,
+    SUPPORTED_FIX_CATEGORIES,
+    REPAIR_LINE_MARKER,
+    REPAIR_RESULT_MARKER,
+    RESCUE_COMPLETE_MARKER,
+    RESCUE_SUBSTEP_LABELS,
+    RESTORE_SUBSTEP_LABELS,
+)
+from gce_rescue_v2.orchestration.rescue import RescueOrchestrator
+from gce_rescue_v2.orchestration.restore import RestoreOrchestrator
+from gce_rescue_v2.core.config import RescueConfig
+from gce_rescue_v2.operations.base import OperationResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers / Fakes
+# ---------------------------------------------------------------------------
+
+class _Exec:
+    def __init__(self, value=None):
+        self._value = value
+
+    def execute(self):
+        return self._value
+
+
+def _make_compute(vm_info=None, serial_output=''):
+    """Create a minimal fake compute client."""
+    compute = Mock()
+
+    if vm_info is None:
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/original-boot',
+                'deviceName': 'original-boot',
+                'licenses': ['projects/debian-cloud/global/licenses/debian-12'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+
+    compute.instances.return_value.get.return_value.execute.return_value = vm_info
+    compute.instances.return_value.getSerialPortOutput.return_value.execute.return_value = {
+        'contents': serial_output
+    }
+    return compute
+
+
+def _make_logger():
+    logger = logging.getLogger('test_repair')
+    logger.setLevel(logging.DEBUG)
+    logger.console_level = logging.WARNING
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# TestRepairOrchestrator
+# ---------------------------------------------------------------------------
+
+class TestRepairOrchestrator:
+    """Core orchestrator logic."""
+
+    def test_validate_linux_passes(self):
+        """Validation should pass for a Linux VM."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        with patch.object(orch, 'validate', return_value=True):
+            assert orch.validate() is True
+
+    def test_validate_windows_rejected(self):
+        """Windows VMs should be rejected by validate()."""
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/win-disk',
+                'deviceName': 'win-disk',
+                'licenses': ['projects/windows-cloud/global/licenses/windows-server-2022'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        # Patch out the rescue validation to isolate OS check
+        with patch(
+            'gce_rescue_v2.orchestration.repair.RescueOrchestrator.validate',
+            return_value=True
+        ):
+            with patch.object(orch, '_create_tracked_client', return_value=compute):
+                assert orch.validate() is False
+
+    def test_diagnose_returns_dict(self):
+        """diagnose() should return a diagnosis dict on success."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        mock_result = OperationResult(
+            operation_name='Diagnose VM',
+            success=True,
+            message='Found 1 boot error(s)',
+            rollback_data={
+                'vm_name': 'vm-1',
+                'zone': 'zone-a',
+                'boot_errors': [{'category': 'fstab', 'severity': 'critical'}],
+                'diagnosis_status': 'boot_errors_detected',
+            }
+        )
+        with patch(
+            'gce_rescue_v2.orchestration.repair.DiagnoseOperation.execute',
+            return_value=mock_result
+        ):
+            result = orch.diagnose()
+            assert result is not None
+            assert len(result['boot_errors']) == 1
+
+    def test_diagnose_returns_none_on_failure(self):
+        """diagnose() should return None when diagnosis fails."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        mock_result = OperationResult(
+            operation_name='Diagnose VM',
+            success=False,
+            message='Serial console disabled',
+            rollback_data={}
+        )
+        with patch(
+            'gce_rescue_v2.orchestration.repair.DiagnoseOperation.execute',
+            return_value=mock_result
+        ):
+            assert orch.diagnose() is None
+
+    def test_get_fixable_categories(self):
+        """Should return only categories with fix scripts."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        diagnosis = {
+            'boot_errors': [
+                {'category': 'fstab', 'severity': 'critical'},
+                {'category': 'grub', 'severity': 'error'},
+                {'category': 'fstab', 'severity': 'warning'},  # duplicate
+            ]
+        }
+        fixable = orch.get_fixable_categories(diagnosis)
+        assert fixable == ['fstab']
+
+    def test_get_unfixable_categories(self):
+        """Should return categories without fix scripts."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        diagnosis = {
+            'boot_errors': [
+                {'category': 'fstab', 'severity': 'critical'},
+                {'category': 'grub', 'severity': 'error'},
+                {'category': 'kernel', 'severity': 'error'},
+            ]
+        }
+        unfixable = orch.get_unfixable_categories(diagnosis)
+        assert 'grub' in unfixable
+        assert 'kernel' in unfixable
+        assert 'fstab' not in unfixable
+
+    def test_execute_no_fixable_returns_no_fix(self):
+        """execute() with no fixable categories returns no_fix status."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        diagnosis = {
+            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+        }
+        result = orch.execute(diagnosis)
+        assert result['status'] == 'no_fix'
+        assert result['fixed_count'] == 0
+
+
+# ---------------------------------------------------------------------------
+# TestRepairCLI
+# ---------------------------------------------------------------------------
+
+class TestRepairCLI:
+    """CLI argument parsing for repair command."""
+
+    def setup_method(self):
+        from gce_rescue_v2.cli import create_parser
+        self.parser = create_parser()
+
+    def test_repair_parses_basic_args(self):
+        """Repair command should parse vm name and zone."""
+        args = self.parser.parse_args([
+            'repair', 'my-vm', '--zone', 'us-central1-a'
+        ])
+        assert args.command == 'repair'
+        assert args.instance_name == 'my-vm'
+        assert args.zone == 'us-central1-a'
+
+    def test_repair_requires_zone(self):
+        """Repair should require --zone flag."""
+        with pytest.raises(SystemExit):
+            self.parser.parse_args(['repair', 'my-vm'])
+
+    def test_repair_requires_vm_name(self):
+        """Repair should require instance name."""
+        with pytest.raises(SystemExit):
+            self.parser.parse_args(['repair', '--zone', 'us-central1-a'])
+
+    def test_repair_snapshot_default_enabled(self):
+        """Snapshot should be enabled by default."""
+        args = self.parser.parse_args([
+            'repair', 'my-vm', '--zone', 'us-central1-a'
+        ])
+        assert args.snapshot is True
+
+    def test_repair_no_snapshot_flag(self):
+        """--no-snapshot should disable snapshot."""
+        args = self.parser.parse_args([
+            'repair', 'my-vm', '--zone', 'us-central1-a', '--no-snapshot'
+        ])
+        assert args.snapshot is False
+
+    def test_repair_quiet_mode(self):
+        """--quiet flag should be recognized."""
+        args = self.parser.parse_args([
+            'repair', 'my-vm', '--zone', 'us-central1-a', '--quiet'
+        ])
+        assert args.quiet is True
+
+    def test_repair_with_project(self):
+        """--project flag should work."""
+        args = self.parser.parse_args([
+            'repair', 'my-vm', '--zone', 'us-central1-a', '--project', 'my-proj'
+        ])
+        assert args.project == 'my-proj'
+
+
+# ---------------------------------------------------------------------------
+# TestRepairScript
+# ---------------------------------------------------------------------------
+
+class TestRepairScript:
+    """Script generation tests."""
+
+    def _make_orchestrator(self):
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/test-boot-disk',
+                'deviceName': 'test-boot-disk',
+                'licenses': ['projects/debian-cloud/global/licenses/debian-12'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        # Patch _create_tracked_client to return mock compute (no real credentials)
+        orch._create_tracked_client = lambda label: compute
+        return orch
+
+    def test_script_contains_disk_placeholder_replaced(self):
+        """Generated script should replace DISK_NAME_PLACEHOLDER."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+        script = orch._generate_repair_script(diagnosis)
+        assert 'DISK_NAME_PLACEHOLDER' not in script
+        assert 'test-boot-disk' in script
+
+    def test_script_contains_fix_script(self):
+        """Generated script should contain fstab fix logic."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+        script = orch._generate_repair_script(diagnosis)
+        assert 'GCE-REPAIR-LINE' in script
+        assert 'GCE-REPAIR-RESULT' in script
+        assert 'fstab' in script.lower()
+
+    def test_completion_marker_at_end(self):
+        """GCE-RESCUE-COMPLETE should be at the end, not in the middle."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+        script = orch._generate_repair_script(diagnosis)
+
+        # Find all occurrences of the marker
+        lines = script.split('\n')
+        marker_lines = [
+            i for i, line in enumerate(lines)
+            if RESCUE_COMPLETE_MARKER in line and 'moved to end' not in line
+        ]
+        assert len(marker_lines) >= 1
+        # The active marker should be near the end (last 5 lines)
+        assert marker_lines[-1] > len(lines) - 6
+
+    def test_original_marker_commented_out(self):
+        """Original completion marker in rescue_mount.sh should be commented."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+        script = orch._generate_repair_script(diagnosis)
+        assert 'marker moved to end' in script
+
+    def test_unsupported_category_not_included(self):
+        """Fix script for unsupported category should not be injected."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+        }
+        # No fixable categories, _generate_repair_script won't be called normally
+        # but let's test _get_fix_script directly
+        assert orch._get_fix_script('grub') is None
+
+
+# ---------------------------------------------------------------------------
+# TestRepairResultParsing
+# ---------------------------------------------------------------------------
+
+class TestRepairResultParsing:
+    """Parsing of structured markers from serial console."""
+
+    def _make_orchestrator(self, serial_output=''):
+        compute = _make_compute(serial_output=serial_output)
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        # Patch _create_tracked_client to return mock compute (no real credentials)
+        orch._create_tracked_client = lambda label: compute
+        return orch
+
+    def test_parse_success_result(self):
+        """Should parse SUCCESS result with fix count."""
+        serial = (
+            "some boot output\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: Commented out invalid UUID for /data\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'success'
+        assert result['fixed_count'] == 1
+        assert len(result['fix_lines']) == 1
+        assert '/data' in result['fix_lines'][0]
+
+    def test_parse_no_issues_result(self):
+        """Should parse NO_ISSUES result."""
+        serial = (
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'no_issues'
+        assert result['fixed_count'] == 0
+
+    def test_parse_failed_result(self):
+        """Should parse FAILED result with reason."""
+        serial = "GCE-REPAIR-RESULT:FAILED:fstab not found\n"
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'failed'
+        assert 'fstab not found' in result['error']
+
+    def test_parse_multiple_fix_lines(self):
+        """Should parse multiple fix lines."""
+        serial = (
+            "GCE-REPAIR-LINE:[FIXED] fstab: UUID for /data\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: device /dev/sdb1\n"
+            "GCE-REPAIR-RESULT:SUCCESS:2\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['fixed_count'] == 2
+        assert len(result['fix_lines']) == 2
+
+    def test_parse_no_markers(self):
+        """Should return unknown status when no markers found."""
+        serial = "just some boot output\n"
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'unknown'
+        assert result['fixed_count'] == 0
+
+    def test_parse_serial_console_error(self):
+        """Should handle serial console fetch failure gracefully."""
+        compute = Mock()
+        compute.instances.return_value.getSerialPortOutput.return_value.execute.side_effect = Exception("API error")
+        compute.instances.return_value.get.return_value.execute.return_value = {}
+
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        # Patch _create_tracked_client to return mock compute (no real credentials)
+        orch._create_tracked_client = lambda label: compute
+        result = orch._parse_repair_results()
+        assert result['status'] == 'unknown'
+        assert result['error'] is not None
+
+
+# ---------------------------------------------------------------------------
+# TestFstabFixScript
+# ---------------------------------------------------------------------------
+
+class TestFstabFixScript:
+    """Validate that the fstab fix script file is well-formed."""
+
+    def test_fix_script_exists(self):
+        """fstab_fix.sh should exist in startup_scripts/fixes/."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        assert fix_path.exists(), f"Fix script not found at {fix_path}"
+
+    def test_fix_script_emits_repair_markers(self):
+        """Script should emit GCE-REPAIR-LINE and GCE-REPAIR-RESULT markers."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert 'GCE-REPAIR-LINE:' in content
+        assert 'GCE-REPAIR-RESULT:' in content
+
+    def test_fix_script_creates_backup(self):
+        """Script should create a backup of fstab."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert 'gce-repair-backup' in content
+
+    def test_fix_script_handles_virtual_fs(self):
+        """Script should skip virtual filesystem types."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert 'proc' in content
+        assert 'tmpfs' in content
+        assert 'sysfs' in content
+
+    def test_fix_script_checks_uuid(self):
+        """Script should check UUID= entries against blkid."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert 'UUID=' in content
+        assert 'blkid' in content
+
+    def test_fix_script_handles_device_paths(self):
+        """Script should check /dev/ entries."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert '/dev/' in content
+
+    def test_fix_script_handles_labels(self):
+        """Script should check LABEL= entries."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert 'LABEL=' in content
+
+    def test_fix_script_detects_malformed_entries(self):
+        """Script should detect entries with fewer than 3 fields."""
+        fix_path = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'fstab_fix.sh'
+        )
+        content = fix_path.read_text()
+        assert 'malformed' in content.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestSupportedCategories
+# ---------------------------------------------------------------------------
+
+class TestSupportedCategories:
+    """Verify supported fix categories are consistent."""
+
+    def test_fstab_is_supported(self):
+        assert 'fstab' in SUPPORTED_FIX_CATEGORIES
+
+    def test_grub_is_not_supported(self):
+        assert 'grub' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_fix_script_exists_for_each_supported_category(self):
+        """Every supported category should have a corresponding fix script."""
+        fixes_dir = (
+            Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
+        )
+        for cat in SUPPORTED_FIX_CATEGORIES:
+            script_path = fixes_dir / f'{cat}_fix.sh'
+            assert script_path.exists(), (
+                f"Missing fix script for supported category '{cat}': {script_path}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestRepairProgressCallback
+# ---------------------------------------------------------------------------
+
+class TestRepairProgressCallback:
+    """Progress callback integration between repair and rescue/restore."""
+
+    def test_rescue_invokes_callback(self):
+        """Rescue _update_progress should invoke the callback with the step label."""
+        compute = _make_compute()
+        received = []
+        rescue = RescueOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1',
+            logger=_make_logger(), suppress_progress=True,
+            progress_callback=lambda label: received.append(label)
+        )
+        rescue._progress_lock = __import__('threading').Lock()
+        rescue._update_progress('Stopping')
+        rescue._update_progress('Starting')
+        assert received == ['Stopping', 'Starting']
+
+    def test_restore_invokes_callback(self):
+        """Restore _update_progress should invoke the callback with the step label."""
+        compute = _make_compute()
+        received = []
+        restore = RestoreOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1',
+            logger=_make_logger(), suppress_progress=True,
+            progress_callback=lambda label: received.append(label)
+        )
+        restore._progress_lock = __import__('threading').Lock()
+        restore._update_progress('Stopping')
+        restore._update_progress('Restoring affected disk')
+        assert received == ['Stopping', 'Restoring affected disk']
+
+    def test_no_callback_by_default(self):
+        """No error when progress_callback is None (default)."""
+        compute = _make_compute()
+        rescue = RescueOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1',
+            logger=_make_logger(), suppress_progress=True
+        )
+        rescue._progress_lock = __import__('threading').Lock()
+        # Should not raise
+        rescue._update_progress('Stopping')
+
+    def test_make_progress_callback_maps_labels(self):
+        """Callback from _make_progress_callback should map raw labels to display names."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._progress_lock = __import__('threading').Lock()
+        cb = orch._make_progress_callback("Rescue", RESCUE_SUBSTEP_LABELS)
+
+        cb('Stopping')
+        assert orch._current_phase == 'Rescue'
+        assert orch._current_substep == 'Stopping VM'
+
+        cb('Starting')
+        assert orch._current_substep == 'Starting rescue VM'
+
+    def test_unknown_label_passthrough(self):
+        """Unmapped labels should pass through unchanged."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._progress_lock = __import__('threading').Lock()
+        cb = orch._make_progress_callback("Rescue", RESCUE_SUBSTEP_LABELS)
+
+        cb('SomeNewStep')
+        assert orch._current_substep == 'SomeNewStep'
+
+
+# ---------------------------------------------------------------------------
+# TestRepairExecuteReturnValues
+# ---------------------------------------------------------------------------
+
+class TestRepairExecuteReturnValues:
+    """Tests for execute() method return values including snapshot_name and duration."""
+
+    def test_execute_no_fixable_returns_snapshot_name_none(self):
+        """execute() with no fixable categories should return snapshot_name=None."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        diagnosis = {
+            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+        }
+        result = orch.execute(diagnosis)
+        assert result['snapshot_name'] is None
+        assert 'duration_seconds' in result
+
+    def test_execute_returns_duration_seconds(self):
+        """execute() should return duration_seconds in all return paths."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        diagnosis = {
+            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+        }
+        result = orch.execute(diagnosis)
+        assert 'duration_seconds' in result
+        assert result['duration_seconds'] >= 0
+        assert isinstance(result['duration_seconds'], (int, float))
+
+    def test_execute_duration_captured_on_success(self):
+        """execute() should capture duration even for quick operations."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        diagnosis = {
+            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+        }
+        result = orch.execute(diagnosis)
+        # Duration should be captured for no_fix result
+        assert 'duration_seconds' in result
+        assert isinstance(result['duration_seconds'], (int, float))
+        assert result['duration_seconds'] >= 0
+
+
+# ---------------------------------------------------------------------------
+# TestRepairResumeMethod
+# ---------------------------------------------------------------------------
+
+class TestRepairResumeMethod:
+    """Tests for resume() method: parse results + restore without rescue."""
+
+    def _make_resume_orchestrator(self, snapshot_name=None):
+        """Create orchestrator with mocked snapshot lookup for resume tests."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._progress_lock = __import__('threading').Lock()
+        orch._progress_started = False
+        orch._find_rescue_snapshot = lambda: snapshot_name
+        orch._create_tracked_client = lambda label: compute
+        return orch
+
+    def test_resume_sets_total_steps_to_2(self):
+        """resume() should set _total_steps=2 (skips rescue)."""
+        orch = self._make_resume_orchestrator()
+        assert orch._total_steps == 3  # Default
+
+        with patch.object(orch, '_parse_repair_results', return_value={'status': 'success', 'fixed_count': 1, 'fix_lines': [], 'error': None}):
+            with patch.object(orch, '_init_progress'):
+                with patch.object(orch, '_update_progress'):
+                    with patch.object(orch, '_finish_progress'):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                            mock_restore = MagicMock()
+                            mock_restore.execute.return_value = True
+                            mock_restore_class.return_value = mock_restore
+
+                            orch.resume()
+                            assert orch._total_steps == 2
+
+    def test_resume_skips_rescue_phase(self):
+        """resume() should not create a RescueOrchestrator."""
+        orch = self._make_resume_orchestrator()
+
+        with patch.object(orch, '_parse_repair_results', return_value={'status': 'success', 'fixed_count': 1, 'fix_lines': [], 'error': None}):
+            with patch.object(orch, '_init_progress'):
+                with patch.object(orch, '_update_progress'):
+                    with patch.object(orch, '_finish_progress'):
+                        with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator') as mock_rescue_class:
+                            with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                                mock_restore = MagicMock()
+                                mock_restore.execute.return_value = True
+                                mock_restore_class.return_value = mock_restore
+
+                                orch.resume()
+                                mock_rescue_class.assert_not_called()
+
+    def test_resume_returns_dict_with_required_keys(self):
+        """resume() should return dict with status, fixed_count, fix_lines, etc."""
+        orch = self._make_resume_orchestrator()
+
+        with patch.object(orch, '_parse_repair_results', return_value={'status': 'success', 'fixed_count': 1, 'fix_lines': ['Fixed UUID'], 'error': None}):
+            with patch.object(orch, '_init_progress'):
+                with patch.object(orch, '_update_progress'):
+                    with patch.object(orch, '_finish_progress'):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                            mock_restore = MagicMock()
+                            mock_restore.execute.return_value = True
+                            mock_restore_class.return_value = mock_restore
+
+                            result = orch.resume()
+                            assert 'status' in result
+                            assert 'fixed_count' in result
+                            assert 'fix_lines' in result
+                            assert 'error' in result
+                            assert 'snapshot_name' in result
+                            assert 'duration_seconds' in result
+
+    def test_resume_finds_snapshot_name(self):
+        """resume() should include snapshot name from _find_rescue_snapshot."""
+        orch = self._make_resume_orchestrator(
+            snapshot_name='pre-rescue-original-boot-1234567890'
+        )
+
+        with patch.object(orch, '_parse_repair_results', return_value={'status': 'success', 'fixed_count': 1, 'fix_lines': [], 'error': None}):
+            with patch.object(orch, '_init_progress'):
+                with patch.object(orch, '_update_progress'):
+                    with patch.object(orch, '_finish_progress'):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                            mock_restore = MagicMock()
+                            mock_restore.execute.return_value = True
+                            mock_restore_class.return_value = mock_restore
+
+                            result = orch.resume()
+                            assert result['snapshot_name'] == 'pre-rescue-original-boot-1234567890'
+
+    def test_resume_snapshot_none_when_not_found(self):
+        """resume() should set snapshot_name=None when no snapshot found."""
+        orch = self._make_resume_orchestrator(snapshot_name=None)
+
+        with patch.object(orch, '_parse_repair_results', return_value={'status': 'success', 'fixed_count': 1, 'fix_lines': [], 'error': None}):
+            with patch.object(orch, '_init_progress'):
+                with patch.object(orch, '_update_progress'):
+                    with patch.object(orch, '_finish_progress'):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                            mock_restore = MagicMock()
+                            mock_restore.execute.return_value = True
+                            mock_restore_class.return_value = mock_restore
+
+                            result = orch.resume()
+                            assert result['snapshot_name'] is None
+
+
+# ---------------------------------------------------------------------------
+# TestRescueSubstepLabels
+# ---------------------------------------------------------------------------
+
+class TestRescueSubstepLabels:
+    """Tests for RESCUE_SUBSTEP_LABELS mapping."""
+
+    def test_attaching_disk_label_changed_to_mounting(self):
+        """'Attaching affected disk' should map to 'Mounting disk'."""
+        assert RESCUE_SUBSTEP_LABELS['Attaching affected disk'] == 'Mounting disk'
+
+    def test_all_substep_labels_are_user_friendly(self):
+        """All labels should be user-friendly, not raw step names."""
+        for raw, display in RESCUE_SUBSTEP_LABELS.items():
+            # Display name should be capitalized and more readable
+            assert display[0].isupper()
+            # Should not contain technical jargon
+            assert 'Stopping' in display or 'Creating' in display or 'Starting' in display or 'Mounting' in display
+
+
+# ---------------------------------------------------------------------------
+# TestRepairMountFailure
+# ---------------------------------------------------------------------------
+
+class TestRepairMountFailure:
+    """Tests for the mount failure path during repair."""
+
+    def test_mount_failed_leaves_vm_in_rescue(self):
+        """If startup script doesn't complete, status should be mount_failed."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = True
+        mock_rescue.snapshot_name = 'pre-rescue-boot-123'
+        mock_rescue.verification_succeeded = False  # Mount failed
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator', return_value=mock_rescue):
+                        result = orch.execute(diagnosis)
+
+        assert result['status'] == 'mount_failed'
+        assert result['fixed_count'] == 0
+        assert result['snapshot_name'] == 'pre-rescue-boot-123'
+
+    def test_mount_failed_does_not_restore(self):
+        """Mount failure should NOT trigger restore (VM stays in rescue mode)."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = True
+        mock_rescue.snapshot_name = None
+        mock_rescue.verification_succeeded = False
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator', return_value=mock_rescue):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                            orch.execute(diagnosis)
+                            # RestoreOrchestrator should never have been created
+                            mock_restore_class.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestRepairRescueFailure
+# ---------------------------------------------------------------------------
+
+class TestRepairRescueFailure:
+    """Tests for rescue phase failure during repair."""
+
+    def test_rescue_failed_returns_rescue_failed(self):
+        """If rescue phase fails, status should be rescue_failed."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = False  # Rescue failed
+        mock_rescue.snapshot_name = 'pre-rescue-boot-123'
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator', return_value=mock_rescue):
+                        result = orch.execute(diagnosis)
+
+        assert result['status'] == 'rescue_failed'
+        assert result['fixed_count'] == 0
+        assert result['snapshot_name'] == 'pre-rescue-boot-123'
+        assert 'duration_seconds' in result
+
+    def test_rescue_failed_does_not_restore(self):
+        """Rescue failure should NOT trigger restore."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = False
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator', return_value=mock_rescue):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator') as mock_restore_class:
+                            orch.execute(diagnosis)
+                            mock_restore_class.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestRepairRestoreFailure
+# ---------------------------------------------------------------------------
+
+class TestRepairRestoreFailure:
+    """Tests for restore phase failure during repair."""
+
+    def test_restore_failed_returns_restore_failed(self):
+        """If restore phase fails, status should be restore_failed."""
+        compute = _make_compute(serial_output=(
+            "GCE-REPAIR-LINE:[FIXED] fstab: Commented out bad entry\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-RESCUE-COMPLETE\n"
+        ))
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = True
+        mock_rescue.snapshot_name = 'pre-rescue-boot-123'
+        mock_rescue.verification_succeeded = True
+
+        mock_restore = MagicMock()
+        mock_restore.execute.return_value = False  # Restore failed
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator', return_value=mock_rescue):
+                        with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator', return_value=mock_restore):
+                            result = orch.execute(diagnosis)
+
+        assert result['status'] == 'restore_failed'
+        assert result['fixed_count'] == 1  # Fix was applied
+        assert result['snapshot_name'] == 'pre-rescue-boot-123'
+
+
+# ---------------------------------------------------------------------------
+# TestRepairResumeRestoreFailure
+# ---------------------------------------------------------------------------
+
+class TestRepairResumeRestoreFailure:
+    """Tests for restore failure during resume path."""
+
+    def test_resume_restore_failed(self):
+        """resume() with restore failure should return restore_failed."""
+        compute = _make_compute(serial_output=(
+            "GCE-REPAIR-LINE:[FIXED] fstab: Commented out bad entry\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+        ))
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        orch._find_rescue_snapshot = lambda: 'pre-rescue-boot-123'
+        orch._progress_lock = __import__('threading').Lock()
+        orch._progress_started = False
+
+        mock_restore = MagicMock()
+        mock_restore.execute.return_value = False
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator', return_value=mock_restore):
+                        result = orch.resume()
+
+        assert result['status'] == 'restore_failed'
+        assert result['snapshot_name'] == 'pre-rescue-boot-123'
+
+    def test_resume_unexpected_error(self):
+        """resume() should handle unexpected exceptions gracefully."""
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        orch._find_rescue_snapshot = lambda: None
+        orch._progress_lock = __import__('threading').Lock()
+        orch._progress_started = False
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch.object(orch, '_parse_repair_results', side_effect=RuntimeError("API timeout")):
+                        result = orch.resume()
+
+        assert result['status'] == 'error'
+        assert 'API timeout' in result['error']
+        assert 'duration_seconds' in result
+
+
+# ---------------------------------------------------------------------------
+# TestFindRescueSnapshot
+# ---------------------------------------------------------------------------
+
+class TestFindRescueSnapshot:
+    """Tests for _find_rescue_snapshot helper."""
+
+    def test_finds_snapshot_from_metadata(self):
+        """Should find snapshot matching original disk name from metadata."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [],
+            'metadata': {
+                'items': [
+                    {'key': 'rescue-mode', 'value': '1234567890'},
+                    {'key': 'rescue-original-disk', 'value': 'boot-disk'},
+                ],
+                'fingerprint': 'abc'
+            },
+        }
+        compute = _make_compute(vm_info=vm_info)
+        # Mock snapshots.list
+        compute.snapshots.return_value.list.return_value.execute.return_value = {
+            'items': [
+                {'name': 'pre-rescue-boot-disk-1111111111', 'creationTimestamp': '2025-01-01T00:00:00Z'},
+                {'name': 'pre-rescue-boot-disk-2222222222', 'creationTimestamp': '2025-01-02T00:00:00Z'},
+            ]
+        }
+
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        result = orch._find_rescue_snapshot()
+        # Should return the most recent one
+        assert result == 'pre-rescue-boot-disk-2222222222'
+
+    def test_no_metadata_returns_none(self):
+        """Should return None when rescue-original-disk not in metadata."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info=vm_info)
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        assert orch._find_rescue_snapshot() is None
+
+    def test_no_matching_snapshots_returns_none(self):
+        """Should return None when no matching snapshots exist."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [],
+            'metadata': {
+                'items': [
+                    {'key': 'rescue-original-disk', 'value': 'boot-disk'},
+                ],
+                'fingerprint': 'abc'
+            },
+        }
+        compute = _make_compute(vm_info=vm_info)
+        compute.snapshots.return_value.list.return_value.execute.return_value = {
+            'items': []
+        }
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        assert orch._find_rescue_snapshot() is None
+
+    def test_api_error_returns_none(self):
+        """Should return None gracefully on API error."""
+        compute = _make_compute()
+        compute.instances.return_value.get.return_value.execute.side_effect = (
+            Exception("API error")
+        )
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+
+        assert orch._find_rescue_snapshot() is None

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -1,0 +1,377 @@
+"""Tests for DiagnosisReportFormatter."""
+
+import pytest
+from unittest.mock import patch
+from gce_rescue_v2.utils.report_formatter import DiagnosisReportFormatter
+
+
+@pytest.fixture
+def formatter():
+    return DiagnosisReportFormatter()
+
+
+@pytest.fixture
+def healthy_diagnosis():
+    return {
+        'vm_name': 'test-vm',
+        'zone': 'us-central1-a',
+        'status': 'RUNNING',
+        'diagnosis_status': 'healthy',
+        'boot_errors': [],
+        'recommendations': [
+            'No boot errors detected in serial console output',
+            'VM appears to be booting normally',
+            'VM is currently running',
+        ],
+    }
+
+
+@pytest.fixture
+def healthy_terminated_diagnosis():
+    return {
+        'vm_name': 'test-vm',
+        'zone': 'us-central1-a',
+        'status': 'TERMINATED',
+        'diagnosis_status': 'healthy',
+        'boot_errors': [],
+        'recommendations': [
+            'No boot errors detected in serial console output',
+            'VM appears to be booting normally',
+            'Note: VM is currently stopped',
+        ],
+    }
+
+
+@pytest.fixture
+def single_error_diagnosis():
+    return {
+        'vm_name': 'test-vm',
+        'zone': 'us-central1-a',
+        'status': 'TERMINATED',
+        'diagnosis_status': 'boot_errors_detected',
+        'boot_errors': [
+            {
+                'category': 'fstab',
+                'severity': 'critical',
+                'description': 'UUID specified in /etc/fstab cannot be found',
+                'detected_pattern': 'UUID=abc123-def456 does not exist',
+                'suggested_fixes': [
+                    "Check /mnt/sysroot/etc/fstab for invalid UUID entries",
+                    "Run 'blkid' to see available UUIDs",
+                    "Comment out or fix the invalid UUID entry",
+                ],
+                'context_lines': [
+                    'systemd[1]: Starting File System Check...',
+                    'UUID=abc123-def456 does not exist',
+                    'systemd[1]: Dependency failed for /data.mount',
+                ],
+                'matched_line_index': 1,
+            }
+        ],
+        'recommendations': [
+            'Found 1 boot error(s) in serial console output',
+        ],
+    }
+
+
+@pytest.fixture
+def multi_error_diagnosis():
+    return {
+        'vm_name': 'test-vm',
+        'zone': 'us-central1-a',
+        'status': 'TERMINATED',
+        'diagnosis_status': 'boot_errors_detected',
+        'boot_errors': [
+            {
+                'category': 'fstab',
+                'severity': 'warning',
+                'description': 'Non-critical mount point failed',
+                'detected_pattern': 'mount failed for /opt',
+                'suggested_fixes': ['Check /etc/fstab'],
+                'context_lines': ['mount failed for /opt'],
+                'matched_line_index': 0,
+            },
+            {
+                'category': 'fstab',
+                'severity': 'critical',
+                'description': 'UUID specified in /etc/fstab cannot be found',
+                'detected_pattern': 'UUID=abc123 does not exist',
+                'suggested_fixes': [
+                    'Check /mnt/sysroot/etc/fstab for invalid UUID entries',
+                ],
+                'context_lines': ['UUID=abc123 does not exist'],
+                'matched_line_index': 0,
+            },
+            {
+                'category': 'filesystem',
+                'severity': 'error',
+                'description': 'Filesystem corruption detected',
+                'detected_pattern': 'UNEXPECTED INCONSISTENCY',
+                'suggested_fixes': ['Run fsck'],
+                'context_lines': ['UNEXPECTED INCONSISTENCY'],
+                'matched_line_index': 0,
+            },
+        ],
+        'recommendations': [],
+    }
+
+
+@pytest.fixture
+def unable_diagnosis():
+    return {
+        'vm_name': 'test-vm',
+        'zone': 'us-central1-a',
+        'status': 'RUNNING',
+        'diagnosis_status': 'unable_to_diagnose',
+        'boot_errors': [],
+        'recommendations': [
+            'Serial console is disabled for this VM',
+            'Enable it with: gcloud compute instances add-metadata VM_NAME --metadata serial-port-enable=TRUE',
+        ],
+    }
+
+
+class TestHealthyReport:
+    """Tests for healthy VM reports."""
+
+    def test_healthy_running_is_compact(self, formatter, healthy_diagnosis):
+        """Healthy running VM should be 3 lines."""
+        report = formatter.format_report(healthy_diagnosis)
+        lines = [l for l in report.split('\n') if l.strip()]
+        assert len(lines) == 3
+
+    def test_healthy_contains_header(self, formatter, healthy_diagnosis):
+        """Healthy report should have Diagnosis/Status/Result header."""
+        report = formatter.format_report(healthy_diagnosis)
+        assert 'Diagnosis: test-vm (us-central1-a)' in report
+        assert 'Status:    RUNNING' in report
+        assert 'No boot issues detected' in report
+
+    def test_healthy_no_borders(self, formatter, healthy_diagnosis):
+        """Healthy report should not contain ===== borders."""
+        report = formatter.format_report(healthy_diagnosis)
+        assert '=====' not in report
+
+    def test_healthy_terminated_shows_start_hint(
+        self, formatter, healthy_terminated_diagnosis
+    ):
+        """Terminated healthy VM should show start command."""
+        report = formatter.format_report(healthy_terminated_diagnosis)
+        assert 'VM is currently stopped' in report
+        assert 'gcloud compute instances start test-vm' in report
+
+
+class TestErrorsReport:
+    """Tests for error report formatting."""
+
+    def test_single_error_header(self, formatter, single_error_diagnosis):
+        """Single error report should have correct result line."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert '1 issue found (1 critical)' in report
+
+    def test_single_error_uses_singular(self, formatter, single_error_diagnosis):
+        """Single error should say 'this issue' not 'these issues'."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'To fix this issue:' in report
+
+    def test_multi_error_uses_plural(self, formatter, multi_error_diagnosis):
+        """Multiple errors should say 'these issues'."""
+        report = formatter.format_report(multi_error_diagnosis)
+        assert 'To fix these issues:' in report
+
+    def test_severity_sorting(self, formatter, multi_error_diagnosis):
+        """Errors should be sorted: critical first, then error, then warning."""
+        report = formatter.format_report(multi_error_diagnosis)
+        # Find positions of each severity
+        critical_pos = report.find('CRITICAL')
+        error_pos = report.find('ERROR')
+        warning_pos = report.find('WARNING')
+        assert critical_pos < error_pos < warning_pos
+
+    def test_severity_count_breakdown(self, formatter, multi_error_diagnosis):
+        """Result line should show severity counts."""
+        report = formatter.format_report(multi_error_diagnosis)
+        assert '3 issues found (1 critical, 1 error, 1 warning)' in report
+
+    def test_context_arrow_on_matched_line(self, formatter, single_error_diagnosis):
+        """The matched line in context should have a <-- arrow."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'UUID=abc123-def456 does not exist  <--' in report
+
+    def test_non_matched_context_no_arrow(self, formatter, single_error_diagnosis):
+        """Non-matched context lines should NOT have <-- arrow."""
+        report = formatter.format_report(single_error_diagnosis)
+        for line in report.split('\n'):
+            if 'Starting File System Check' in line:
+                assert '<--' not in line
+
+    def test_rescue_command_in_fix_section(self, formatter, single_error_diagnosis):
+        """Fix section should contain rescue command exactly once."""
+        report = formatter.format_report(single_error_diagnosis)
+        rescue_count = report.count('gce-rescue rescue test-vm')
+        assert rescue_count == 1
+
+    def test_restore_command_in_fix_section(self, formatter, single_error_diagnosis):
+        """Fix section should contain restore command."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'gce-rescue restore test-vm --zone=us-central1-a' in report
+
+    def test_no_borders(self, formatter, single_error_diagnosis):
+        """Error report should not contain ===== borders."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert '=====' not in report
+
+    def test_category_label_in_brackets(self, formatter, single_error_diagnosis):
+        """Error should show category in brackets like [FSTAB]."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert '[FSTAB]' in report
+
+    def test_multi_category_fix_section(self, formatter, multi_error_diagnosis):
+        """Multiple categories should list each fix guidance."""
+        report = formatter.format_report(multi_error_diagnosis)
+        assert 'Repair boot configuration:' in report
+        assert 'fstab' in report.lower()
+        assert 'filesystem' in report.lower()
+
+    def test_serial_console_label(self, formatter, single_error_diagnosis):
+        """Context section should be labeled 'Serial console:'."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'Serial console:' in report
+        assert 'Context:' not in report
+
+
+class TestArrowPlacement:
+    """Tests that the <-- arrow is placed by index, not substring match."""
+
+    def test_arrow_on_correct_index(self, formatter):
+        """Arrow should appear on matched_line_index, not substring match."""
+        diagnosis = {
+            'vm_name': 'test-vm',
+            'zone': 'us-central1-a',
+            'status': 'TERMINATED',
+            'diagnosis_status': 'boot_errors_detected',
+            'boot_errors': [
+                {
+                    'category': 'fstab',
+                    'severity': 'critical',
+                    'description': 'Test error',
+                    'detected_pattern': 'some regex match',
+                    'suggested_fixes': ['Fix it'],
+                    'context_lines': [
+                        'line before',
+                        'the actual matched line from serial',
+                        'line after',
+                    ],
+                    'matched_line_index': 1,
+                }
+            ],
+            'recommendations': [],
+        }
+        report = formatter.format_report(diagnosis)
+        for line in report.split('\n'):
+            if 'the actual matched line' in line:
+                assert '<--' in line
+            if 'line before' in line:
+                assert '<--' not in line
+            if 'line after' in line:
+                assert '<--' not in line
+
+    def test_no_arrow_when_index_missing(self, formatter):
+        """No arrow should appear if matched_line_index is -1."""
+        diagnosis = {
+            'vm_name': 'test-vm',
+            'zone': 'us-central1-a',
+            'status': 'TERMINATED',
+            'diagnosis_status': 'boot_errors_detected',
+            'boot_errors': [
+                {
+                    'category': 'fstab',
+                    'severity': 'critical',
+                    'description': 'Test error',
+                    'detected_pattern': 'something',
+                    'suggested_fixes': ['Fix it'],
+                    'context_lines': ['line A', 'line B'],
+                    'matched_line_index': -1,
+                }
+            ],
+            'recommendations': [],
+        }
+        report = formatter.format_report(diagnosis)
+        # No line in Serial console section should have <--
+        in_serial = False
+        for line in report.split('\n'):
+            if 'Serial console:' in line:
+                in_serial = True
+                continue
+            if in_serial and 'Fix:' in line:
+                break
+            if in_serial:
+                assert '<--' not in line
+
+
+class TestUnableReport:
+    """Tests for unable-to-diagnose reports."""
+
+    def test_unable_shows_result(self, formatter, unable_diagnosis):
+        """Unable report should show 'Unable to diagnose'."""
+        report = formatter.format_report(unable_diagnosis)
+        assert 'Unable to diagnose' in report
+
+    def test_unable_shows_recommendations(self, formatter, unable_diagnosis):
+        """Unable report should display recommendations."""
+        report = formatter.format_report(unable_diagnosis)
+        assert 'Serial console is disabled' in report
+
+    def test_unable_placeholder_replacement(self, formatter, unable_diagnosis):
+        """VM_NAME placeholder in recommendations should be replaced."""
+        report = formatter.format_report(unable_diagnosis)
+        assert 'VM_NAME' not in report
+        assert 'test-vm' in report
+
+    def test_unable_shows_retry_hint(self, formatter, unable_diagnosis):
+        """Unable report should show how to retry diagnosis."""
+        report = formatter.format_report(unable_diagnosis)
+        assert 'gce-rescue diagnose-boot test-vm' in report
+
+
+class TestSerialConsoleStyling:
+    """Tests for serial console log line styling."""
+
+    @patch('gce_rescue_v2.utils.colors._is_tty', return_value=True)
+    def test_log_lines_are_dimmed_on_tty(
+        self, mock_tty, formatter, single_error_diagnosis
+    ):
+        """Serial console log lines should use dim ANSI code on TTY."""
+        report = formatter.format_report(single_error_diagnosis)
+        # DIM = \033[2m should appear in the log line area
+        assert '\033[2m' in report
+
+    @patch('gce_rescue_v2.utils.colors._is_tty', return_value=False)
+    def test_log_lines_plain_when_piped(
+        self, mock_tty, formatter, single_error_diagnosis
+    ):
+        """Serial console log lines should not have ANSI when piped."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert '\033[2m' not in report
+
+
+class TestNoAnsiWhenPiped:
+    """Tests that ANSI codes are stripped when not a TTY."""
+
+    @patch('gce_rescue_v2.utils.colors._is_tty', return_value=False)
+    def test_no_ansi_in_healthy(self, mock_tty, formatter, healthy_diagnosis):
+        """No ANSI codes when piped."""
+        report = formatter.format_report(healthy_diagnosis)
+        assert '\033[' not in report
+
+    @patch('gce_rescue_v2.utils.colors._is_tty', return_value=False)
+    def test_no_ansi_in_errors(self, mock_tty, formatter, single_error_diagnosis):
+        """No ANSI codes when piped."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert '\033[' not in report
+
+    @patch('gce_rescue_v2.utils.colors._is_tty', return_value=False)
+    def test_no_ansi_in_unable(self, mock_tty, formatter, unable_diagnosis):
+        """No ANSI codes when piped."""
+        report = formatter.format_report(unable_diagnosis)
+        assert '\033[' not in report

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -16,6 +16,10 @@ def healthy_diagnosis():
         'vm_name': 'test-vm',
         'zone': 'us-central1-a',
         'status': 'RUNNING',
+        'os_type': 'linux',
+        'os_flavor': 'debian-12',
+        'architecture': 'x86_64',
+        'license_type': 'free',
         'diagnosis_status': 'healthy',
         'boot_errors': [],
         'recommendations': [
@@ -32,6 +36,10 @@ def healthy_terminated_diagnosis():
         'vm_name': 'test-vm',
         'zone': 'us-central1-a',
         'status': 'TERMINATED',
+        'os_type': 'linux',
+        'os_flavor': 'debian-12',
+        'architecture': 'x86_64',
+        'license_type': 'free',
         'diagnosis_status': 'healthy',
         'boot_errors': [],
         'recommendations': [
@@ -48,6 +56,10 @@ def single_error_diagnosis():
         'vm_name': 'test-vm',
         'zone': 'us-central1-a',
         'status': 'TERMINATED',
+        'os_type': 'linux',
+        'os_flavor': 'debian-12',
+        'architecture': 'x86_64',
+        'license_type': 'free',
         'diagnosis_status': 'boot_errors_detected',
         'boot_errors': [
             {
@@ -80,6 +92,10 @@ def multi_error_diagnosis():
         'vm_name': 'test-vm',
         'zone': 'us-central1-a',
         'status': 'TERMINATED',
+        'os_type': 'linux',
+        'os_flavor': 'rhel-9',
+        'architecture': 'x86_64',
+        'license_type': 'payg',
         'diagnosis_status': 'boot_errors_detected',
         'boot_errors': [
             {
@@ -122,6 +138,10 @@ def unable_diagnosis():
         'vm_name': 'test-vm',
         'zone': 'us-central1-a',
         'status': 'RUNNING',
+        'os_type': 'unknown',
+        'os_flavor': 'unknown',
+        'architecture': 'unknown',
+        'license_type': 'unknown',
         'diagnosis_status': 'unable_to_diagnose',
         'boot_errors': [],
         'recommendations': [
@@ -135,16 +155,17 @@ class TestHealthyReport:
     """Tests for healthy VM reports."""
 
     def test_healthy_running_is_compact(self, formatter, healthy_diagnosis):
-        """Healthy running VM should be 3 lines."""
+        """Healthy running VM should be 4 lines."""
         report = formatter.format_report(healthy_diagnosis)
         lines = [l for l in report.split('\n') if l.strip()]
-        assert len(lines) == 3
+        assert len(lines) == 4
 
     def test_healthy_contains_header(self, formatter, healthy_diagnosis):
-        """Healthy report should have Diagnosis/Status/Result header."""
+        """Healthy report should have Diagnosis/Status/OS/Result header."""
         report = formatter.format_report(healthy_diagnosis)
         assert 'Diagnosis: test-vm (us-central1-a)' in report
         assert 'Status:    RUNNING' in report
+        assert 'OS:        Linux (debian-12, x86_64, Free)' in report
         assert 'No boot issues detected' in report
 
     def test_healthy_no_borders(self, formatter, healthy_diagnosis):
@@ -249,6 +270,10 @@ class TestArrowPlacement:
             'vm_name': 'test-vm',
             'zone': 'us-central1-a',
             'status': 'TERMINATED',
+            'os_type': 'linux',
+            'os_flavor': 'debian-12',
+            'architecture': 'x86_64',
+            'license_type': 'free',
             'diagnosis_status': 'boot_errors_detected',
             'boot_errors': [
                 {
@@ -282,6 +307,10 @@ class TestArrowPlacement:
             'vm_name': 'test-vm',
             'zone': 'us-central1-a',
             'status': 'TERMINATED',
+            'os_type': 'linux',
+            'os_flavor': 'debian-12',
+            'architecture': 'x86_64',
+            'license_type': 'free',
             'diagnosis_status': 'boot_errors_detected',
             'boot_errors': [
                 {
@@ -331,7 +360,7 @@ class TestUnableReport:
     def test_unable_shows_retry_hint(self, formatter, unable_diagnosis):
         """Unable report should show how to retry diagnosis."""
         report = formatter.format_report(unable_diagnosis)
-        assert 'gce-rescue diagnose-boot test-vm' in report
+        assert 'gce-rescue diagnose test-vm' in report
 
 
 class TestSerialConsoleStyling:

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -229,13 +229,13 @@ class TestErrorsReport:
     def test_rescue_command_in_fix_section(self, formatter, single_error_diagnosis):
         """Fix section should contain rescue command exactly once."""
         report = formatter.format_report(single_error_diagnosis)
-        rescue_count = report.count('gce-rescue rescue test-vm')
+        rescue_count = report.count('gce-rescue-v2 rescue test-vm')
         assert rescue_count == 1
 
     def test_restore_command_in_fix_section(self, formatter, single_error_diagnosis):
         """Fix section should contain restore command."""
         report = formatter.format_report(single_error_diagnosis)
-        assert 'gce-rescue restore test-vm --zone=us-central1-a' in report
+        assert 'gce-rescue-v2 restore test-vm --zone=us-central1-a' in report
 
     def test_no_borders(self, formatter, single_error_diagnosis):
         """Error report should not contain ===== borders."""
@@ -360,7 +360,7 @@ class TestUnableReport:
     def test_unable_shows_retry_hint(self, formatter, unable_diagnosis):
         """Unable report should show how to retry diagnosis."""
         report = formatter.format_report(unable_diagnosis)
-        assert 'gce-rescue diagnose test-vm' in report
+        assert 'gce-rescue-v2 diagnose test-vm' in report
 
 
 class TestSerialConsoleStyling:
@@ -404,3 +404,122 @@ class TestNoAnsiWhenPiped:
         """No ANSI codes when piped."""
         report = formatter.format_report(unable_diagnosis)
         assert '\033[' not in report
+
+
+class TestSkipFixSection:
+    """Tests for skip_fix_section parameter to skip manual fix guidance."""
+
+    def test_skip_fix_section_true_omits_guidance(
+        self, formatter, single_error_diagnosis
+    ):
+        """When skip_fix_section=True, 'To fix' section should be omitted."""
+        report = formatter.format_report(
+            single_error_diagnosis, skip_fix_section=True
+        )
+        assert 'To fix this issue:' not in report
+        assert 'gce-rescue-v2 rescue' not in report
+        assert 'gce-rescue-v2 restore' not in report
+
+    def test_skip_fix_section_true_keeps_errors(
+        self, formatter, single_error_diagnosis
+    ):
+        """Even with skip_fix_section=True, error details should remain."""
+        report = formatter.format_report(
+            single_error_diagnosis, skip_fix_section=True
+        )
+        # Error details should still be there
+        assert 'UUID=abc123-def456 does not exist' in report
+        assert '[FSTAB]' in report
+        assert 'CRITICAL' in report
+
+    def test_skip_fix_section_false_includes_guidance(
+        self, formatter, single_error_diagnosis
+    ):
+        """When skip_fix_section=False (default), fix section should be present."""
+        report = formatter.format_report(
+            single_error_diagnosis, skip_fix_section=False
+        )
+        assert 'To fix this issue:' in report
+        assert 'gce-rescue-v2 rescue' in report
+
+    def test_skip_fix_section_default_includes_guidance(
+        self, formatter, single_error_diagnosis
+    ):
+        """Default behavior should include fix section."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'To fix this issue:' in report
+
+    def test_skip_fix_section_multi_error(
+        self, formatter, multi_error_diagnosis
+    ):
+        """skip_fix_section should work with multiple errors."""
+        report_with = formatter.format_report(
+            multi_error_diagnosis, skip_fix_section=False
+        )
+        report_without = formatter.format_report(
+            multi_error_diagnosis, skip_fix_section=True
+        )
+        assert 'To fix these issues:' in report_with
+        assert 'To fix these issues:' not in report_without
+
+
+class TestAutoRepairSuggestion:
+    """Tests for 'Or auto-repair' suggestion when categories support auto-fix."""
+
+    def test_auto_repair_shown_for_fstab(
+        self, formatter, single_error_diagnosis
+    ):
+        """When fstab error is detected, auto-repair suggestion should appear."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'Or auto-repair:' in report
+        assert 'gce-rescue-v2 repair' in report
+
+    def test_auto_repair_shown_for_multi_error_with_fstab(
+        self, formatter, multi_error_diagnosis
+    ):
+        """When any fixable category is present, auto-repair should appear."""
+        report = formatter.format_report(multi_error_diagnosis)
+        assert 'Or auto-repair:' in report
+        assert 'gce-rescue-v2 repair' in report
+
+    def test_no_auto_repair_for_unfixable_only(self, formatter):
+        """When no fixable categories, auto-repair should not appear."""
+        diagnosis = {
+            'vm_name': 'test-vm',
+            'zone': 'us-central1-a',
+            'status': 'TERMINATED',
+            'os_type': 'linux',
+            'os_flavor': 'debian-12',
+            'architecture': 'x86_64',
+            'license_type': 'free',
+            'diagnosis_status': 'boot_errors_detected',
+            'boot_errors': [
+                {
+                    'category': 'grub',
+                    'severity': 'critical',
+                    'description': 'GRUB missing',
+                    'detected_pattern': 'grub pattern',
+                    'suggested_fixes': ['Fix GRUB'],
+                    'context_lines': ['grub error'],
+                    'matched_line_index': 0,
+                }
+            ],
+            'recommendations': [],
+        }
+        report = formatter.format_report(diagnosis)
+        assert 'Or auto-repair:' not in report
+        assert 'gce-rescue-v2 repair' not in report
+
+    def test_auto_repair_line_has_vm_name(
+        self, formatter, single_error_diagnosis
+    ):
+        """Auto-repair suggestion should include the VM name."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert 'gce-rescue-v2 repair test-vm' in report
+
+    def test_auto_repair_line_has_zone(
+        self, formatter, single_error_diagnosis
+    ):
+        """Auto-repair suggestion should include the zone."""
+        report = formatter.format_report(single_error_diagnosis)
+        assert '--zone=us-central1-a' in report

--- a/gce_rescue_v2/tests/test_validators.py
+++ b/gce_rescue_v2/tests/test_validators.py
@@ -206,6 +206,89 @@ class TestVMStateValidator:
         assert result.passed is False
         assert "no boot disk" in result.message.lower()
 
+    def test_confidential_vm_blocked(self, mock_compute):
+        """Test Confidential VM is blocked with clear message."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "confidentialInstanceConfig": {"enableConfidentialCompute": True}
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is False
+        assert "Confidential VM" in result.message
+        assert "not supported" in result.message.lower()
+        assert "fix" in result.details
+
+    def test_confidential_vm_with_type(self, mock_compute):
+        """Test Confidential VM shows type in error message."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "confidentialInstanceConfig": {
+                "enableConfidentialCompute": True,
+                "confidentialInstanceType": "SEV_SNP"
+            }
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is False
+        assert "SEV_SNP" in result.message
+
+    def test_shielded_vm_secure_boot_blocked(self, mock_compute):
+        """Test Shielded VM with Secure Boot is blocked."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "shieldedInstanceConfig": {"enableSecureBoot": True}
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is False
+        assert "Shielded VM" in result.message
+        assert "Secure Boot" in result.message
+        assert "fix" in result.details
+
+    def test_shielded_vm_without_secure_boot_allowed(self, mock_compute):
+        """Test Shielded VM without Secure Boot is allowed."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+            "shieldedInstanceConfig": {
+                "enableSecureBoot": False,
+                "enableVtpm": True,
+                "enableIntegrityMonitoring": True
+            }
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is True
+
+    def test_non_confidential_non_shielded_vm_allowed(self, mock_compute):
+        """Test regular VM without Confidential or Shielded is allowed."""
+        payload = {
+            "status": "RUNNING",
+            "disks": [{"source": "projects/p/zones/z/disks/d", "boot": True, "deviceName": "d"}],
+        }
+        self._set_vm(mock_compute, payload)
+        validator = VMStateValidator(mock_compute, "proj", "zone", "vm-1")
+
+        result = validator.validate()
+
+        assert result.passed is True
+
 
 class TestValidationRunner:
     """Tests for ValidationRunner."""

--- a/gce_rescue_v2/tests/test_vm_features.py
+++ b/gce_rescue_v2/tests/test_vm_features.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for VM feature detection functions.
+
+Covers:
+- Architecture detection (x86_64, ARM64)
+- Shielded VM detection
+- Confidential VM detection
+"""
+
+import pytest
+
+from gce_rescue_v2.utils.os_detection import (
+    detect_architecture,
+    is_shielded_vm,
+    get_shielded_config,
+    is_confidential_vm,
+    get_confidential_type,
+    ARCH_X86_64,
+    ARCH_ARM64,
+)
+
+
+class TestArchitectureDetection:
+    """Tests for detect_architecture function."""
+
+    def test_x86_64_from_disk_field(self):
+        """Detect x86_64 from disk architecture field."""
+        vm = {
+            'disks': [
+                {'boot': True, 'architecture': 'X86_64', 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_X86_64
+
+    def test_arm64_from_disk_field(self):
+        """Detect ARM64 from disk architecture field."""
+        vm = {
+            'disks': [
+                {'boot': True, 'architecture': 'ARM64', 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_architecture_case_insensitive(self):
+        """Architecture detection handles different cases."""
+        vm = {
+            'disks': [
+                {'boot': True, 'architecture': 'arm64', 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_arm64_from_machine_type_t2a(self):
+        """Detect ARM64 from T2A machine type."""
+        vm = {
+            'machineType': 'zones/us-central1-a/machineTypes/t2a-standard-4',
+            'disks': [
+                {'boot': True, 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_arm64_from_short_machine_type(self):
+        """Detect ARM64 from short T2A machine type."""
+        vm = {
+            'machineType': 't2a-standard-1',
+            'disks': [
+                {'boot': True, 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+    def test_default_x86_64_no_architecture_field(self):
+        """Default to x86_64 when no architecture field."""
+        vm = {
+            'machineType': 'zones/us-central1-a/machineTypes/e2-micro',
+            'disks': [
+                {'boot': True, 'source': '/disks/boot'}
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_X86_64
+
+    def test_default_x86_64_empty_vm(self):
+        """Default to x86_64 when VM has minimal info."""
+        vm = {}
+        assert detect_architecture(vm) == ARCH_X86_64
+
+    def test_multiple_disks_uses_boot_disk(self):
+        """Uses boot disk for architecture detection."""
+        vm = {
+            'disks': [
+                {'boot': False, 'architecture': 'X86_64', 'source': '/disks/data'},
+                {'boot': True, 'architecture': 'ARM64', 'source': '/disks/boot'},
+            ]
+        }
+        assert detect_architecture(vm) == ARCH_ARM64
+
+
+class TestShieldedVMDetection:
+    """Tests for Shielded VM detection functions."""
+
+    def test_secure_boot_enabled(self):
+        """Detect Secure Boot enabled."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': True,
+                'enableVtpm': True,
+                'enableIntegrityMonitoring': True
+            }
+        }
+        assert is_shielded_vm(vm) is True
+
+    def test_secure_boot_disabled(self):
+        """Detect Secure Boot disabled."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': False,
+                'enableVtpm': True,
+                'enableIntegrityMonitoring': True
+            }
+        }
+        assert is_shielded_vm(vm) is False
+
+    def test_no_shielded_config(self):
+        """No shielded config means not a shielded VM."""
+        vm = {}
+        assert is_shielded_vm(vm) is False
+
+    def test_empty_shielded_config(self):
+        """Empty shielded config defaults to False."""
+        vm = {'shieldedInstanceConfig': {}}
+        assert is_shielded_vm(vm) is False
+
+    def test_get_shielded_config_all_enabled(self):
+        """Get full shielded config when all enabled."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': True,
+                'enableVtpm': True,
+                'enableIntegrityMonitoring': True
+            }
+        }
+        config = get_shielded_config(vm)
+        assert config['secure_boot'] is True
+        assert config['vtpm'] is True
+        assert config['integrity_monitoring'] is True
+
+    def test_get_shielded_config_partial(self):
+        """Get shielded config with partial settings."""
+        vm = {
+            'shieldedInstanceConfig': {
+                'enableSecureBoot': True
+            }
+        }
+        config = get_shielded_config(vm)
+        assert config['secure_boot'] is True
+        assert config['vtpm'] is False
+        assert config['integrity_monitoring'] is False
+
+    def test_get_shielded_config_empty(self):
+        """Get shielded config when not configured."""
+        vm = {}
+        config = get_shielded_config(vm)
+        assert config['secure_boot'] is False
+        assert config['vtpm'] is False
+        assert config['integrity_monitoring'] is False
+
+
+class TestConfidentialVMDetection:
+    """Tests for Confidential VM detection functions."""
+
+    def test_confidential_vm_enabled(self):
+        """Detect Confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True
+            }
+        }
+        assert is_confidential_vm(vm) is True
+
+    def test_confidential_vm_disabled(self):
+        """Detect non-confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': False
+            }
+        }
+        assert is_confidential_vm(vm) is False
+
+    def test_no_confidential_config(self):
+        """No confidential config means not confidential."""
+        vm = {}
+        assert is_confidential_vm(vm) is False
+
+    def test_empty_confidential_config(self):
+        """Empty confidential config defaults to False."""
+        vm = {'confidentialInstanceConfig': {}}
+        assert is_confidential_vm(vm) is False
+
+    def test_get_confidential_type_sev(self):
+        """Get SEV type for confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True,
+                'confidentialInstanceType': 'SEV'
+            }
+        }
+        assert get_confidential_type(vm) == 'SEV'
+
+    def test_get_confidential_type_sev_snp(self):
+        """Get SEV-SNP type for confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True,
+                'confidentialInstanceType': 'SEV_SNP'
+            }
+        }
+        assert get_confidential_type(vm) == 'SEV_SNP'
+
+    def test_get_confidential_type_tdx(self):
+        """Get TDX type for confidential VM."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True,
+                'confidentialInstanceType': 'TDX'
+            }
+        }
+        assert get_confidential_type(vm) == 'TDX'
+
+    def test_get_confidential_type_default(self):
+        """Default to SEV when type not specified."""
+        vm = {
+            'confidentialInstanceConfig': {
+                'enableConfidentialCompute': True
+            }
+        }
+        assert get_confidential_type(vm) == 'SEV'
+
+    def test_get_confidential_type_not_confidential(self):
+        """Return empty string for non-confidential VM."""
+        vm = {}
+        assert get_confidential_type(vm) == ''

--- a/gce_rescue_v2/utils/colors.py
+++ b/gce_rescue_v2/utils/colors.py
@@ -9,7 +9,10 @@ import sys
 
 # ANSI color codes
 RED = '\033[91m'
+GREEN = '\033[92m'
 YELLOW = '\033[93m'
+BOLD = '\033[1m'
+DIM = '\033[2m'
 RESET = '\033[0m'
 
 
@@ -29,6 +32,27 @@ def yellow(text: str) -> str:
     """Return text in yellow if TTY, otherwise plain text."""
     if _is_tty():
         return f"{YELLOW}{text}{RESET}"
+    return text
+
+
+def green(text: str) -> str:
+    """Return text in green if TTY, otherwise plain text."""
+    if _is_tty():
+        return f"{GREEN}{text}{RESET}"
+    return text
+
+
+def bold(text: str) -> str:
+    """Return text in bold if TTY, otherwise plain text."""
+    if _is_tty():
+        return f"{BOLD}{text}{RESET}"
+    return text
+
+
+def dim(text: str) -> str:
+    """Return text in dim/faint if TTY, otherwise plain text."""
+    if _is_tty():
+        return f"{DIM}{text}{RESET}"
     return text
 
 

--- a/gce_rescue_v2/utils/os_detection.py
+++ b/gce_rescue_v2/utils/os_detection.py
@@ -1,14 +1,19 @@
 """
-GCE Rescue - OS Detection Utility
+GCE Rescue - OS and VM Feature Detection Utility
 
-Detects whether a VM is running Windows or Linux based on:
-1. Guest OS features (most reliable)
-2. Boot disk source image
-3. License information
+Detects VM characteristics:
+- Operating system (Windows/Linux)
+- CPU architecture (x86_64/ARM64)
+- Shielded VM configuration
+- Confidential VM configuration
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 from ..core.config import OS_TYPE_LINUX, OS_TYPE_WINDOWS
+
+# Architecture types
+ARCH_X86_64 = 'x86_64'
+ARCH_ARM64 = 'arm64'
 
 
 def detect_os_type(vm: Dict[str, Any]) -> str:
@@ -87,3 +92,104 @@ def detect_os_from_compute(compute, project: str, zone: str, vm_name: str) -> st
     ).execute()
 
     return detect_os_type(vm)
+
+
+def detect_architecture(vm: Dict[str, Any]) -> str:
+    """
+    Detect the CPU architecture of a VM.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        'x86_64' or 'arm64'
+
+    Detection methods:
+    1. Check boot disk 'architecture' field (most reliable)
+    2. Check machine type for T2A family (ARM64)
+    """
+    # Method 1: Check boot disk architecture field
+    for disk in vm.get('disks', []):
+        if disk.get('boot'):
+            arch = disk.get('architecture', '').upper()
+            if arch == 'ARM64':
+                return ARCH_ARM64
+            elif arch == 'X86_64':
+                return ARCH_X86_64
+
+    # Method 2: Check machine type (T2A = ARM64)
+    machine_type = vm.get('machineType', '').lower()
+    # Machine type format: zones/ZONE/machineTypes/TYPE or just TYPE
+    machine_type_name = machine_type.split('/')[-1] if '/' in machine_type else machine_type
+    if machine_type_name.startswith('t2a-'):
+        return ARCH_ARM64
+
+    # Default to x86_64
+    return ARCH_X86_64
+
+
+def is_shielded_vm(vm: Dict[str, Any]) -> bool:
+    """
+    Check if VM has Shielded VM features enabled (Secure Boot).
+
+    Shielded VMs with Secure Boot enabled cannot boot unsigned rescue disks.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        True if Secure Boot is enabled
+    """
+    shielded_config = vm.get('shieldedInstanceConfig', {})
+    return shielded_config.get('enableSecureBoot', False)
+
+
+def get_shielded_config(vm: Dict[str, Any]) -> Dict[str, bool]:
+    """
+    Get full Shielded VM configuration.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        Dict with secure_boot, vtpm, and integrity_monitoring settings
+    """
+    shielded_config = vm.get('shieldedInstanceConfig', {})
+    return {
+        'secure_boot': shielded_config.get('enableSecureBoot', False),
+        'vtpm': shielded_config.get('enableVtpm', False),
+        'integrity_monitoring': shielded_config.get('enableIntegrityMonitoring', False)
+    }
+
+
+def is_confidential_vm(vm: Dict[str, Any]) -> bool:
+    """
+    Check if VM is a Confidential VM.
+
+    Confidential VMs use memory encryption (AMD SEV/Intel TDX) and cannot
+    be rescued because the disk contents cannot be accessed externally.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        True if Confidential Computing is enabled
+    """
+    confidential_config = vm.get('confidentialInstanceConfig', {})
+    return confidential_config.get('enableConfidentialCompute', False)
+
+
+def get_confidential_type(vm: Dict[str, Any]) -> str:
+    """
+    Get the type of Confidential Computing technology.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        Type string (SEV, SEV_SNP, TDX) or empty string if not confidential
+    """
+    confidential_config = vm.get('confidentialInstanceConfig', {})
+    if not confidential_config.get('enableConfidentialCompute', False):
+        return ''
+    return confidential_config.get('confidentialInstanceType', 'SEV')

--- a/gce_rescue_v2/utils/os_detection.py
+++ b/gce_rescue_v2/utils/os_detection.py
@@ -15,6 +15,22 @@ from ..core.config import OS_TYPE_LINUX, OS_TYPE_WINDOWS
 ARCH_X86_64 = 'x86_64'
 ARCH_ARM64 = 'arm64'
 
+# License types
+LICENSE_FREE = 'free'
+LICENSE_PAYG = 'payg'
+LICENSE_BYOS = 'byos'
+
+# Projects that charge per-instance license fees
+_PAYG_LICENSE_PROJECTS = frozenset({
+    'rhel-cloud',
+    'rhel-sap-cloud',
+    'suse-cloud',
+    'suse-sap-cloud',
+    'sles-cloud',
+    'windows-cloud',
+    'windows-sql-cloud',
+})
+
 
 def detect_os_type(vm: Dict[str, Any]) -> str:
     """
@@ -92,6 +108,78 @@ def detect_os_from_compute(compute, project: str, zone: str, vm_name: str) -> st
     ).execute()
 
     return detect_os_type(vm)
+
+
+def detect_os_flavor(vm: Dict[str, Any]) -> str:
+    """Detect specific OS flavor from disk licenses or source image.
+
+    Parses the boot disk's license URLs (e.g.,
+    projects/debian-cloud/global/licenses/debian-12) or falls back
+    to the source image name.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        OS flavor string like 'debian-12', 'ubuntu-2204-lts',
+        'rhel-9', 'windows-server-2022-dc', or 'unknown'.
+    """
+    for disk in vm.get('disks', []):
+        if not disk.get('boot'):
+            continue
+
+        # Method 1: Parse license URL (most reliable)
+        for license_url in disk.get('licenses', []):
+            # Format: projects/PROJECT/global/licenses/LICENSE_NAME
+            parts = license_url.rstrip('/').split('/')
+            if parts:
+                return parts[-1]
+
+        # Method 2: Parse source image name
+        source = disk.get('source', '')
+        if source:
+            # Format: projects/PROJECT/zones/ZONE/disks/DISK_NAME
+            # The disk name often contains the image family
+            image_name = source.rstrip('/').split('/')[-1]
+            if image_name:
+                return image_name
+
+    return 'unknown'
+
+
+def detect_license_type(vm: Dict[str, Any]) -> str:
+    """Detect boot disk license type from license URL project.
+
+    Parses the license project from the boot disk's license URL
+    to determine if the OS is free, PAYG, or BYOS.
+
+    Args:
+        vm: VM instance response from GCP API
+
+    Returns:
+        'free', 'payg', 'byos', or 'unknown'.
+    """
+    for disk in vm.get('disks', []):
+        if not disk.get('boot'):
+            continue
+
+        for license_url in disk.get('licenses', []):
+            # Check BYOS/BYOL first (in the license name)
+            license_name = license_url.rstrip('/').split('/')[-1].lower()
+            if 'byos' in license_name or 'byol' in license_name:
+                return LICENSE_BYOS
+
+            # Extract project from URL
+            # Format: .../projects/{PROJECT}/global/licenses/{NAME}
+            parts = license_url.split('/')
+            if 'projects' in parts:
+                project = parts[parts.index('projects') + 1]
+                if project in _PAYG_LICENSE_PROJECTS:
+                    return LICENSE_PAYG
+
+        return LICENSE_FREE
+
+    return 'unknown'
 
 
 def detect_architecture(vm: Dict[str, Any]) -> str:

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -1,4 +1,4 @@
-"""Diagnostic report formatter for diagnose-boot command.
+"""Diagnostic report formatter for diagnose command.
 
 Formats diagnosis results into clean, professional CLI output
 following gcloud conventions and trivy/kubectl-style design.
@@ -33,14 +33,45 @@ class DiagnosisReportFormatter:
             return self._format_unable(diagnosis)
 
     def _format_header(self, diagnosis: Dict[str, Any]) -> str:
-        """Format the 3-line header block."""
+        """Format the header block with VM info."""
         vm_name = diagnosis['vm_name']
         zone = diagnosis['zone']
         vm_status = diagnosis['status']
-        return (
+        os_line = self._format_os_line(diagnosis)
+        header = (
             f"Diagnosis: {vm_name} ({zone})\n"
             f"Status:    {vm_status}"
         )
+        if os_line:
+            header += f"\n{os_line}"
+        return header
+
+    def _format_os_line(self, diagnosis: Dict[str, Any]) -> str:
+        """Format the OS info line.
+
+        Returns empty string if no OS info is available.
+        """
+        os_type = diagnosis.get('os_type', 'unknown')
+        os_flavor = diagnosis.get('os_flavor', 'unknown')
+        architecture = diagnosis.get('architecture', 'unknown')
+        license_type = diagnosis.get('license_type', 'unknown')
+
+        if os_type == 'unknown':
+            return "OS:        Unknown"
+
+        display_name = 'Windows' if os_type == 'windows' else 'Linux'
+        details = []
+        if os_flavor != 'unknown':
+            details.append(os_flavor)
+        if architecture != 'unknown':
+            details.append(architecture)
+        if license_type != 'unknown':
+            details.append(license_type.upper() if license_type == 'payg'
+                           else license_type.capitalize())
+
+        if details:
+            return f"OS:        {display_name} ({', '.join(details)})"
+        return f"OS:        {display_name}"
 
     def _format_result_line(self, diagnosis: Dict[str, Any]) -> str:
         """Format the result summary line with severity counts."""
@@ -230,7 +261,7 @@ class DiagnosisReportFormatter:
 
         lines.append("")
         lines.append("Then run diagnosis again:")
-        lines.append(f"  $ gce-rescue diagnose-boot {vm_name} --zone={zone}")
+        lines.append(f"  $ gce-rescue diagnose {vm_name} --zone={zone}")
 
         return "\n".join(lines)
 

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -12,13 +12,16 @@ from .colors import red, yellow, green, bold, dim
 class DiagnosisReportFormatter:
     """Formats DiagnosisResult dicts into human-readable CLI reports."""
 
-    def format_report(self, diagnosis: Dict[str, Any]) -> str:
+    def format_report(self, diagnosis: Dict[str, Any],
+                      skip_fix_section: bool = False) -> str:
         """Format a complete diagnosis report.
 
         Args:
             diagnosis: Diagnosis result dict with keys:
                 vm_name, zone, status, diagnosis_status,
                 boot_errors, recommendations
+            skip_fix_section: If True, omit the "To fix this issue:" section.
+                Used by repair command which shows its own repair plan.
 
         Returns:
             Formatted report string
@@ -26,7 +29,7 @@ class DiagnosisReportFormatter:
         status = diagnosis.get('diagnosis_status', '')
 
         if status == 'boot_errors_detected':
-            return self._format_errors_report(diagnosis)
+            return self._format_errors_report(diagnosis, skip_fix_section)
         elif status == 'healthy':
             return self._format_healthy(diagnosis)
         else:
@@ -98,7 +101,8 @@ class DiagnosisReportFormatter:
 
         return f"Result:    {red(summary)}"
 
-    def _format_errors_report(self, diagnosis: Dict[str, Any]) -> str:
+    def _format_errors_report(self, diagnosis: Dict[str, Any],
+                              skip_fix_section: bool = False) -> str:
         """Format a report with detected errors."""
         lines = []
 
@@ -117,8 +121,9 @@ class DiagnosisReportFormatter:
         for error in errors:
             lines.append(self._format_single_issue(error, diagnosis))
 
-        # Consolidated fix section
-        lines.append(self._format_fix_section(diagnosis))
+        # Consolidated fix section (omitted when repair command handles it)
+        if not skip_fix_section:
+            lines.append(self._format_fix_section(diagnosis))
 
         return "\n".join(lines)
 
@@ -182,7 +187,7 @@ class DiagnosisReportFormatter:
 
         # Step 1: Enter rescue mode
         lines.append("  1. Enter rescue mode:")
-        lines.append(f"     $ gce-rescue rescue {vm_name} --zone={zone}")
+        lines.append(f"     $ gce-rescue-v2 rescue {vm_name} --zone={zone}")
         lines.append("")
 
         # Step 2: Category-aware fix guidance
@@ -214,7 +219,15 @@ class DiagnosisReportFormatter:
 
         # Step 3: Restore
         lines.append("  3. Restore the VM:")
-        lines.append(f"     $ gce-rescue restore {vm_name} --zone={zone}")
+        lines.append(f"     $ gce-rescue-v2 restore {vm_name} --zone={zone}")
+
+        # Show auto-repair alternative if any category supports it
+        from ..orchestration.repair import SUPPORTED_FIX_CATEGORIES
+        auto_fixable = [c for c in categories if c in SUPPORTED_FIX_CATEGORIES]
+        if auto_fixable:
+            lines.append("")
+            lines.append("Or auto-repair:")
+            lines.append(f"  $ gce-rescue-v2 repair {vm_name} --zone={zone}")
 
         return "\n".join(lines)
 
@@ -257,7 +270,7 @@ class DiagnosisReportFormatter:
 
         lines.append("")
         lines.append("Then run diagnosis again:")
-        lines.append(f"  $ gce-rescue diagnose {vm_name} --zone={zone}")
+        lines.append(f"  $ gce-rescue-v2 diagnose {vm_name} --zone={zone}")
 
         return "\n".join(lines)
 

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -129,7 +129,6 @@ class DiagnosisReportFormatter:
         severity = error['severity'].upper()
         category = error['category'].upper()
         description = error['description']
-        matched = error.get('detected_pattern', '')
         context = error.get('context_lines', [])
         matched_idx = error.get('matched_line_index', -1)
         fixes = error.get('suggested_fixes', [])
@@ -147,12 +146,9 @@ class DiagnosisReportFormatter:
         # Severity + category + description
         lines.append(f"{sev_label} [{category}] {description}")
 
-        # Matched pattern
         indent = " " * 10
         vm_name = diagnosis['vm_name']
         zone = diagnosis['zone']
-        formatted_matched = matched.replace('VM_NAME', vm_name).replace('ZONE', zone)
-        lines.append(f"{indent}Matched: {formatted_matched}")
 
         # Serial console log lines
         if context:

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -1,0 +1,247 @@
+"""Diagnostic report formatter for diagnose-boot command.
+
+Formats diagnosis results into clean, professional CLI output
+following gcloud conventions and trivy/kubectl-style design.
+"""
+
+from typing import Dict, Any, List
+from ..core.boot_patterns import SEVERITY_ORDER, CATEGORY_FIX_GUIDANCE
+from .colors import red, yellow, green, bold, dim
+
+
+class DiagnosisReportFormatter:
+    """Formats DiagnosisResult dicts into human-readable CLI reports."""
+
+    def format_report(self, diagnosis: Dict[str, Any]) -> str:
+        """Format a complete diagnosis report.
+
+        Args:
+            diagnosis: Diagnosis result dict with keys:
+                vm_name, zone, status, diagnosis_status,
+                boot_errors, recommendations
+
+        Returns:
+            Formatted report string
+        """
+        status = diagnosis.get('diagnosis_status', '')
+
+        if status == 'boot_errors_detected':
+            return self._format_errors_report(diagnosis)
+        elif status == 'healthy':
+            return self._format_healthy(diagnosis)
+        else:
+            return self._format_unable(diagnosis)
+
+    def _format_header(self, diagnosis: Dict[str, Any]) -> str:
+        """Format the 3-line header block."""
+        vm_name = diagnosis['vm_name']
+        zone = diagnosis['zone']
+        vm_status = diagnosis['status']
+        return (
+            f"Diagnosis: {vm_name} ({zone})\n"
+            f"Status:    {vm_status}"
+        )
+
+    def _format_result_line(self, diagnosis: Dict[str, Any]) -> str:
+        """Format the result summary line with severity counts."""
+        errors = diagnosis.get('boot_errors', [])
+        total = len(errors)
+
+        if total == 0:
+            return f"Result:    {green('No boot issues detected')}"
+
+        counts = {}
+        for err in errors:
+            sev = err['severity']
+            counts[sev] = counts.get(sev, 0) + 1
+
+        # Build severity breakdown
+        parts = []
+        for sev in ('critical', 'error', 'warning'):
+            if sev in counts:
+                parts.append(f"{counts[sev]} {sev}")
+
+        issue_word = "issue" if total == 1 else "issues"
+        breakdown = ", ".join(parts)
+        summary = f"{total} {issue_word} found ({breakdown})"
+
+        return f"Result:    {red(summary)}"
+
+    def _format_errors_report(self, diagnosis: Dict[str, Any]) -> str:
+        """Format a report with detected errors."""
+        lines = []
+
+        # Header
+        lines.append(self._format_header(diagnosis))
+        lines.append(self._format_result_line(diagnosis))
+        lines.append("")
+
+        # Sort errors by severity
+        errors = sorted(
+            diagnosis['boot_errors'],
+            key=lambda e: SEVERITY_ORDER.get(e['severity'], 99)
+        )
+
+        # Format each issue
+        for error in errors:
+            lines.append(self._format_single_issue(error, diagnosis))
+
+        # Consolidated fix section
+        lines.append(self._format_fix_section(diagnosis))
+
+        return "\n".join(lines)
+
+    def _format_single_issue(
+        self, error: Dict[str, Any], diagnosis: Dict[str, Any]
+    ) -> str:
+        """Format a single detected issue."""
+        severity = error['severity'].upper()
+        category = error['category'].upper()
+        description = error['description']
+        matched = error.get('detected_pattern', '')
+        context = error.get('context_lines', [])
+        matched_idx = error.get('matched_line_index', -1)
+        fixes = error.get('suggested_fixes', [])
+
+        # Color the severity label
+        if severity == 'CRITICAL':
+            sev_label = red(f"{'CRITICAL':<9}")
+        elif severity == 'ERROR':
+            sev_label = red(f"{'ERROR':<9}")
+        else:
+            sev_label = yellow(f"{'WARNING':<9}")
+
+        lines = []
+
+        # Severity + category + description
+        lines.append(f"{sev_label} [{category}] {description}")
+
+        # Matched pattern
+        indent = " " * 10
+        vm_name = diagnosis['vm_name']
+        zone = diagnosis['zone']
+        formatted_matched = matched.replace('VM_NAME', vm_name).replace('ZONE', zone)
+        lines.append(f"{indent}Matched: {formatted_matched}")
+
+        # Serial console log lines
+        if context:
+            lines.append(f"{indent}Serial console:")
+            for i, ctx_line in enumerate(context):
+                if not ctx_line.strip():
+                    continue
+                if i == matched_idx:
+                    lines.append(f"{indent}  {dim(ctx_line)}  <--")
+                else:
+                    lines.append(f"{indent}  {dim(ctx_line)}")
+
+        # Per-issue fixes
+        if fixes:
+            lines.append(f"{indent}Fix:")
+            for fix in fixes:
+                fix = fix.replace('VM_NAME', vm_name).replace('ZONE', zone)
+                lines.append(f"{indent}  - {fix}")
+
+        lines.append("")
+        return "\n".join(lines)
+
+    def _format_fix_section(self, diagnosis: Dict[str, Any]) -> str:
+        """Format the consolidated fix section at the bottom."""
+        vm_name = diagnosis['vm_name']
+        zone = diagnosis['zone']
+        errors = diagnosis.get('boot_errors', [])
+
+        issue_word = "this issue" if len(errors) == 1 else "these issues"
+        lines = [f"To fix {issue_word}:", ""]
+
+        # Step 1: Enter rescue mode
+        lines.append("  1. Enter rescue mode:")
+        lines.append(f"     $ gce-rescue rescue {vm_name} --zone={zone}")
+        lines.append("")
+
+        # Step 2: Category-aware fix guidance
+        categories = []
+        seen = set()
+        for err in errors:
+            cat = err['category']
+            if cat not in seen:
+                seen.add(cat)
+                categories.append(cat)
+
+        if len(categories) == 1:
+            # Single category - use specific guidance
+            cat = categories[0]
+            guidance = CATEGORY_FIX_GUIDANCE.get(cat)
+            if guidance:
+                label = _category_label(cat)
+                lines.append(f"  2. {label}:")
+                lines.append(f"     $ {guidance}")
+        else:
+            # Multiple categories - list each
+            lines.append("  2. Repair boot configuration:")
+            for cat in categories:
+                guidance = CATEGORY_FIX_GUIDANCE.get(cat)
+                if guidance:
+                    lines.append(f"     - {guidance}")
+
+        lines.append("")
+
+        # Step 3: Restore
+        lines.append("  3. Restore the VM:")
+        lines.append(f"     $ gce-rescue restore {vm_name} --zone={zone}")
+
+        return "\n".join(lines)
+
+    def _format_healthy(self, diagnosis: Dict[str, Any]) -> str:
+        """Format a healthy VM report."""
+        lines = []
+        lines.append(self._format_header(diagnosis))
+        lines.append(f"Result:    {green('No boot issues detected')}")
+
+        vm_status = diagnosis.get('status', '')
+        if vm_status == 'TERMINATED':
+            vm_name = diagnosis['vm_name']
+            zone = diagnosis['zone']
+            lines.append("")
+            lines.append("Note: VM is currently stopped. Start it with:")
+            lines.append(
+                f"  $ gcloud compute instances start {vm_name} --zone={zone}"
+            )
+
+        return "\n".join(lines)
+
+    def _format_unable(self, diagnosis: Dict[str, Any]) -> str:
+        """Format an unable-to-diagnose report."""
+        vm_name = diagnosis['vm_name']
+        zone = diagnosis['zone']
+        recommendations = diagnosis.get('recommendations', [])
+
+        lines = []
+        lines.append(self._format_header(diagnosis))
+        lines.append(f"Result:    {red('Unable to diagnose')}")
+        lines.append("")
+
+        # Show the first recommendation as the main error detail
+        if recommendations:
+            for rec in recommendations:
+                rec = rec.replace('VM_NAME', vm_name).replace('ZONE', zone)
+                lines.append(rec)
+        else:
+            lines.append("No diagnostic information available.")
+
+        lines.append("")
+        lines.append("Then run diagnosis again:")
+        lines.append(f"  $ gce-rescue diagnose-boot {vm_name} --zone={zone}")
+
+        return "\n".join(lines)
+
+
+def _category_label(category: str) -> str:
+    """Return a human-readable label for a fix step based on category."""
+    labels = {
+        'fstab': 'Fix /etc/fstab',
+        'grub': 'Repair GRUB',
+        'kernel': 'Check kernel',
+        'filesystem': 'Fix filesystem',
+        'initramfs': 'Rebuild initramfs',
+    }
+    return labels.get(category, f'Fix {category}')

--- a/gce_rescue_v2/validators/__init__.py
+++ b/gce_rescue_v2/validators/__init__.py
@@ -36,6 +36,7 @@ from .base import (
 from .credentials import CredentialsValidator
 from .iam_permissions import IAMPermissionsValidator
 from .vm_state import VMStateValidator, VMRestoreStateValidator
+from .diagnose import DiagnosePermissionsValidator
 
 __all__ = [
     # Base classes
@@ -49,4 +50,5 @@ __all__ = [
     'IAMPermissionsValidator',
     'VMStateValidator',
     'VMRestoreStateValidator',
+    'DiagnosePermissionsValidator',
 ]

--- a/gce_rescue_v2/validators/diagnose.py
+++ b/gce_rescue_v2/validators/diagnose.py
@@ -114,6 +114,23 @@ class DiagnosePermissionsValidator(BaseValidator):
                         ),
                     }
                 )
+            elif e.resp.status == 403:
+                # testIamPermissions itself requires compute.instances.list
+                # at the project level. In production environments, users often
+                # have instance-level access without project-level list.
+                # Pass through and let the actual API calls validate access.
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=True,
+                    message="Skipped (insufficient access to testIamPermissions API)",
+                    details={
+                        "note": (
+                            "Could not pre-check permissions because "
+                            "testIamPermissions requires compute.instances.list. "
+                            "Actual permissions will be validated during execution."
+                        ),
+                    }
+                )
             else:
                 return ValidationResult(
                     validator_name=self.name,

--- a/gce_rescue_v2/validators/diagnose.py
+++ b/gce_rescue_v2/validators/diagnose.py
@@ -1,0 +1,131 @@
+"""
+GCE Rescue - Diagnose Permissions Validator
+
+Validates that the user has required IAM permissions for diagnose-boot.
+This is a lightweight check - diagnose only needs read permissions.
+"""
+
+from googleapiclient.errors import HttpError
+
+from .base import BaseValidator, ValidationResult
+
+
+class DiagnosePermissionsValidator(BaseValidator):
+    """
+    Validates that user has required IAM permissions for diagnose-boot.
+
+    Required permissions (read-only):
+    - compute.instances.get (to fetch VM status)
+    - compute.instances.getSerialPortOutput (to read serial console)
+
+    Example:
+        validator = DiagnosePermissionsValidator(compute, project, zone, 'my-vm')
+        result = validator.validate()
+
+        if not result.passed:
+            print(f"Missing permissions: {result.details['missing']}")
+    """
+
+    REQUIRED_PERMISSIONS = [
+        'compute.instances.get',
+        'compute.instances.getSerialPortOutput',
+    ]
+
+    @property
+    def name(self) -> str:
+        """Display name for this validator."""
+        return "Diagnose Permissions"
+
+    def validate(self) -> ValidationResult:
+        """Check if user has required IAM permissions for diagnose-boot.
+
+        Returns:
+            ValidationResult with pass/fail
+        """
+        if not self.vm_name:
+            return ValidationResult(
+                validator_name=self.name,
+                passed=False,
+                message="VM name required to check permissions",
+                details={"error": "vm_name not provided"}
+            )
+
+        try:
+            request_body = {
+                'permissions': self.REQUIRED_PERMISSIONS
+            }
+
+            compute = (
+                self._create_tracked_client(self.tracking_label)
+                if self.tracking_label
+                else self.compute
+            )
+            result = compute.instances().testIamPermissions(
+                project=self.project,
+                zone=self.zone,
+                resource=self.vm_name,
+                body=request_body
+            ).execute()
+
+            granted_permissions = result.get('permissions', [])
+
+            missing_permissions = [
+                p for p in self.REQUIRED_PERMISSIONS
+                if p not in granted_permissions
+            ]
+
+            if missing_permissions:
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message=f"Missing {len(missing_permissions)} required permission(s)",
+                    details={
+                        "missing": missing_permissions,
+                        "granted": granted_permissions,
+                        "required_roles": [
+                            "roles/compute.viewer (for read-only access)",
+                        ],
+                        "fix": (
+                            f"Grant compute.viewer role to your account "
+                            f"for project {self.project}"
+                        ),
+                    }
+                )
+
+            return ValidationResult(
+                validator_name=self.name,
+                passed=True,
+                message=f"Permissions OK ({len(granted_permissions)}/{len(self.REQUIRED_PERMISSIONS)})",
+                details={"granted": granted_permissions}
+            )
+
+        except HttpError as e:
+            if e.resp.status == 404:
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message=f"Instance '{self.vm_name}' not found in zone '{self.zone}'",
+                    details={
+                        "error": "VM not found",
+                        "fix": (
+                            f"Verify the instance name and zone are correct.\n"
+                            f"      To list instances: "
+                            f"gcloud compute instances list --project={self.project}"
+                        ),
+                    }
+                )
+            else:
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message=f"Failed to check permissions: {str(e)}",
+                    details={"error": str(e)}
+                )
+
+        except Exception as e:
+            return ValidationResult(
+                validator_name=self.name,
+                passed=False,
+                message=f"Unexpected error checking permissions: {str(e)}",
+                details={"error": str(e)}
+            )

--- a/gce_rescue_v2/validators/diagnose.py
+++ b/gce_rescue_v2/validators/diagnose.py
@@ -1,7 +1,7 @@
 """
 GCE Rescue - Diagnose Permissions Validator
 
-Validates that the user has required IAM permissions for diagnose-boot.
+Validates that the user has required IAM permissions for diagnose.
 This is a lightweight check - diagnose only needs read permissions.
 """
 
@@ -12,7 +12,7 @@ from .base import BaseValidator, ValidationResult
 
 class DiagnosePermissionsValidator(BaseValidator):
     """
-    Validates that user has required IAM permissions for diagnose-boot.
+    Validates that user has required IAM permissions for diagnose.
 
     Required permissions (read-only):
     - compute.instances.get (to fetch VM status)
@@ -37,7 +37,7 @@ class DiagnosePermissionsValidator(BaseValidator):
         return "Diagnose Permissions"
 
     def validate(self) -> ValidationResult:
-        """Check if user has required IAM permissions for diagnose-boot.
+        """Check if user has required IAM permissions for diagnose.
 
         Returns:
             ValidationResult with pass/fail

--- a/gce_rescue_v2/validators/vm_state.py
+++ b/gce_rescue_v2/validators/vm_state.py
@@ -7,6 +7,7 @@ Validates that the VM exists and is in a valid state for rescue operations.
 from googleapiclient.errors import HttpError
 
 from .base import BaseValidator, ValidationResult
+from ..utils.os_detection import is_shielded_vm, is_confidential_vm, get_confidential_type
 
 
 class VMStateValidator(BaseValidator):
@@ -125,6 +126,55 @@ class VMStateValidator(BaseValidator):
                     passed=False,
                     message="VM has no boot disk",
                     details={"error": "No boot disk found"}
+                )
+
+            # Check for Confidential VM (not supported)
+            if is_confidential_vm(vm):
+                conf_type = get_confidential_type(vm) or 'SEV'
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message=f"Confidential VMs ({conf_type}) are not supported",
+                    details={
+                        "vm_name": self.vm_name,
+                        "confidential_type": conf_type,
+                        "reason": (
+                            "Confidential VMs use memory encryption that prevents "
+                            "external access to disk contents from a rescue environment."
+                        ),
+                        "fix": (
+                            "Alternatives for Confidential VMs:\n"
+                            f"  1. Use serial console: gcloud compute instances "
+                            f"get-serial-port-output {self.vm_name} --zone={self.zone}\n"
+                            "  2. Create a snapshot and new VM for data recovery\n"
+                            "  3. Contact Google Cloud Support for assistance"
+                        )
+                    }
+                )
+
+            # Check for Shielded VM with Secure Boot (not supported)
+            if is_shielded_vm(vm):
+                return ValidationResult(
+                    validator_name=self.name,
+                    passed=False,
+                    message="Shielded VMs with Secure Boot are not supported",
+                    details={
+                        "vm_name": self.vm_name,
+                        "reason": (
+                            "Shielded VMs with Secure Boot enabled require signed boot disks. "
+                            "The rescue disk cannot boot with Secure Boot enabled."
+                        ),
+                        "fix": (
+                            "Options for Shielded VMs:\n"
+                            f"  1. Temporarily disable Secure Boot:\n"
+                            f"     gcloud compute instances stop {self.vm_name} --zone={self.zone}\n"
+                            f"     gcloud compute instances update {self.vm_name} --zone={self.zone} "
+                            "--no-shielded-secure-boot\n"
+                            "     Then run rescue again.\n"
+                            "  2. Use serial console for debugging\n"
+                            "  3. Create a snapshot and attach to another VM"
+                        )
+                    }
                 )
 
             # Build result details

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,12 @@ setup(
   package_dir = {'': '.'},
   package_data = {
       '': ['startup-script.txt'],
-      'gce_rescue_v2': ['startup_scripts/*.sh', 'startup_scripts/*.ps1'],
+      'gce_rescue_v2': [
+          'startup_scripts/*.sh',
+          'startup_scripts/*.ps1',
+          'core/patterns/*.yaml',
+          'core/patterns/README.md',
+      ],
   },
   include_package_data = True,
   python_requires='>=3.9',


### PR DESCRIPTION
## Summary

- **`diagnose` command**: Read-only boot diagnostics from serial console. Matches fstab error patterns (UUID not found, device missing, mount failed, emergency mode, dependency failed, device timeout, fsck failed) with OS detection and license type display.
- **`repair` command**: Automated diagnose-fix-restore in one command (Linux only). Embeds fix script in startup script — no SSH needed. Creates backup snapshot and backs up modified files on disk.
- **Safety improvements**: Rescue/restore confirmation prompts now list all major changes (disk detach, metadata replacement). All failure paths show backup snapshot name. Snapshot cleanup hint shown after restore.

## Changes

- New: `operations/diagnose.py` — DiagnoseOperation with boot pattern analysis
- New: `orchestration/repair.py` — RepairOrchestrator (diagnose → rescue with fix → restore)
- New: `startup_scripts/fixes/fstab_fix.sh` — Auto-fix for invalid fstab entries
- New: `core/boot_patterns.py` — Boot error pattern library (7 fstab patterns)
- Updated: `cli.py` — diagnose/repair subcommands, improved confirmation prompts
- Updated: `main.py` — Snapshot cleanup hint after restore
- Updated: READMEs with diagnose/repair examples and decision tree
- Fixed: pyproject.toml entry point (`gce-rescue` → `gce-rescue-v2`)
- Fixed: Pipfile missing pyyaml (V1 CI compatibility)
- 334 tests passing (including 83 new tests for diagnose, repair, and interrupt recovery)

## Test plan

- [x] `python -m pytest gce_rescue_v2/tests/ -v` — 334 passed, 4 skipped
- [x] CI: All workflows passing (Test, Lint, V2 CI)
- [x] Manual: `gce-rescue-v2 diagnose` on VM with fstab error
- [x] Manual: `gce-rescue-v2 repair` on VM with fstab error
- [x] Manual: Ctrl+C during repair and resume
- [x] Manual: `gce-rescue-v2 rescue` + `restore` round-trip