### PR TITLE
fix: Version bump, User-Agent tracking, and CLI UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ vir-env/
 
 # Private/local files
 private-docs/
+docs/

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -27,6 +27,45 @@ from .utils.report_formatter import DiagnosisReportFormatter
 from .orchestration.checkpoint import CheckpointManager, CheckpointData
 
 
+def _create_tracked_client(compute, tracking_label: str):
+    """Create a compute client with a tracking User-Agent header.
+
+    Args:
+        compute: Base compute client (used to extract credentials)
+        tracking_label: Label appended to User-Agent (e.g., 'diagnose-vm-state')
+
+    Returns:
+        Compute API client with User-Agent: gce-rescue-{VERSION}-{tracking_label}
+    """
+    try:
+        from googleapiclient import discovery
+        import googleapiclient.http
+        import google_auth_httplib2
+        import httplib2
+
+        # Verify compute client has real credentials (not a test mock)
+        if not isinstance(getattr(compute, '_http', None), google_auth_httplib2.AuthorizedHttp):
+            return compute
+
+        credentials = compute._http.credentials
+        user_agent = f'gce-rescue-{VERSION}-{tracking_label}'
+
+        def _request_builder(http, *args, **kwargs):
+            headers = kwargs.setdefault('headers', {})
+            headers['user-agent'] = user_agent
+            auth_http = google_auth_httplib2.AuthorizedHttp(
+                credentials, http=httplib2.Http()
+            )
+            return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+        return discovery.build(
+            'compute', 'v1', credentials=credentials,
+            cache_discovery=False, requestBuilder=_request_builder
+        )
+    except Exception:
+        return compute
+
+
 class OutputFormatter:
     """
     Handle output formatting similar to gcloud.
@@ -661,7 +700,8 @@ def _validate_vm_exists(compute, project: str, zone: str, vm_name: str) -> tuple
         (success: bool, vm_info: dict or None, error_message: str or None)
     """
     try:
-        vm = compute.instances().get(
+        tracked = _create_tracked_client(compute, 'rescue-vm-preflight')
+        vm = tracked.instances().get(
             project=project,
             zone=zone,
             instance=vm_name
@@ -721,7 +761,8 @@ def _validate_vm_for_restore(compute, project: str, zone: str, vm_name: str) -> 
         (success: bool, vm_info: dict or None, error_message: str or None)
     """
     try:
-        vm = compute.instances().get(
+        tracked = _create_tracked_client(compute, 'restore-vm-preflight')
+        vm = tracked.instances().get(
             project=project,
             zone=zone,
             instance=vm_name
@@ -922,7 +963,8 @@ def _reconcile_rescue_state(compute, project: str, zone: str, vm_name: str,
 
     # Get actual VM state
     try:
-        vm = compute.instances().get(
+        tracked = _create_tracked_client(compute, 'rescue-reconcile')
+        vm = tracked.instances().get(
             project=project, zone=zone, instance=vm_name
         ).execute()
     except Exception as e:
@@ -988,7 +1030,8 @@ def _reconcile_rescue_state(compute, project: str, zone: str, vm_name: str,
     if rescue_disk_name and "Create Rescue Disk" not in checkpointed_op_names:
         if rescue_disk_name not in attached_disk_names:
             try:
-                compute.disks().get(
+                tracked_disk = _create_tracked_client(compute, 'rescue-reconcile')
+                tracked_disk.disks().get(
                     project=project, zone=zone, disk=rescue_disk_name
                 ).execute()
                 _log(f"Rescue disk '{rescue_disk_name}' exists but not in checkpoint - adding to rollback")
@@ -1452,7 +1495,8 @@ def handle_diagnose(args: argparse.Namespace) -> int:
     # Also fetch VM info for state/rescue/OS checks under the same spinner
     vm = None
     try:
-        vm = compute.instances().get(
+        tracked = _create_tracked_client(compute, 'diagnose-vm-state')
+        vm = tracked.instances().get(
             project=project, zone=args.zone, instance=args.instance_name
         ).execute()
     except Exception as e:
@@ -1495,8 +1539,10 @@ def handle_diagnose(args: argparse.Namespace) -> int:
         if os_type == 'windows':
             print(f"{error_prefix()} Diagnose is only supported for Linux VMs.", file=sys.stderr)
             print("", file=sys.stderr)
-            print("For Windows VMs, use rescue mode for manual investigation:", file=sys.stderr)
-            print(f"  $ gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            print("For Windows VMs, check the serial console output manually:", file=sys.stderr)
+            print(f"  $ gcloud compute instances get-serial-port-output {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            print("", file=sys.stderr)
+            print(f"  Console: https://console.cloud.google.com/compute/instancesDetail/zones/{args.zone}/instances/{args.instance_name}/console?project={project}&port=1", file=sys.stderr)
             return 1
 
     # Create and execute diagnose operation
@@ -1531,6 +1577,7 @@ def handle_diagnose(args: argparse.Namespace) -> int:
             return 0
 
         # Otherwise, print human-readable output
+        diagnosis['project'] = project
         formatter = DiagnosisReportFormatter()
         print(formatter.format_report(diagnosis))
 
@@ -1708,7 +1755,8 @@ def handle_repair(args: argparse.Namespace) -> int:
     if not debug:
         spinner.start()
     try:
-        vm = compute.instances().get(
+        tracked = _create_tracked_client(compute, 'repair-vm-state')
+        vm = tracked.instances().get(
             project=project, zone=args.zone, instance=args.instance_name
         ).execute()
     except Exception as e:
@@ -1721,6 +1769,21 @@ def handle_repair(args: argparse.Namespace) -> int:
         spinner.stop()
 
     if vm:
+        # Linux-only check (before any spinners or prompts)
+        from .utils.os_detection import detect_os_type
+        os_type = detect_os_type(vm)
+        if os_type == 'windows':
+            print(f"{error_prefix()} Repair is only supported for Linux VMs.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("For Windows VMs, use rescue mode for manual repair:", file=sys.stderr)
+            print(f"  $ gce-rescue-v2 rescue {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("Or check the serial console output manually:", file=sys.stderr)
+            print(f"  $ gcloud compute instances get-serial-port-output {args.instance_name} --zone={args.zone} --project={project}", file=sys.stderr)
+            print("", file=sys.stderr)
+            print(f"  Console: https://console.cloud.google.com/compute/instancesDetail/zones/{args.zone}/instances/{args.instance_name}/console?project={project}&port=1", file=sys.stderr)
+            return 1
+
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])
         in_rescue = any(item.get('key') == 'rescue-mode' for item in metadata_items)
@@ -1832,6 +1895,7 @@ def handle_repair(args: argparse.Namespace) -> int:
         return 1
 
     # Show diagnosis report (skip manual fix steps since repair plan follows)
+    diagnosis['project'] = project
     formatter = DiagnosisReportFormatter()
     print(formatter.format_report(diagnosis, skip_fix_section=True))
     print("")

--- a/gce_rescue_v2/core/auth.py
+++ b/gce_rescue_v2/core/auth.py
@@ -19,8 +19,9 @@ import httplib2
 from .exceptions import AuthenticationError
 from .config import VERSION
 
-# Suppress httplib2 timeout warnings (they're harmless and noisy)
+# Suppress noisy warnings from auth libraries
 warnings.filterwarnings('ignore', message='.*httplib2 transport does not support per-request timeout.*')
+warnings.filterwarnings('ignore', message='.*Your application has authenticated using end user credentials.*')
 logging.getLogger('googleapiclient.http').setLevel(logging.ERROR)
 
 # OAuth scopes required for Google Compute Engine API

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0-beta.4'
+VERSION = '2.0.0-beta.5'
 
 # OS Types
 OS_TYPE_LINUX = 'linux'

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -116,13 +116,25 @@ class RepairOrchestrator:
 
     def validate(self) -> bool:
         """Run pre-flight validation (credentials, IAM, VM state) + Linux-only check."""
-        # Create a temporary rescue orchestrator to reuse its validation
-        rescue = RescueOrchestrator(
-            compute=self.compute, project=self.project, zone=self.zone,
-            vm_name=self.vm_name, config=self.config, logger=self.logger,
-            suppress_progress=True
+        from ..validators import (
+            ValidationRunner, CredentialsValidator,
+            IAMPermissionsValidator, VMStateValidator,
         )
-        if not rescue.validate():
+
+        runner = ValidationRunner()
+        runner.add(CredentialsValidator(self.compute, self.project, self.zone))
+        runner.add(IAMPermissionsValidator(
+            self.compute, self.project, self.zone, self.vm_name,
+            tracking_label='repair-val-iam'
+        ))
+        runner.add(VMStateValidator(
+            self.compute, self.project, self.zone, self.vm_name,
+            tracking_label='repair-val-vm-state'
+        ))
+
+        results = runner.run_all(self.logger)
+        if not results.all_passed():
+            results.print_failures()
             return False
 
         # Check Linux-only
@@ -134,11 +146,12 @@ class RepairOrchestrator:
         os_type = detect_os_type(vm_info)
         if os_type == 'windows':
             self._log_error("Repair is only supported for Linux VMs.")
-            self._log_error("")
-            self._log_error("For Windows VMs, use rescue mode for manual repair:")
-            self._log_error(
+            print("", file=sys.stderr)
+            print("For Windows VMs, use rescue mode for manual repair:", file=sys.stderr)
+            print(
                 f"  $ gce-rescue-v2 rescue {self.vm_name} "
-                f"--zone={self.zone} --project={self.project}"
+                f"--zone={self.zone} --project={self.project}",
+                file=sys.stderr
             )
             return False
 

--- a/gce_rescue_v2/pyproject.toml
+++ b/gce_rescue_v2/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gce-rescue"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.5"
 description = "Rescue unbootable Google Compute Engine VMs"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -155,10 +155,10 @@ class TestHealthyReport:
     """Tests for healthy VM reports."""
 
     def test_healthy_running_is_compact(self, formatter, healthy_diagnosis):
-        """Healthy running VM should be 4 lines."""
+        """Healthy running VM should have header + result + note."""
         report = formatter.format_report(healthy_diagnosis)
         lines = [l for l in report.split('\n') if l.strip()]
-        assert len(lines) == 4
+        assert len(lines) == 6
 
     def test_healthy_contains_header(self, formatter, healthy_diagnosis):
         """Healthy report should have Diagnosis/Status/OS/Result header."""

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -233,19 +233,34 @@ class DiagnosisReportFormatter:
 
     def _format_healthy(self, diagnosis: Dict[str, Any]) -> str:
         """Format a healthy VM report."""
+        vm_name = diagnosis['vm_name']
+        zone = diagnosis['zone']
+        project = diagnosis.get('project', '')
+
         lines = []
         lines.append(self._format_header(diagnosis))
         lines.append(f"Result:    {green('No boot issues detected')}")
 
         vm_status = diagnosis.get('status', '')
         if vm_status == 'TERMINATED':
-            vm_name = diagnosis['vm_name']
-            zone = diagnosis['zone']
             lines.append("")
             lines.append("Note: VM is currently stopped. Start it with:")
             lines.append(
                 f"  $ gcloud compute instances start {vm_name} --zone={zone}"
             )
+
+        lines.append("")
+        lines.append(dim("Note: Currently checks fstab errors only. "
+                         "If the VM still won't boot, check the serial console:"))
+        gcloud_cmd = f"  $ gcloud compute instances get-serial-port-output {vm_name} --zone={zone}"
+        if project:
+            gcloud_cmd += f" --project={project}"
+        lines.append(dim(gcloud_cmd))
+        if project:
+            lines.append(dim(
+                f"  Console: https://console.cloud.google.com/compute/instancesDetail"
+                f"/zones/{zone}/instances/{vm_name}/console?project={project}&port=1"
+            ))
 
         return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

- Bump version to `2.0.0-beta.5`
- Add User-Agent tracking labels for all GCP API calls 
- Fix Windows VM error output: clean formatting, serial console links (gcloud + Console URL)
- Add scope note to healthy diagnosis: "Currently checks fstab errors only"
- Suppress noisy Google auth warning

## Test plan

- [x] 334 tests pass
- [x] Verify Windows VM error messages (diagnose + repair)
- [x] Verify healthy diagnosis note with serial console link
- [x] End-to-end repair on fstab VM