### PR TITLE
fix: Repair command UX improvements and boot verification

### DIFF
--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -19,7 +19,7 @@ import json
 import threading
 import time
 import yaml
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from .core.config import RescueConfig, RestoreConfig, VERSION
 from .main import rescue_vm, restore_vm, repair_vm
 from .utils.colors import error_prefix, warning_prefix, clear_lines
@@ -1589,6 +1589,23 @@ def handle_diagnose(args: argparse.Namespace) -> int:
         return 1
 
 
+def _show_boot_verification(boot_verified: Optional[bool],
+                            boot_errors: List[str],
+                            vm_name: str, zone: str) -> None:
+    """Display boot verification result after repair."""
+    if boot_verified is True:
+        print("Boot verification: VM is booting normally.")
+    elif boot_verified is False:
+        print("")
+        print(f"{warning_prefix()} VM may still have boot issues:")
+        for err in boot_errors:
+            print(f"  - {err}")
+        print("")
+        print("Consider using rescue mode for manual investigation:")
+        print(f"  $ gce-rescue-v2 rescue {vm_name} --zone={zone}")
+    # If None, skip silently (couldn't verify)
+
+
 def _show_repair_results(result: Dict[str, Any], vm_name: str,
                          zone: str = '', project: str = '') -> int:
     """Display repair results and return exit code."""
@@ -1600,6 +1617,9 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
     duration = result.get('duration_seconds', 0)
 
     duration_str = _format_duration(duration) if duration else ''
+
+    boot_verified = result.get('boot_verified')
+    boot_errors_after = result.get('boot_errors_after', [])
 
     if status == 'success':
         print("")
@@ -1617,6 +1637,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         if duration_str:
             completion += f" ({duration_str})"
         print(completion)
+        _show_boot_verification(boot_verified, boot_errors_after, vm_name, zone)
         return 0
 
     elif status == 'no_issues':
@@ -1630,6 +1651,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         if duration_str:
             completion += f" ({duration_str})"
         print(completion)
+        _show_boot_verification(boot_verified, boot_errors_after, vm_name, zone)
         return 0
 
     elif status == 'no_fix':
@@ -1714,9 +1736,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         print(completion)
         if snapshot_name:
             print(f"Backup snapshot: {snapshot_name}")
-        print("")
-        print("Verify the fix manually:")
-        print(f"  $ gcloud compute ssh {vm_name} --zone={zone}")
+        _show_boot_verification(boot_verified, boot_errors_after, vm_name, zone)
         return 0
 
     else:

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -1702,6 +1702,23 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         print(restore_cmd, file=sys.stderr)
         return 1
 
+    elif status == 'unknown':
+        # All phases completed but repair markers not found in serial output.
+        # The fix likely applied but we couldn't parse confirmation.
+        print("")
+        print(f"{warning_prefix()} Repair completed but could not confirm fix results from serial console.")
+        print("")
+        completion = f"Instance [{vm_name}] has been restored and is running."
+        if duration_str:
+            completion += f" ({duration_str})"
+        print(completion)
+        if snapshot_name:
+            print(f"Backup snapshot: {snapshot_name}")
+        print("")
+        print("Verify the fix manually:")
+        print(f"  $ gcloud compute ssh {vm_name} --zone={zone}")
+        return 0
+
     else:
         print(f"\n{error_prefix()} Unexpected result: {status}", file=sys.stderr)
         if error:

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -2047,7 +2047,6 @@ def handle_repair(args: argparse.Namespace) -> int:
             return 0
 
         lines_to_clear += 1  # input line
-        lines_to_clear += 1  # buffer for ANSI padding / print trailing newline
 
         # Clear diagnosis + plan + confirmation
         clear_lines(lines_to_clear)

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -614,13 +614,13 @@ class _Spinner:
             sys.stdout.flush()
 
     def _spin(self):
-        chars = ['|', '/', '-', '\\']
+        dots = ['.  ', '.. ', '...']
         idx = 0
         while not self._stop:
-            sys.stdout.write(f"\r{self._message}..{chars[idx]}")
+            sys.stdout.write(f"\r{self._message}{dots[idx]}")
             sys.stdout.flush()
-            idx = (idx + 1) % len(chars)
-            time.sleep(0.1)
+            idx = (idx + 1) % len(dots)
+            time.sleep(0.4)
 
 
 def _format_duration(seconds: float) -> str:

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -1963,38 +1963,61 @@ def handle_repair(args: argparse.Namespace) -> int:
         )
         return 0
 
-    # Repair path: show full diagnosis + plan, get confirmation, then clear
+    # Repair path: show compact summary + plan, get confirmation, then clear
     if not args.quiet:
         lines_to_clear = 0
 
-        # Full diagnosis report
-        formatter = DiagnosisReportFormatter()
-        report = formatter.format_report(diagnosis, skip_fix_section=True)
-        print(report)
-        lines_to_clear = len(report.split('\n'))
+        # Header
+        print(f"Repair: {args.instance_name} ({args.zone})")
+        lines_to_clear += 1
         print("")
         lines_to_clear += 1
+
+        # Compact issue summary grouped by category
+        from collections import Counter
+        category_counts: Dict[str, int] = Counter(
+            err['category'] for err in boot_errors
+        )
+        severity_counts: Dict[str, Dict[str, int]] = {}
+        for err in boot_errors:
+            cat = err['category']
+            sev = err.get('severity', 'error')
+            if cat not in severity_counts:
+                severity_counts[cat] = Counter()
+            severity_counts[cat][sev] += 1
+
+        for cat, count in category_counts.items():
+            sev_parts = []
+            for sev in ('critical', 'error', 'warning'):
+                if severity_counts[cat].get(sev, 0) > 0:
+                    sev_parts.append(f"{severity_counts[cat][sev]} {sev}")
+            sev_str = ', '.join(sev_parts)
+            issue_word = 'issue' if count == 1 else 'issues'
+            print(f"  Found {count} {cat} {issue_word} ({sev_str})")
+            lines_to_clear += 1
 
         # Unfixable warnings
         if unfixable:
             for cat in unfixable:
                 print(
-                    f"{warning_prefix()} [{cat.upper()}] issue detected but "
-                    f"no automated fix available. Will require manual repair."
+                    f"  {warning_prefix()} [{cat.upper()}] requires manual repair"
                 )
                 lines_to_clear += 1
-            print("")
-            lines_to_clear += 1
+
+        print("  Run 'diagnose' for details.")
+        lines_to_clear += 1
+        print("")
+        lines_to_clear += 1
 
         # Repair plan
-        print("Repair plan:")
+        print("  Repair plan:")
         lines_to_clear += 1
         step = 1
         if snapshot_enabled:
-            print(f"  {step}. Create backup snapshot of boot disk")
+            print(f"    {step}. Create backup snapshot of boot disk")
             lines_to_clear += 1
             step += 1
-        print(f"  {step}. Enter rescue mode (stop VM, swap boot disk)")
+        print(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
         lines_to_clear += 1
         step += 1
         fix_descriptions = {
@@ -2002,22 +2025,18 @@ def handle_repair(args: argparse.Namespace) -> int:
         }
         for cat in fixable:
             desc = fix_descriptions.get(cat, f'Fix {cat}')
-            print(f"  {step}. {desc}")
+            print(f"    {step}. {desc}")
             lines_to_clear += 1
             step += 1
-        print(f"  {step}. Restore original boot disk and start VM")
+        print(f"    {step}. Restore original boot disk and start VM")
         lines_to_clear += 1
         print("")
         lines_to_clear += 1
 
         # Confirmation
         try:
-            safety_note = ""
-            if snapshot_enabled:
-                safety_note = " A backup snapshot will be created before any changes."
             response = input(
-                f"This will stop the VM, apply fixes, and restart it.{safety_note} "
-                f"Proceed? [y/N]: "
+                "  Proceed? [y/N]: "
             ).strip().lower()
         except (KeyboardInterrupt, EOFError):
             print("\nAborted.")

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -22,7 +22,7 @@ import yaml
 from typing import Optional, Dict, Any, List
 from .core.config import RescueConfig, RestoreConfig, VERSION
 from .main import rescue_vm, restore_vm, repair_vm
-from .utils.colors import error_prefix, warning_prefix, clear_lines
+from .utils.colors import error_prefix, warning_prefix, clear_lines, green
 from .utils.report_formatter import DiagnosisReportFormatter
 from .orchestration.checkpoint import CheckpointManager, CheckpointData
 
@@ -1594,7 +1594,7 @@ def _show_boot_verification(boot_verified: Optional[bool],
                             vm_name: str, zone: str) -> None:
     """Display boot verification result after repair."""
     if boot_verified is True:
-        print("Boot verification: VM is booting normally.")
+        print(green("Boot verification: VM is booting normally."))
     elif boot_verified is False:
         print("")
         print(f"{warning_prefix()} VM may still have boot issues:")
@@ -1625,7 +1625,8 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         print("")
         print("Repair results:")
         for line in fix_lines:
-            print(f"  {line}")
+            colored_line = line.replace('[FIXED]', green('[FIXED]'), 1)
+            print(f"  {colored_line}")
         issue_word = "issue" if fixed_count == 1 else "issues"
         print(f"  {fixed_count} {issue_word} fixed.")
         if any('fstab' in line.lower() for line in fix_lines):
@@ -1931,23 +1932,25 @@ def handle_repair(args: argparse.Namespace) -> int:
     if diagnosis is None:
         return 1
 
-    # Show diagnosis report (skip manual fix steps since repair plan follows)
+    # Analyze diagnosis results
     diagnosis['project'] = project
-    formatter = DiagnosisReportFormatter()
-    print(formatter.format_report(diagnosis, skip_fix_section=True))
-    print("")
-
-    # Check if there are any boot errors
     boot_errors = diagnosis.get('boot_errors', [])
+    fixable = orchestrator.get_fixable_categories(diagnosis)
+    unfixable = orchestrator.get_unfixable_categories(diagnosis)
+    snapshot_enabled = getattr(args, 'snapshot', True)
+
+    # Non-repair paths: show full diagnosis and return
     if not boot_errors:
+        formatter = DiagnosisReportFormatter()
+        print(formatter.format_report(diagnosis, skip_fix_section=True))
+        print("")
         print("No boot issues found. Repair not needed.")
         return 0
 
-    # Check if any errors are fixable
-    fixable = orchestrator.get_fixable_categories(diagnosis)
-    unfixable = orchestrator.get_unfixable_categories(diagnosis)
-
     if not fixable:
+        formatter = DiagnosisReportFormatter()
+        print(formatter.format_report(diagnosis, skip_fix_section=True))
+        print("")
         for cat in unfixable:
             print(
                 f"Detected [{cat.upper()}] issue but automated fix is not yet available."
@@ -1960,36 +1963,54 @@ def handle_repair(args: argparse.Namespace) -> int:
         )
         return 0
 
-    # Show unfixable categories as warnings
-    if unfixable:
-        for cat in unfixable:
-            print(
-                f"{warning_prefix()} [{cat.upper()}] issue detected but "
-                f"no automated fix available. Will require manual repair."
-            )
-        print("")
-
-    # Show repair plan
-    snapshot_enabled = getattr(args, 'snapshot', True)
-    print("Repair plan:")
-    step = 1
-    if snapshot_enabled:
-        print(f"  {step}. Create backup snapshot of boot disk")
-        step += 1
-    print(f"  {step}. Enter rescue mode (stop VM, swap boot disk)")
-    step += 1
-    fix_descriptions = {
-        'fstab': 'Fix /etc/fstab (comment out invalid entries)',
-    }
-    for cat in fixable:
-        desc = fix_descriptions.get(cat, f'Fix {cat}')
-        print(f"  {step}. {desc}")
-        step += 1
-    print(f"  {step}. Restore original boot disk and start VM")
-    print("")
-
-    # Confirmation (unless --quiet)
+    # Repair path: show full diagnosis + plan, get confirmation, then clear
     if not args.quiet:
+        lines_to_clear = 0
+
+        # Full diagnosis report
+        formatter = DiagnosisReportFormatter()
+        report = formatter.format_report(diagnosis, skip_fix_section=True)
+        print(report)
+        lines_to_clear = len(report.split('\n'))
+        print("")
+        lines_to_clear += 1
+
+        # Unfixable warnings
+        if unfixable:
+            for cat in unfixable:
+                print(
+                    f"{warning_prefix()} [{cat.upper()}] issue detected but "
+                    f"no automated fix available. Will require manual repair."
+                )
+                lines_to_clear += 1
+            print("")
+            lines_to_clear += 1
+
+        # Repair plan
+        print("Repair plan:")
+        lines_to_clear += 1
+        step = 1
+        if snapshot_enabled:
+            print(f"  {step}. Create backup snapshot of boot disk")
+            lines_to_clear += 1
+            step += 1
+        print(f"  {step}. Enter rescue mode (stop VM, swap boot disk)")
+        lines_to_clear += 1
+        step += 1
+        fix_descriptions = {
+            'fstab': 'Fix /etc/fstab (comment out invalid entries)',
+        }
+        for cat in fixable:
+            desc = fix_descriptions.get(cat, f'Fix {cat}')
+            print(f"  {step}. {desc}")
+            lines_to_clear += 1
+            step += 1
+        print(f"  {step}. Restore original boot disk and start VM")
+        lines_to_clear += 1
+        print("")
+        lines_to_clear += 1
+
+        # Confirmation
         try:
             safety_note = ""
             if snapshot_enabled:
@@ -2005,9 +2026,38 @@ def handle_repair(args: argparse.Namespace) -> int:
         if response not in ('y', 'yes'):
             print("\nAborted by user.")
             return 0
-        print("")
 
-    # Execute repair
+        lines_to_clear += 1  # input line
+        lines_to_clear += 1  # buffer for ANSI padding / print trailing newline
+
+        # Clear diagnosis + plan + confirmation
+        clear_lines(lines_to_clear)
+
+    # Print concise repair header
+    print(f"Repairing instance [{args.instance_name}]:")
+    if len(boot_errors) == 1:
+        err = boot_errors[0]
+        print(f"  Issue:  [{err['category'].upper()}] {err['description']}")
+    else:
+        for i, err in enumerate(boot_errors[:3]):
+            label = "  Issues:" if i == 0 else "         "
+            print(f"{label} [{err['category'].upper()}] {err['description']}")
+        if len(boot_errors) > 3:
+            print(f"          ... and {len(boot_errors) - 3} more")
+
+    plan_parts = []
+    if snapshot_enabled:
+        plan_parts.append("Snapshot")
+    plan_parts.append("Rescue")
+    fix_labels = {'fstab': 'Fix fstab'}
+    for cat in fixable:
+        plan_parts.append(fix_labels.get(cat, f'Fix {cat}'))
+    plan_parts.append("Restore")
+    print(f"  Plan:   {' -> '.join(plan_parts)}")
+    print("")
+
+    # Execute repair (concise header already printed)
+    orchestrator._suppress_header = True
     result = orchestrator.execute(diagnosis)
     return _show_repair_results(result, args.instance_name,
                                 zone=args.zone, project=project)

--- a/gce_rescue_v2/cli.py
+++ b/gce_rescue_v2/cli.py
@@ -1939,26 +1939,26 @@ def handle_repair(args: argparse.Namespace) -> int:
     unfixable = orchestrator.get_unfixable_categories(diagnosis)
     snapshot_enabled = getattr(args, 'snapshot', True)
 
-    # Non-repair paths: show full diagnosis and return
+    # Non-repair paths: compact message and return
     if not boot_errors:
-        formatter = DiagnosisReportFormatter()
-        print(formatter.format_report(diagnosis, skip_fix_section=True))
+        print(f"Repair: {args.instance_name} ({args.zone})")
         print("")
-        print("No boot issues found. Repair not needed.")
+        print("  No boot issues found. Nothing to repair.")
+        print("  Run 'diagnose' for details.")
         return 0
 
     if not fixable:
-        formatter = DiagnosisReportFormatter()
-        print(formatter.format_report(diagnosis, skip_fix_section=True))
+        print(f"Repair: {args.instance_name} ({args.zone})")
         print("")
         for cat in unfixable:
             print(
-                f"Detected [{cat.upper()}] issue but automated fix is not yet available."
+                f"  Detected [{cat.upper()}] issue but automated fix is not yet available."
             )
+        print("  Run 'diagnose' for details.")
         print("")
-        print("Use rescue mode for manual repair:")
+        print("  Use rescue mode for manual repair:")
         print(
-            f"  $ gce-rescue-v2 rescue {args.instance_name} "
+            f"    $ gce-rescue-v2 rescue {args.instance_name} "
             f"--zone={args.zone} --project={project}"
         )
         return 0

--- a/gce_rescue_v2/core/boot_patterns.py
+++ b/gce_rescue_v2/core/boot_patterns.py
@@ -260,7 +260,8 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                               for err in detected_errors):
                         # Extract context around the error
                         context, match_idx = _extract_context_lines(
-                            serial_output, match.group(0)
+                            serial_output, match.group(0),
+                            context_lines=1
                         )
 
                         detected_errors.append(BootError(

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -29,6 +29,7 @@ import httplib2
 
 from ..core.config import RescueConfig, RestoreConfig, VERSION
 from ..operations import DiagnoseOperation
+from ..utils.colors import green, red
 from .rescue import RescueOrchestrator
 from .restore import RestoreOrchestrator
 
@@ -83,6 +84,10 @@ class RepairOrchestrator:
         self._current_phase = ''
         self._current_substep = ''
         self._current_line_substeps: List[str] = []
+
+        # When True, _init_progress() skips the "Repairing instance" header
+        # (caller prints its own concise header before execute())
+        self._suppress_header = False
 
     def _log_info(self, message: str):
         if self.logger:
@@ -642,9 +647,12 @@ class RepairOrchestrator:
         self._log_debug(
             f"Waiting {BOOT_WAIT_SECONDS}s for VM to boot before verification"
         )
-        sys.stdout.write("Verifying boot...")
-        sys.stdout.flush()
-        time.sleep(BOOT_WAIT_SECONDS)
+        for remaining in range(BOOT_WAIT_SECONDS, 0, -1):
+            sys.stdout.write(
+                f"\rVerifying boot (waiting {remaining}s for serial output)..."
+            )
+            sys.stdout.flush()
+            time.sleep(1)
 
         try:
             compute = self._create_tracked_client('repair-boot-verify')
@@ -655,7 +663,7 @@ class RepairOrchestrator:
             serial_output = serial_response.get('contents', '')
 
             if not serial_output or len(serial_output.strip()) < 50:
-                sys.stdout.write("\r" + " " * 40 + "\r")
+                sys.stdout.write("\r" + " " * 60 + "\r")
                 sys.stdout.flush()
                 self._log_debug("Serial output too short for boot verification")
                 return {'verified': None, 'errors': []}
@@ -667,7 +675,7 @@ class RepairOrchestrator:
                 vm_status='RUNNING'
             )
 
-            sys.stdout.write("\r" + " " * 40 + "\r")
+            sys.stdout.write("\r" + " " * 60 + "\r")
             sys.stdout.flush()
 
             if diagnosis.diagnosis_status == 'healthy':
@@ -686,7 +694,7 @@ class RepairOrchestrator:
                 return {'verified': None, 'errors': []}
 
         except Exception as e:
-            sys.stdout.write("\r" + " " * 40 + "\r")
+            sys.stdout.write("\r" + " " * 60 + "\r")
             sys.stdout.flush()
             self._log_debug(f"Boot verification failed: {e}")
             return {'verified': None, 'errors': []}
@@ -729,8 +737,9 @@ class RepairOrchestrator:
         self._current_line_substeps: List[str] = []
 
         if not self._is_debug_mode:
-            sys.stdout.write(f"Repairing instance [{self.vm_name}]:\n")
-            sys.stdout.flush()
+            if not self._suppress_header:
+                sys.stdout.write(f"Repairing instance [{self.vm_name}]:\n")
+                sys.stdout.flush()
             self._spinner_stop = False
             self._spinner_thread = threading.Thread(
                 target=self._run_spinner, daemon=True
@@ -769,7 +778,7 @@ class RepairOrchestrator:
                     trail = substep
 
             phase_num = len(self._progress_phases)
-            prefix = f"  ({phase_num}/3) {phase + ':':<9}"
+            prefix = f"  ({phase_num}/{self._total_steps}) {phase + ':':<9}"
             if trail:
                 line = f"\r{prefix} {trail}{dots[idx]}"
             else:
@@ -801,11 +810,12 @@ class RepairOrchestrator:
         if prev_phase and not self._is_debug_mode:
             trail = " -> ".join(prev_substeps) if prev_substeps else ""
             prev_num = len(self._progress_phases) - 1
-            prefix = f"  ({prev_num}/3) {prev_phase + ':':<9}"
+            prefix = f"  ({prev_num}/{self._total_steps}) {prev_phase + ':':<9}"
+            done = green("done.")
             if trail:
-                final = f"\r{prefix} {trail}  done."
+                final = f"\r{prefix} {trail}  {done}"
             else:
-                final = f"\r{prefix} done."
+                final = f"\r{prefix} {done}"
             sys.stdout.write(f"{final:<120}\n")
             sys.stdout.flush()
 
@@ -832,8 +842,8 @@ class RepairOrchestrator:
 
             trail = " -> ".join(substeps) if substeps else ""
             phase_num = len(self._progress_phases)
-            prefix = f"  ({phase_num}/3) {phase + ':':<9}" if phase else "  "
-            status_label = "done." if success else "FAILED."
+            prefix = f"  ({phase_num}/{self._total_steps}) {phase + ':':<9}" if phase else "  "
+            status_label = green("done.") if success else red("FAILED.")
 
             if trail:
                 final = f"\r{prefix} {trail}  {status_label}"

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -694,7 +694,8 @@ class RepairOrchestrator:
                 else:
                     trail = substep
 
-            prefix = f"  {phase + ':':<9}"
+            phase_num = len(self._progress_phases)
+            prefix = f"  ({phase_num}/3) {phase + ':':<9}"
             if trail:
                 line = f"\r{prefix} {trail}{dots[idx]}"
             else:
@@ -725,7 +726,8 @@ class RepairOrchestrator:
         # Finalize previous phase line (if any) as "done."
         if prev_phase and not self._is_debug_mode:
             trail = " -> ".join(prev_substeps) if prev_substeps else ""
-            prefix = f"  {prev_phase + ':':<9}"
+            prev_num = len(self._progress_phases) - 1
+            prefix = f"  ({prev_num}/3) {prev_phase + ':':<9}"
             if trail:
                 final = f"\r{prefix} {trail}  done."
             else:
@@ -755,7 +757,8 @@ class RepairOrchestrator:
                 substeps.append(substep)
 
             trail = " -> ".join(substeps) if substeps else ""
-            prefix = f"  {phase + ':':<9}" if phase else "  "
+            phase_num = len(self._progress_phases)
+            prefix = f"  ({phase_num}/3) {phase + ':':<9}" if phase else "  "
             status_label = "done." if success else "FAILED."
 
             if trail:

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -673,7 +673,7 @@ class RepairOrchestrator:
         When phase completes:
           Rescue:  Stopping VM -> Creating snapshot -> Creating rescue disk  done.
         """
-        spinner_chars = ['|', '/', '-', '\\']
+        dots = ['.  ', '.. ', '...']
         idx = 0
 
         while not self._spinner_stop:
@@ -683,7 +683,7 @@ class RepairOrchestrator:
                 substeps = list(self._current_line_substeps)
 
             if not phase:
-                time.sleep(0.1)
+                time.sleep(0.4)
                 continue
 
             # Build the substep trail for the current phase line
@@ -696,14 +696,14 @@ class RepairOrchestrator:
 
             prefix = f"  {phase + ':':<9}"
             if trail:
-                line = f"\r{prefix} {trail}..{spinner_chars[idx]}"
+                line = f"\r{prefix} {trail}{dots[idx]}"
             else:
-                line = f"\r{prefix} {spinner_chars[idx]}"
+                line = f"\r{prefix} {dots[idx]}"
 
             sys.stdout.write(f"{line:<120}")
             sys.stdout.flush()
-            idx = (idx + 1) % len(spinner_chars)
-            time.sleep(0.1)
+            idx = (idx + 1) % len(dots)
+            time.sleep(0.4)
 
     def _update_progress(self, phase: str):
         """Start a new phase, finalizing the previous phase line."""

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -541,23 +541,40 @@ class RepairOrchestrator:
         """Parse repair results from serial console output.
 
         Looks for GCE-REPAIR-LINE: and GCE-REPAIR-RESULT: markers.
+        Checks both default port and port 2 as fallback.
 
         Returns:
             Dict with: status, fixed_count, fix_lines, error
         """
+        serial_output = ''
         try:
             compute = self._create_tracked_client('repair-serial-parse')
+            # Try default port first (matches verify_startup behavior)
             serial_response = compute.instances().getSerialPortOutput(
                 project=self.project, zone=self.zone,
-                instance=self.vm_name, port=1
+                instance=self.vm_name
             ).execute()
             serial_output = serial_response.get('contents', '')
+
+            # If no repair markers found, try port 2 as fallback
+            if REPAIR_RESULT_MARKER not in serial_output:
+                self._log_debug("No repair markers on default port, trying port 2")
+                serial_response = compute.instances().getSerialPortOutput(
+                    project=self.project, zone=self.zone,
+                    instance=self.vm_name, port=2
+                ).execute()
+                port2_output = serial_response.get('contents', '')
+                if REPAIR_RESULT_MARKER in port2_output:
+                    serial_output = port2_output
         except Exception as e:
             self._log_debug(f"Could not fetch serial console: {e}")
             return {
                 'status': 'unknown', 'fixed_count': 0,
                 'fix_lines': [], 'error': f'Could not read serial console: {e}'
             }
+
+        # Strip control characters that may interfere with marker detection
+        serial_output = serial_output.replace('\r', '')
 
         # Extract repair lines
         fix_lines = []
@@ -588,6 +605,12 @@ class RepairOrchestrator:
                 elif result_str.startswith('FAILED:'):
                     status = 'failed'
                     error = result_str.split(':', 1)[1] if ':' in result_str else 'Unknown'
+
+        if status == 'unknown':
+            self._log_debug(
+                f"No repair markers found in serial output "
+                f"({len(serial_output)} bytes)"
+            )
 
         return {
             'status': status, 'fixed_count': fixed_count,

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -321,8 +321,13 @@ class RepairOrchestrator:
                 }
 
             self._finish_progress(True)
+
+            # Post-restore boot verification
+            boot_check = self._verify_boot_after_repair()
             repair_results['snapshot_name'] = snapshot_name
             repair_results['duration_seconds'] = time.time() - start_time
+            repair_results['boot_verified'] = boot_check.get('verified')
+            repair_results['boot_errors_after'] = boot_check.get('errors', [])
             return repair_results
 
         except Exception as e:
@@ -442,8 +447,13 @@ class RepairOrchestrator:
                 }
 
             self._finish_progress(True)
+
+            # Post-restore boot verification
+            boot_check = self._verify_boot_after_repair()
             repair_results['snapshot_name'] = snapshot_name
             repair_results['duration_seconds'] = time.time() - start_time
+            repair_results['boot_verified'] = boot_check.get('verified')
+            repair_results['boot_errors_after'] = boot_check.get('errors', [])
             return repair_results
 
         except Exception as e:
@@ -616,6 +626,70 @@ class RepairOrchestrator:
             'status': status, 'fixed_count': fixed_count,
             'fix_lines': fix_lines, 'error': error
         }
+
+    def _verify_boot_after_repair(self) -> Dict[str, Any]:
+        """Check if the VM boots successfully after repair.
+
+        Waits for the VM to generate new serial console output after restore,
+        then analyzes it for boot errors.
+
+        Returns:
+            Dict with: verified (bool/None), errors (list of error descriptions)
+        """
+        from ..core.boot_patterns import analyze_serial_output
+
+        BOOT_WAIT_SECONDS = 45
+        self._log_debug(
+            f"Waiting {BOOT_WAIT_SECONDS}s for VM to boot before verification"
+        )
+        sys.stdout.write("Verifying boot...")
+        sys.stdout.flush()
+        time.sleep(BOOT_WAIT_SECONDS)
+
+        try:
+            compute = self._create_tracked_client('repair-boot-verify')
+            serial_response = compute.instances().getSerialPortOutput(
+                project=self.project, zone=self.zone,
+                instance=self.vm_name
+            ).execute()
+            serial_output = serial_response.get('contents', '')
+
+            if not serial_output or len(serial_output.strip()) < 50:
+                sys.stdout.write("\r" + " " * 40 + "\r")
+                sys.stdout.flush()
+                self._log_debug("Serial output too short for boot verification")
+                return {'verified': None, 'errors': []}
+
+            diagnosis = analyze_serial_output(
+                serial_output=serial_output,
+                vm_name=self.vm_name,
+                zone=self.zone,
+                vm_status='RUNNING'
+            )
+
+            sys.stdout.write("\r" + " " * 40 + "\r")
+            sys.stdout.flush()
+
+            if diagnosis.diagnosis_status == 'healthy':
+                self._log_debug("Boot verification: VM is booting normally")
+                return {'verified': True, 'errors': []}
+            elif diagnosis.diagnosis_status == 'boot_errors_detected':
+                error_descs = [
+                    f"{e.category}: {e.description}"
+                    for e in diagnosis.boot_errors
+                ]
+                self._log_debug(
+                    f"Boot verification: {len(error_descs)} error(s) still detected"
+                )
+                return {'verified': False, 'errors': error_descs}
+            else:
+                return {'verified': None, 'errors': []}
+
+        except Exception as e:
+            sys.stdout.write("\r" + " " * 40 + "\r")
+            sys.stdout.flush()
+            self._log_debug(f"Boot verification failed: {e}")
+            return {'verified': None, 'errors': []}
 
     # --- Progress display ---
 

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -36,6 +36,16 @@ from .restore import RestoreOrchestrator
 # Categories that have automated fix scripts
 SUPPORTED_FIX_CATEGORIES: Set[str] = {'fstab'}
 
+# Validate fix scripts exist at import time (fail fast, not during a repair)
+_FIXES_DIR = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
+for _cat in SUPPORTED_FIX_CATEGORIES:
+    _script = _FIXES_DIR / f'{_cat}_fix.sh'
+    if not _script.exists():
+        raise ImportError(
+            f"Fix script missing for supported category '{_cat}': {_script}. "
+            f"SUPPORTED_FIX_CATEGORIES is out of sync with available fix scripts."
+        )
+
 # Marker prefixes emitted by fix scripts to serial console
 REPAIR_LINE_MARKER = 'GCE-REPAIR-LINE:'
 REPAIR_RESULT_MARKER = 'GCE-REPAIR-RESULT:'
@@ -517,8 +527,13 @@ class RepairOrchestrator:
         fix_scripts = []
         for category in fixable:
             fix_script = self._get_fix_script(category)
-            if fix_script:
-                fix_scripts.append(fix_script)
+            fix_scripts.append(fix_script)
+
+        if not fix_scripts:
+            raise ValueError(
+                f"No fix scripts were loaded for categories {fixable}. "
+                f"Cannot proceed with repair."
+            )
 
         # Combine: base script + fix scripts + completion marker
         combined = base_script + '\n'
@@ -534,17 +549,30 @@ class RepairOrchestrator:
 
         return combined
 
-    def _get_fix_script(self, category: str) -> Optional[str]:
-        """Load fix script template for a category."""
+    def _get_fix_script(self, category: str) -> str:
+        """Load fix script template for a category.
+
+        Raises:
+            FileNotFoundError: If the fix script file does not exist.
+            ValueError: If the fix script file is empty.
+        """
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
         script_path = fixes_dir / f'{category}_fix.sh'
 
         if not script_path.exists():
-            self._log_debug(f"No fix script found for category: {category}")
-            return None
+            raise FileNotFoundError(
+                f"Fix script missing for category '{category}': {script_path}. "
+                f"Cannot proceed with repair — the fix would not be applied."
+            )
 
         with open(script_path, 'r') as f:
             content = f.read()
+
+        if not content.strip():
+            raise ValueError(
+                f"Fix script for category '{category}' is empty: {script_path}. "
+                f"Cannot proceed with repair — the fix would not be applied."
+            )
 
         # Remove shebang line if present (already in base script)
         if content.startswith('#!/bin/bash'):

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -36,16 +36,6 @@ from .restore import RestoreOrchestrator
 # Categories that have automated fix scripts
 SUPPORTED_FIX_CATEGORIES: Set[str] = {'fstab'}
 
-# Validate fix scripts exist at import time (fail fast, not during a repair)
-_FIXES_DIR = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
-for _cat in SUPPORTED_FIX_CATEGORIES:
-    _script = _FIXES_DIR / f'{_cat}_fix.sh'
-    if not _script.exists():
-        raise ImportError(
-            f"Fix script missing for supported category '{_cat}': {_script}. "
-            f"SUPPORTED_FIX_CATEGORIES is out of sync with available fix scripts."
-        )
-
 # Marker prefixes emitted by fix scripts to serial console
 REPAIR_LINE_MARKER = 'GCE-REPAIR-LINE:'
 REPAIR_RESULT_MARKER = 'GCE-REPAIR-RESULT:'
@@ -169,6 +159,18 @@ class RepairOrchestrator:
                 file=sys.stderr
             )
             return False
+
+        # Verify fix scripts exist for all supported categories
+        fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
+        for cat in SUPPORTED_FIX_CATEGORIES:
+            script_path = fixes_dir / f'{cat}_fix.sh'
+            if not script_path.exists():
+                self._log_error(
+                    f"Fix script missing for category '{cat}': {script_path}\n"
+                    f"The repair tool may not be installed correctly. "
+                    f"Try reinstalling: pip install --force-reinstall ."
+                )
+                return False
 
         self._log_debug("Validation passed")
         return True

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -193,28 +193,28 @@ class RescueOrchestrator:
         import sys
         import time
 
-        spinner_chars = ['|', '/', '-', '\\']
+        dots = ['.  ', '.. ', '...']
         idx = 0
 
         while not self._spinner_stop:
             with self._progress_lock:
                 current_step = len(self._progress_phases)
                 if self._progress_phases:
-                    # Show completed phases, then current phase with dots and spinner
+                    # Show completed phases, then current phase with dots
                     completed = self._progress_phases[:-1]
                     current = self._progress_phases[-1]
                     if completed:
-                        phases_str = " -> ".join(completed) + " -> " + current + ".." + spinner_chars[idx]
+                        phases_str = " -> ".join(completed) + " -> " + current + dots[idx]
                     else:
-                        phases_str = current + ".." + spinner_chars[idx]
+                        phases_str = current + dots[idx]
                 else:
-                    phases_str = spinner_chars[idx]
+                    phases_str = dots[idx]
 
             line = f"\r ({current_step}/{self._total_steps}) [{phases_str}"
             sys.stdout.write(line)
             sys.stdout.flush()
-            idx = (idx + 1) % len(spinner_chars)
-            time.sleep(0.1)
+            idx = (idx + 1) % len(dots)
+            time.sleep(0.4)
 
     def _update_progress(self, phase: str):
         """Add a new phase to the progress display."""

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -164,28 +164,28 @@ class RestoreOrchestrator:
         import sys
         import time
 
-        spinner_chars = ['|', '/', '-', '\\']
+        dots = ['.  ', '.. ', '...']
         idx = 0
 
         while not self._spinner_stop:
             with self._progress_lock:
                 current_step = len(self._progress_phases)
                 if self._progress_phases:
-                    # Show completed phases, then current phase with dots and spinner
+                    # Show completed phases, then current phase with dots
                     completed = self._progress_phases[:-1]
                     current = self._progress_phases[-1]
                     if completed:
-                        phases_str = " -> ".join(completed) + " -> " + current + ".." + spinner_chars[idx]
+                        phases_str = " -> ".join(completed) + " -> " + current + dots[idx]
                     else:
-                        phases_str = current + ".." + spinner_chars[idx]
+                        phases_str = current + dots[idx]
                 else:
-                    phases_str = spinner_chars[idx]
+                    phases_str = dots[idx]
 
             line = f"\r ({current_step}/{self._total_steps}) [{phases_str}"
             sys.stdout.write(line)
             sys.stdout.flush()
-            idx = (idx + 1) % len(spinner_chars)
-            time.sleep(0.1)
+            idx = (idx + 1) % len(dots)
+            time.sleep(0.4)
 
     def _update_progress(self, phase: str):
         """Add a new phase to the progress display."""

--- a/gce_rescue_v2/pyproject.toml
+++ b/gce_rescue_v2/pyproject.toml
@@ -55,7 +55,13 @@ where = ["."]
 include = ["gce_rescue_v2*"]
 
 [tool.setuptools.package-data]
-gce_rescue_v2 = ["startup_scripts/*.sh", "startup_scripts/*.ps1"]
+gce_rescue_v2 = [
+    "startup_scripts/*.sh",
+    "startup_scripts/*.ps1",
+    "startup_scripts/fixes/*.sh",
+    "core/patterns/*.yaml",
+    "core/patterns/README.md",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/gce_rescue_v2/startup_scripts/fixes/fstab_fix.sh
+++ b/gce_rescue_v2/startup_scripts/fixes/fstab_fix.sh
@@ -9,7 +9,8 @@
 #   - UUID= entries: verified against blkid output
 #   - LABEL= entries: verified against blkid output
 #   - PARTUUID= entries: verified against blkid output
-#   - /dev/ entries: mapped to target disk, checked existence + fstype match
+#   - /dev/ entries: boot disk partitions mapped + validated; secondary disk
+#                    entries flagged (not present on rescue VM)
 #   - Malformed entries: fewer than 3 fields
 #   - Virtual filesystems (proc, tmpfs, etc.): always skipped
 
@@ -101,7 +102,34 @@ if [ -n "$TARGET_DISK_BASE" ]; then
     done < <(lsblk -rno NAME,FSTYPE "$TARGET_DISK_BASE" 2>/dev/null | grep -v "^${TARGET_DISK_SHORT} ")
 fi
 
-# Function to check /dev/ device entries by mapping to target disk
+# --- Determine original boot disk device base from fstab root entry ---
+# On GCE: boot disk is typically /dev/sda, secondary disks are /dev/sdb, sdc, etc.
+# On rescue VM: rescue disk = /dev/sda, original boot disk = /dev/sdb.
+# We need to know the original boot base to distinguish boot disk partitions
+# from secondary disk entries that may reference detached disks.
+ORIGINAL_BOOT_BASE=""
+while IFS= read -r fline; do
+    echo "$fline" | grep -qE '^\s*$|^\s*#' && continue
+    fmountpoint=$(echo "$fline" | awk '{print $2}')
+    fdevice=$(echo "$fline" | awk '{print $1}')
+    if [ "$fmountpoint" = "/" ]; then
+        if echo "$fdevice" | grep -q '^/dev/'; then
+            ORIGINAL_BOOT_BASE=$(basename "$fdevice" | sed 's/[0-9]*$//')
+        fi
+        break
+    fi
+done < "$FSTAB"
+
+# Default: GCE boot disk is almost always /dev/sda
+if [ -z "$ORIGINAL_BOOT_BASE" ]; then
+    ORIGINAL_BOOT_BASE="sda"
+    log "Root uses UUID/PARTUUID, assuming original boot device base: sda"
+else
+    log "Original boot device base from fstab: $ORIGINAL_BOOT_BASE"
+fi
+
+# Function to check /dev/ device entries
+# Return codes: 0=valid, 1=missing device, 2=fstype mismatch, 3=secondary disk not present
 check_dev_entry() {
     local device="$1"
     local fstab_fstype="$2"
@@ -128,7 +156,16 @@ check_dev_entry() {
         return 0  # never comment out root
     fi
 
-    # If we have target disk info, do a mapped check
+    # Check if this is a boot disk partition or a secondary disk
+    if [ -n "$ORIGINAL_BOOT_BASE" ] && [ "$dev_base" != "$ORIGINAL_BOOT_BASE" ]; then
+        # Different device base than boot disk — this is a secondary disk.
+        # Secondary disks are not attached to the rescue VM, so we can't
+        # validate them. Flag as missing.
+        log "Device $device: secondary disk (base $dev_base != boot base $ORIGINAL_BOOT_BASE)"
+        return 3  # secondary disk not present
+    fi
+
+    # This is a boot disk partition — map to target disk and validate
     if [ -n "$TARGET_DISK_BASE" ] && [ -n "$dev_partnum" ]; then
         # Check if this partition exists on the target disk
         local mapped_dev="${TARGET_DISK_BASE}${dev_partnum}"
@@ -232,7 +269,13 @@ while IFS= read -r line; do
     if echo "$device" | grep -q '^/dev/'; then
         check_dev_entry "$device" "$fstype" "$mountpoint"
         check_result=$?
-        if [ $check_result -eq 1 ]; then
+        if [ $check_result -eq 3 ]; then
+            echo "# GCE-REPAIR: commented out secondary disk entry (disk not attached)" >> "$tmpfile"
+            echo "#$line" >> "$tmpfile"
+            fixes=$((fixes + 1))
+            repair_line "[FIXED] fstab: Commented out secondary disk entry for $mountpoint ($device)"
+            continue
+        elif [ $check_result -eq 1 ]; then
             echo "# GCE-REPAIR: commented out missing device entry" >> "$tmpfile"
             echo "#$line" >> "$tmpfile"
             fixes=$((fixes + 1))

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -329,15 +329,11 @@ class TestRepairScript:
         script = orch._generate_repair_script(diagnosis)
         assert 'marker moved to end' in script
 
-    def test_unsupported_category_not_included(self):
-        """Fix script for unsupported category should not be injected."""
+    def test_missing_fix_script_raises_error(self):
+        """Fix script for category without a .sh file should raise, not silently skip."""
         orch = self._make_orchestrator()
-        diagnosis = {
-            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
-        }
-        # No fixable categories, _generate_repair_script won't be called normally
-        # but let's test _get_fix_script directly
-        assert orch._get_fix_script('grub') is None
+        with pytest.raises(FileNotFoundError, match="Fix script missing for category 'grub'"):
+            orch._get_fix_script('grub')
 
 
 # ---------------------------------------------------------------------------

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -227,10 +227,9 @@ class TestErrorsReport:
                 assert '<--' not in line
 
     def test_rescue_command_in_fix_section(self, formatter, single_error_diagnosis):
-        """Fix section should contain rescue command exactly once."""
+        """Fix section should contain rescue command in manual steps."""
         report = formatter.format_report(single_error_diagnosis)
-        rescue_count = report.count('gce-rescue-v2 rescue test-vm')
-        assert rescue_count == 1
+        assert 'gce-rescue-v2 rescue test-vm' in report
 
     def test_restore_command_in_fix_section(self, formatter, single_error_diagnosis):
         """Fix section should contain restore command."""
@@ -469,17 +468,26 @@ class TestAutoRepairSuggestion:
     def test_auto_repair_shown_for_fstab(
         self, formatter, single_error_diagnosis
     ):
-        """When fstab error is detected, auto-repair suggestion should appear."""
+        """When fstab error is detected, auto-repair should lead the fix section."""
         report = formatter.format_report(single_error_diagnosis)
-        assert 'Or auto-repair:' in report
+        assert 'Auto-repair (recommended):' in report
         assert 'gce-rescue-v2 repair' in report
+
+    def test_auto_repair_before_manual(
+        self, formatter, single_error_diagnosis
+    ):
+        """Auto-repair should appear before manual steps."""
+        report = formatter.format_report(single_error_diagnosis)
+        repair_pos = report.find('Auto-repair')
+        manual_pos = report.find('Or fix manually:')
+        assert repair_pos < manual_pos
 
     def test_auto_repair_shown_for_multi_error_with_fstab(
         self, formatter, multi_error_diagnosis
     ):
         """When any fixable category is present, auto-repair should appear."""
         report = formatter.format_report(multi_error_diagnosis)
-        assert 'Or auto-repair:' in report
+        assert 'Auto-repair (recommended):' in report
         assert 'gce-rescue-v2 repair' in report
 
     def test_no_auto_repair_for_unfixable_only(self, formatter):
@@ -507,7 +515,8 @@ class TestAutoRepairSuggestion:
             'recommendations': [],
         }
         report = formatter.format_report(diagnosis)
-        assert 'Or auto-repair:' not in report
+        assert 'Auto-repair' not in report
+        assert 'Or fix manually:' not in report
         assert 'gce-rescue-v2 repair' not in report
 
     def test_auto_repair_line_has_vm_name(

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -138,13 +138,8 @@ class DiagnosisReportFormatter:
         matched_idx = error.get('matched_line_index', -1)
         fixes = error.get('suggested_fixes', [])
 
-        # Color the severity label
-        if severity == 'CRITICAL':
-            sev_label = red(f"{'CRITICAL':<9}")
-        elif severity == 'ERROR':
-            sev_label = red(f"{'ERROR':<9}")
-        else:
-            sev_label = yellow(f"{'WARNING':<9}")
+        # Style the severity label (bold, no color)
+        sev_label = bold(f"{severity:<9}")
 
         lines = []
 
@@ -158,11 +153,15 @@ class DiagnosisReportFormatter:
         # Serial console log lines
         if context:
             lines.append(f"{indent}Serial console:")
+            max_width = 100
             for i, ctx_line in enumerate(context):
                 if not ctx_line.strip():
                     continue
+                ctx_line = _decode_systemd_escapes(ctx_line)
+                if len(ctx_line) > max_width:
+                    ctx_line = ctx_line[:max_width] + "..."
                 if i == matched_idx:
-                    lines.append(f"{indent}  {dim(ctx_line)}  <--")
+                    lines.append(f"{indent}  {dim(ctx_line)}  {red('<--')}")
                 else:
                     lines.append(f"{indent}  {dim(ctx_line)}")
 
@@ -185,12 +184,7 @@ class DiagnosisReportFormatter:
         issue_word = "this issue" if len(errors) == 1 else "these issues"
         lines = [f"To fix {issue_word}:", ""]
 
-        # Step 1: Enter rescue mode
-        lines.append("  1. Enter rescue mode:")
-        lines.append(f"     $ gce-rescue-v2 rescue {vm_name} --zone={zone}")
-        lines.append("")
-
-        # Step 2: Category-aware fix guidance
+        # Collect unique categories
         categories = []
         seen = set()
         for err in errors:
@@ -199,35 +193,38 @@ class DiagnosisReportFormatter:
                 seen.add(cat)
                 categories.append(cat)
 
+        # Check if auto-repair is available
+        from ..orchestration.repair import SUPPORTED_FIX_CATEGORIES
+        auto_fixable = [c for c in categories if c in SUPPORTED_FIX_CATEGORIES]
+
+        # Lead with auto-repair when available
+        if auto_fixable:
+            lines.append("  Auto-repair (recommended):")
+            lines.append(f"    $ gce-rescue-v2 repair {vm_name} --zone={zone}")
+            lines.append("")
+            lines.append("  Or fix manually:")
+
+        # Manual steps
+        lines.append("    1. Enter rescue mode:")
+        lines.append(f"       $ gce-rescue-v2 rescue {vm_name} --zone={zone}")
+
+        # Category-aware fix guidance
         if len(categories) == 1:
-            # Single category - use specific guidance
             cat = categories[0]
             guidance = CATEGORY_FIX_GUIDANCE.get(cat)
             if guidance:
                 label = _category_label(cat)
-                lines.append(f"  2. {label}:")
-                lines.append(f"     $ {guidance}")
+                lines.append(f"    2. {label}:")
+                lines.append(f"       $ {guidance}")
         else:
-            # Multiple categories - list each
-            lines.append("  2. Repair boot configuration:")
+            lines.append("    2. Repair boot configuration:")
             for cat in categories:
                 guidance = CATEGORY_FIX_GUIDANCE.get(cat)
                 if guidance:
-                    lines.append(f"     - {guidance}")
+                    lines.append(f"       - {guidance}")
 
-        lines.append("")
-
-        # Step 3: Restore
-        lines.append("  3. Restore the VM:")
-        lines.append(f"     $ gce-rescue-v2 restore {vm_name} --zone={zone}")
-
-        # Show auto-repair alternative if any category supports it
-        from ..orchestration.repair import SUPPORTED_FIX_CATEGORIES
-        auto_fixable = [c for c in categories if c in SUPPORTED_FIX_CATEGORIES]
-        if auto_fixable:
-            lines.append("")
-            lines.append("Or auto-repair:")
-            lines.append(f"  $ gce-rescue-v2 repair {vm_name} --zone={zone}")
+        lines.append("    3. Restore the VM:")
+        lines.append(f"       $ gce-rescue-v2 restore {vm_name} --zone={zone}")
 
         return "\n".join(lines)
 
@@ -288,6 +285,12 @@ class DiagnosisReportFormatter:
         lines.append(f"  $ gce-rescue-v2 diagnose {vm_name} --zone={zone}")
 
         return "\n".join(lines)
+
+
+def _decode_systemd_escapes(text: str) -> str:
+    """Decode systemd hex escape sequences (e.g. \\x2d -> '-') for readability."""
+    import re
+    return re.sub(r'\\x([0-9a-fA-F]{2})', lambda m: chr(int(m.group(1), 16)), text)
 
 
 def _category_label(category: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
       'gce_rescue_v2': [
           'startup_scripts/*.sh',
           'startup_scripts/*.ps1',
+          'startup_scripts/fixes/*.sh',
           'core/patterns/*.yaml',
           'core/patterns/README.md',
       ],


### PR DESCRIPTION
## Summary
- Add post-restore boot verification to repair command
- Improve diagnose/repair output readability (compact prompts, bold severity labels, red arrows, systemd escape decoding, line truncation)
- Compact repair output for no-issues and unfixable cases
- Add phase counters (1/3, 2/3, 3/3) to repair progress
- Fix fstab fix script to detect secondary disk entries
- Include fix scripts and pattern YAML in package data

## Test plan
- [x] Run `python -m pytest gce_rescue_v2/tests/ -v` (335 passed, 4 skipped)
- [x] Test `diagnose` on healthy VM — shows compact "No boot issues detected"
- [x] Test `diagnose` on fstab-broken VM — shows issues with serial context and red arrows
- [x] Test `repair` on healthy VM — shows compact "Nothing to repair"
- [x] Test `repair` on fstab-broken VM — compact confirmation, auto-fix, boot verification
- [x] Test `repair --quiet` skips confirmation prompt