### PR TITLE
fix: Auto-detect rescue disk type for incompatible VM families

### DIFF
--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -32,7 +32,7 @@ class RescueConfig:
 
     # Rescue disk settings
     rescue_disk_size_gb: int = 10
-    rescue_disk_type: str = 'pd-standard'
+    rescue_disk_type: str = 'pd-balanced'
 
     # Linux rescue image (default)
     rescue_image_family: str = 'debian-12'  # Use newer kernel for XFS/Btrfs compatibility

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -12,7 +12,8 @@ Coordinates the rescue workflow:
 import time
 from ..core.config import RescueConfig, OS_TYPE_WINDOWS, OS_TYPE_LINUX
 from ..utils.os_detection import (
-    detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64
+    detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64,
+    get_rescue_disk_type
 )
 from ..validators import (
     ValidationRunner,
@@ -810,6 +811,12 @@ class RescueOrchestrator:
         self.architecture = detect_architecture(self.vm_info)
         self._log_debug(f"Detected OS: {get_os_display_name(self.os_type)}, Architecture: {self.architecture}")
 
+        # Auto-detect rescue disk type based on machine family
+        detected_disk_type = get_rescue_disk_type(self.vm_info, self.config.rescue_disk_type)
+        if detected_disk_type != self.config.rescue_disk_type:
+            self._log_debug(f"Machine type requires {detected_disk_type} (overriding {self.config.rescue_disk_type})")
+            self.config.rescue_disk_type = detected_disk_type
+
         for disk in self.vm_info.get('disks', []):
             if disk.get('boot'):
                 self.original_disk_name = disk['source'].split('/')[-1]
@@ -983,6 +990,11 @@ fi
         self._log_error("")
         self._log_error("Operation failed, rolling back...")
         rollback_success = self.rollback_handler.rollback(self.state_tracker, self.operations_map)
+
+        # Clear checkpoint after rollback regardless of success/failure.
+        # Success: VM is back to original state, no checkpoint needed.
+        # Failure: state is inconsistent, stale checkpoint won't help recovery.
+        self.checkpoint_manager.clear_checkpoint()
 
         if not rollback_success:
             self._log_error("")

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -811,6 +811,11 @@ class RestoreOrchestrator:
         self._log_error("Operation failed, rolling back to rescue mode...")
         rollback_success = self.rollback_handler.rollback(self.state_tracker, self.operations_map)
 
+        # Clear checkpoint after rollback regardless of success/failure.
+        # Success: VM is back to original state, no checkpoint needed.
+        # Failure: state is inconsistent, stale checkpoint won't help recovery.
+        self.checkpoint_manager.clear_checkpoint()
+
         if not rollback_success:
             self._log_error("")
             self._log_error("=" * 60)

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -388,3 +388,93 @@ def test_rescue_async_snapshot_failure_required_aborts(stub_rescue, monkeypatch)
     config = RescueConfig(create_snapshot=True, async_snapshot=True, require_snapshot=True)
     orch = _make_orch(config)
     assert orch.execute() is False
+
+
+# ===================================================================
+# Checkpoint cleared after rollback
+# ===================================================================
+
+
+def test_rescue_c4_uses_hyperdisk(stub_rescue, monkeypatch):
+    """C4 machine type auto-selects hyperdisk-balanced for rescue disk."""
+    captured = SimpleNamespace(disk_type=None)
+
+    def _fake_get_disk_info_c4(self):
+        self.vm_info = {
+            "machineType": "zones/z/machineTypes/c4-standard-2",
+            "disks": [{
+                "boot": True,
+                "source": "projects/p/zones/z/disks/original-boot",
+                "deviceName": "sda",
+            }]
+        }
+        # Call the real detection logic
+        from gce_rescue_v2.utils.os_detection import (
+            detect_os_type, detect_architecture, get_rescue_disk_type
+        )
+        self.os_type = detect_os_type(self.vm_info)
+        self.architecture = detect_architecture(self.vm_info)
+        detected_disk_type = get_rescue_disk_type(self.vm_info, self.config.rescue_disk_type)
+        if detected_disk_type != self.config.rescue_disk_type:
+            self.config.rescue_disk_type = detected_disk_type
+        self.original_disk_name = "original-boot"
+        self.original_device_name = "sda"
+
+    def _capture_create_disk(self, *args, **kwargs):
+        captured.disk_type = kwargs.get('disk_type')
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={},
+        )
+
+    monkeypatch.setattr(RescueOrchestrator, "_get_original_disk_info", _fake_get_disk_info_c4)
+    monkeypatch.setattr(CreateDiskOperation, "execute", _capture_create_disk)
+
+    config = RescueConfig(create_snapshot=False)
+    orch = _make_orch(config)
+    assert orch.execute() is True
+    assert captured.disk_type == 'hyperdisk-balanced'
+
+
+def test_rescue_rollback_clears_checkpoint(stub_rescue, monkeypatch):
+    """Rollback after failure clears the checkpoint metadata."""
+    from unittest.mock import MagicMock
+    from gce_rescue_v2.orchestration.rollback import RollbackHandler
+
+    # Let _rollback run (undo the no-op stub from fixture)
+    monkeypatch.undo()
+
+    # Re-apply all stubs except _rollback
+    for op_cls in ALL_RESCUE_OPS:
+        monkeypatch.setattr(op_cls, "execute", _success_execute)
+    monkeypatch.setattr(CheckpointManager, "create_checkpoint", lambda *a, **kw: None)
+    monkeypatch.setattr(CheckpointManager, "update_checkpoint", lambda *a, **kw: None)
+    monkeypatch.setattr(RescueOrchestrator, "_disk_exists", lambda self, n: False)
+    monkeypatch.setattr(RescueOrchestrator, "_is_disk_attached", lambda self, n: False)
+    monkeypatch.setattr(RescueOrchestrator, "_get_vm_status", lambda self: "TERMINATED")
+    monkeypatch.setattr(RescueOrchestrator, "_generate_startup_script", lambda self: "echo test")
+
+    def _fake_get_disk_info(self):
+        self.vm_info = {
+            "disks": [{"boot": True, "source": "projects/p/zones/z/disks/original-boot",
+                        "deviceName": "sda"}]
+        }
+        self.os_type = "linux"
+        self.architecture = "x86_64"
+        self.original_disk_name = "original-boot"
+        self.original_device_name = "sda"
+
+    monkeypatch.setattr(RescueOrchestrator, "_get_original_disk_info", _fake_get_disk_info)
+
+    # Stub rollback handler to succeed without real API calls
+    monkeypatch.setattr(RollbackHandler, "rollback", lambda self, *a, **kw: True)
+
+    # Track clear_checkpoint calls
+    clear_mock = MagicMock(return_value=True)
+    monkeypatch.setattr(CheckpointManager, "clear_checkpoint", clear_mock)
+
+    # Inject a failure so _rollback is triggered
+    monkeypatch.setattr(StopVMOperation, "execute", _failure_execute)
+
+    orch = _make_orch()
+    assert orch.execute() is False
+    clear_mock.assert_called_once()

--- a/gce_rescue_v2/tests/test_restore.py
+++ b/gce_rescue_v2/tests/test_restore.py
@@ -339,3 +339,58 @@ def test_restore_detach_original_failure_triggers_rollback(stub_restore, monkeyp
 
     orch = _make_orch()
     assert orch.execute() is False
+
+
+# ===================================================================
+# Checkpoint cleared after rollback
+# ===================================================================
+
+
+def test_restore_rollback_clears_checkpoint(stub_restore, monkeypatch):
+    """Rollback after failure clears the checkpoint metadata."""
+    from unittest.mock import MagicMock
+    from gce_rescue_v2.orchestration.rollback import RollbackHandler
+
+    # Let _rollback run (undo the no-op stub from fixture)
+    monkeypatch.undo()
+
+    # Re-apply all stubs except _rollback
+    ALL_RESTORE_OPS = [
+        StopVMOperation, DetachDiskOperation, AttachDiskOperation,
+        SetMetadataOperation, StartVMOperation, DeleteDiskOperation,
+    ]
+    for op_cls in ALL_RESTORE_OPS:
+        monkeypatch.setattr(op_cls, "execute", _success_execute)
+    monkeypatch.setattr(CheckpointManager, "create_checkpoint", lambda *a, **kw: None)
+    monkeypatch.setattr(CheckpointManager, "update_checkpoint", lambda *a, **kw: None)
+    monkeypatch.setattr(RestoreOrchestrator, "_is_disk_attached", lambda self, n: True)
+    monkeypatch.setattr(RestoreOrchestrator, "_is_disk_boot", lambda self, n: False)
+    monkeypatch.setattr(RestoreOrchestrator, "_get_vm_status", lambda self: "TERMINATED")
+    monkeypatch.setattr(RestoreOrchestrator, "_disk_exists", lambda self, n: True)
+    monkeypatch.setattr(RestoreOrchestrator, "_check_snapshot_status", lambda self: None)
+
+    def _fake_get_disk_info(self):
+        self.rescue_disk_name = "rescue-disk-123"
+        self.rescue_device_name = "disk-rescue"
+        self.original_disk_name = "orig-disk"
+        self.original_device_name = "sda"
+
+    monkeypatch.setattr(RestoreOrchestrator, "_get_disk_info", _fake_get_disk_info)
+    monkeypatch.setattr(
+        RestoreOrchestrator, "_get_clean_metadata",
+        lambda self: [{"key": "ssh-keys", "value": "user:key"}],
+    )
+
+    # Stub rollback handler to succeed without real API calls
+    monkeypatch.setattr(RollbackHandler, "rollback", lambda self, *a, **kw: True)
+
+    # Track clear_checkpoint calls
+    clear_mock = MagicMock(return_value=True)
+    monkeypatch.setattr(CheckpointManager, "clear_checkpoint", clear_mock)
+
+    # Inject a failure so _rollback is triggered
+    monkeypatch.setattr(StopVMOperation, "execute", _failure_execute)
+
+    orch = _make_orch()
+    assert orch.execute() is False
+    clear_mock.assert_called_once()

--- a/gce_rescue_v2/tests/test_vm_features.py
+++ b/gce_rescue_v2/tests/test_vm_features.py
@@ -5,12 +5,14 @@ Covers:
 - Architecture detection (x86_64, ARM64)
 - Shielded VM detection
 - Confidential VM detection
+- Rescue disk type detection (Hyperdisk-only families)
 """
 
 import pytest
 
 from gce_rescue_v2.utils.os_detection import (
     detect_architecture,
+    get_rescue_disk_type,
     is_shielded_vm,
     get_shielded_config,
     is_confidential_vm,
@@ -240,3 +242,102 @@ class TestConfidentialVMDetection:
         """Return empty string for non-confidential VM."""
         vm = {}
         assert get_confidential_type(vm) == ''
+
+
+class TestRescueDiskTypeDetection:
+    """Tests for get_rescue_disk_type function."""
+
+    def test_hyperdisk_c4(self):
+        """C4 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/c4-standard-2'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_n4(self):
+        """N4 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/n4-standard-4'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_c4a(self):
+        """C4A machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/c4a-standard-2'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_c4d(self):
+        """C4D machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'c4d-standard-8'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_m4(self):
+        """M4 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/m4-megamem-416'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_x4(self):
+        """X4 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/x4-megamem-960'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_a4(self):
+        """A4 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/a4-highgpu-8g'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_h4d(self):
+        """H4D machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/h4d-standard-4'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_h3(self):
+        """H3 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/h3-standard-88'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_a3(self):
+        """A3 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/a3-highgpu-8g'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_hyperdisk_z3(self):
+        """Z3 machine type requires hyperdisk-balanced."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/z3-standard-88'}
+        assert get_rescue_disk_type(vm) == 'hyperdisk-balanced'
+
+    def test_pd_balanced_e2(self):
+        """E2 machine type uses pd-balanced (default)."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/e2-micro'}
+        assert get_rescue_disk_type(vm) == 'pd-balanced'
+
+    def test_pd_balanced_n2(self):
+        """N2 machine type uses pd-balanced (default)."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/n2-standard-4'}
+        assert get_rescue_disk_type(vm) == 'pd-balanced'
+
+    def test_pd_balanced_c3(self):
+        """C3 machine type uses pd-balanced (no pd-standard support)."""
+        vm = {'machineType': 'zones/us-central1-a/machineTypes/c3-standard-4'}
+        assert get_rescue_disk_type(vm) == 'pd-balanced'
+
+    def test_pd_balanced_n1(self):
+        """N1 machine type uses pd-balanced (default)."""
+        vm = {'machineType': 'n1-standard-1'}
+        assert get_rescue_disk_type(vm) == 'pd-balanced'
+
+    def test_no_machine_type(self):
+        """Missing machineType field falls back to default."""
+        vm = {}
+        assert get_rescue_disk_type(vm) == 'pd-balanced'
+
+    def test_empty_machine_type(self):
+        """Empty machineType string falls back to default."""
+        vm = {'machineType': ''}
+        assert get_rescue_disk_type(vm) == 'pd-balanced'
+
+    def test_custom_default(self):
+        """Custom default is returned for standard families."""
+        vm = {'machineType': 'e2-micro'}
+        assert get_rescue_disk_type(vm, default='pd-ssd') == 'pd-ssd'
+
+    def test_custom_default_overridden_for_hyperdisk(self):
+        """Custom default is overridden for Hyperdisk-only families."""
+        vm = {'machineType': 'c4-standard-2'}
+        assert get_rescue_disk_type(vm, default='pd-ssd') == 'hyperdisk-balanced'

--- a/gce_rescue_v2/utils/os_detection.py
+++ b/gce_rescue_v2/utils/os_detection.py
@@ -181,6 +181,50 @@ def detect_license_type(vm: Dict[str, Any]) -> str:
     return 'unknown'
 
 
+# Machine families that only support Hyperdisk (no Persistent Disk at all).
+# These cannot use pd-balanced or any other PD type.
+HYPERDISK_ONLY_FAMILIES = frozenset([
+    'a3', 'a4',
+    'c4', 'c4a', 'c4d',
+    'h3', 'h4d',
+    'm4',
+    'n4', 'n4a', 'n4d',
+    'x4',
+    'z3',
+])
+
+
+def get_rescue_disk_type(vm: Dict[str, Any], default: str = 'pd-balanced') -> str:
+    """Get the appropriate rescue disk type based on the VM's machine family.
+
+    Many newer machine families don't support pd-standard. The default
+    pd-balanced covers most families. Hyperdisk-only families (C4, N4,
+    H3, etc.) that don't support any Persistent Disk type get
+    hyperdisk-balanced.
+
+    Args:
+        vm: VM instance response from GCP API
+        default: Default disk type (pd-balanced covers most families)
+
+    Returns:
+        'hyperdisk-balanced' for Hyperdisk-only families, otherwise the default
+    """
+    machine_type = vm.get('machineType', '')
+    if not machine_type:
+        return default
+
+    # Machine type format: zones/ZONE/machineTypes/TYPE or just TYPE
+    machine_type_name = machine_type.split('/')[-1] if '/' in machine_type else machine_type
+
+    # Extract family prefix (everything before the first '-')
+    family = machine_type_name.split('-')[0].lower()
+
+    if family in HYPERDISK_ONLY_FAMILIES:
+        return 'hyperdisk-balanced'
+
+    return default
+
+
 def detect_architecture(vm: Dict[str, Any]) -> str:
     """
     Detect the CPU architecture of a VM.


### PR DESCRIPTION
## Summary

- Change default rescue disk type from `pd-standard` to `pd-balanced` (widely supported, fixes C3 and other families that reject pd-standard)
- Auto-detect machine family and select `hyperdisk-balanced` for Hyperdisk-only families (C4, N4, M4, X4, A3, A4, H3, H4D, Z3) that don't support any Persistent Disk type
- Clear checkpoint metadata after rollback to prevent stale recovery state

## Changes

| File | Change |
|------|--------|
| `gce_rescue_v2/core/config.py` | Default `rescue_disk_type` from `pd-standard` → `pd-balanced` |
| `gce_rescue_v2/utils/os_detection.py` | Add `HYPERDISK_ONLY_FAMILIES` set + `get_rescue_disk_type()` helper |
| `gce_rescue_v2/orchestration/rescue.py` | Call `get_rescue_disk_type()` in `_get_original_disk_info()`, clear checkpoint after rollback |
| `gce_rescue_v2/orchestration/restore.py` | Clear checkpoint after rollback |
| `gce_rescue_v2/tests/test_vm_features.py` | 19 unit tests for disk type detection |
| `gce_rescue_v2/tests/test_rescue.py` | Integration test for C4 + rollback checkpoint test |
| `gce_rescue_v2/tests/test_restore.py` | Rollback checkpoint test |

## Test plan

- [x] `python -m pytest gce_rescue_v2/tests/ -v` — all 433 tests pass