### PR TITLE
chore: sync v2.0.1 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-05-21
+
+### Fixed
+- Test failures under sandboxed test environments (e.g., Bazel/Forge): CLI handlers were writing log files to the working directory, which is read-only under sandboxed runners. An autouse fixture in `gce_rescue_v2/tests/conftest.py` redirects to `TEST_TMPDIR` when set (#88).
+
+### Changed
+- Post-GA README and CI workflow updates (#83).
+
 ## [2.0.0] - 2026-03-04
 
 ### GA Release

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 
 def _sanitize_ua_value(value: str) -> str:


### PR DESCRIPTION
Routine post-release sync. Brings the `v2.0.1` release commits (`#89`) from `main` into `develop` so the two branches stay aligned and the version on `develop` reflects what's published.

## What's included

Just the contents of `#89` (already reviewed and merged into `main`):

- `gce_rescue_v2/core/config.py`: `VERSION` bumped to `2.0.1`
- `CHANGELOG.md`: `[2.0.1] - 2026-05-21` entry added

Todd's underlying test fix (`#88`) was already on `develop` from an earlier sync; this PR only adds the two release-prep changes.

## Why a PR (not a direct push)

`develop` is a protected branch. Routine sync merges should still flow through PR + review for a clean audit trail rather than being pushed with admin bypass.