### PR TITLE
tests: Use temporary directory in the Bazel sandbox

### DIFF
--- a/gce_rescue_v2/tests/conftest.py
+++ b/gce_rescue_v2/tests/conftest.py
@@ -7,9 +7,16 @@ Provides:
 - sample_rescue_config: RescueConfig with test values
 """
 
+import os
 import pytest
 from unittest.mock import Mock, MagicMock
 from gce_rescue_v2.core.config import RescueConfig
+
+@pytest.fixture(autouse=True, scope='session')
+def change_to_tmpdir():
+    """Change to TEST_TMPDIR if running under the Bazel sandbox."""
+    if 'TEST_TMPDIR' in os.environ:
+        os.chdir(os.environ['TEST_TMPDIR'])
 
 @pytest.fixture
 def mock_compute():


### PR DESCRIPTION
Switch to a temporary directory as the current working directory when running under the Bazel sandbox, as indicated by the presence of the TEST_TMPDIR environment variable.

Certain tests generate log files in the current directory, which cannot be written to under the sandbox.

## Checklist

Check compliance with the following [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists) and describe any forced non-compliances:

- [x] [Consistency standards](https://github.com/GoogleCloudPlatform/gce-rescue/blob/main/CONTRIBUTING.md#consistency-standards) have been met
- [x] New code complies with the [PEP8](https://peps.python.org/pep-0008/)
- [x] All Python tests passed after the changes