### PR TITLE
ci: add PyPI publishing workflow (OIDC trusted publisher)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Validate artifacts
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gce-rescue
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build sdist and wheel


### PR DESCRIPTION
Automates PyPI publication on every GitHub release.

## What it does

When a new release is published on GitHub (`release: types: [published]`), the workflow:

1. Builds the sdist and wheel using `python -m build`.
2. Validates artifacts with `python -m twine check`.
3. Publishes to PyPI from a separate job using `pypa/gh-action-pypi-publish`.

The split-job pattern ensures the build artifacts are produced and validated before any publishing happens.

## Authentication

Uses PyPI's **Trusted Publisher / OIDC** flow rather than a stored API token:

- The publish job runs in a GitHub Environment named `pypi` with `permissions: id-token: write`.
- GitHub Actions mints a short-lived OIDC token; PyPI verifies it matches a trusted publisher configured for the project.
- **No long-lived secrets** stored in the repository.

## PyPI-side configuration required

Before this workflow can publish, a trusted publisher must be configured at:

https://pypi.org/manage/project/gce-rescue/settings/publishing/

Matching values:

| Field | Value |
|---|---|
| Owner | `GoogleCloudPlatform` |
| Repository | `gce-rescue` |
| Workflow filename | `publish.yml` |
| Environment | `pypi` |

## Release process going forward

After this merges, the release flow becomes:

1. PR with version bump in `core/config.py` + `CHANGELOG.md` entry.
2. Merge to `main`.
3. Tag the merge commit: `git tag vX.Y.Z && git push upstream vX.Y.Z`.
4. Create a GitHub release pointing at the tag.
5. **Workflow fires automatically** — builds, validates, publishes to PyPI.

Steps 1-4 stay manual (release decisions deserve a human); step 5 is no longer manual.

## Why this matters

v2.0.1 was published to PyPI manually with `twine upload`. Future releases (2.0.2, etc.) shouldn't require the same dance. This also closes the gap where a tagged GitHub release silently has no matching PyPI release (which would confuse downstream consumers).