### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-05-21
+
+### Fixed
+- Test failures under sandboxed test environments (e.g., Bazel/Forge): CLI handlers were writing log files to the working directory, which is read-only under sandboxed runners. An autouse fixture in `gce_rescue_v2/tests/conftest.py` redirects to `TEST_TMPDIR` when set (#88).
+
+### Changed
+- Post-GA README and CI workflow updates (#83).
+
 ## [2.0.0] - 2026-03-04
 
 ### GA Release

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 
 def _sanitize_ua_value(value: str) -> str:


### PR DESCRIPTION
Patch release containing bug fixes and post-GA documentation updates since v2.0.0.

## What's included

### Fixed
- Test failures under sandboxed test environments (e.g., Bazel/Forge): CLI handlers were writing log files to the working directory, which is read-only under sandboxed runners. An autouse fixture in `gce_rescue_v2/tests/conftest.py` redirects to `TEST_TMPDIR` when set (#88).

### Changed
- Post-GA README and CI workflow updates (#83).

## Why now

Downstream security-compliance tooling requires importing a specific tagged version rather than a moving branch HEAD, so vulnerabilities can be tracked against an immutable reference. Cutting v2.0.1 satisfies that need with the smallest possible delta over v2.0.0 — two non-breaking patches.

After this merges, the next steps are: tag `v2.0.1` on the resulting merge commit, push the tag, and create the GitHub release using the CHANGELOG entry as release notes.

## Checklist

- [x] Version bumped in `gce_rescue_v2/core/config.py` (`2.0.0` -> `2.0.1`)
- [x] `CHANGELOG.md` entry added for `[2.0.1] - 2026-05-21`
- [x] Only non-breaking commits since v2.0.0 included (semver: patch)
- [x] PEP8 / consistency standards met