### PR TITLE
feat: add --rescue-image option for custom rescue disk images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Validate artifacts
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gce-rescue
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to GCE Rescue will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-05-21
+
+### Fixed
+- Test failures under sandboxed test environments (e.g., Bazel/Forge): CLI handlers were writing log files to the working directory, which is read-only under sandboxed runners. An autouse fixture in `gce_rescue_v2/tests/conftest.py` redirects to `TEST_TMPDIR` when set (#88).
+
+### Changed
+- Post-GA README and CI workflow updates (#83).
+
 ## [2.0.0] - 2026-03-04
 
 ### GA Release

--- a/gce_rescue/config.py
+++ b/gce_rescue/config.py
@@ -25,6 +25,7 @@ config = {
   'version': VERSION,
   'debug': False,
   'skip-snapshot': False,
+  'rescue-image': None,
   'startup-script-file': os.path.join(dirname, 'startup-script.txt'),
   'source_guests': {
     'x86_64':[
@@ -59,9 +60,16 @@ def process_args():
                       help='Don\'t ask for confirmation.')
   parser.add_argument('--skip-snapshot', action='store_true',
                       help='Skip backing up the disk using a snapshot.')
+  parser.add_argument('--rescue-image', metavar='IMAGE_URL', default=None,
+                      help='Custom rescue disk image URL. Overrides the default'
+                           ' OS/arch-based image selection. Accepts a specific'
+                           ' image URL (projects/PROJECT/global/images/IMAGE)'
+                           ' or an image family URL'
+                           ' (projects/PROJECT/global/images/family/FAMILY).')
   return parser
 
 
 def set_configs(user_args):
   config['debug'] = getattr(user_args, 'debug')
   config['skip-snapshot'] = getattr(user_args, 'skip_snapshot')
+  config['rescue-image'] = getattr(user_args, 'rescue_image', None)

--- a/gce_rescue/gce.py
+++ b/gce_rescue/gce.py
@@ -49,6 +49,10 @@ def guess_guest(data: Dict) -> str:
   different OS for recovery disk.
      Default: projects/debian-cloud/global/images/family/debian-11"""
 
+  custom_image = get_config('rescue-image')
+  if custom_image:
+    return custom_image
+
   guests = get_config('source_guests')
   for disk in data['disks']:
     if disk['boot']:

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -37,7 +37,7 @@ class CustomArgumentParser(argparse.ArgumentParser):
     """Custom ArgumentParser with cleaner error messages."""
 
     # Flags specific to each command (for helpful error messages)
-    RESCUE_ONLY_FLAGS = ['--snapshot', '--no-snapshot']
+    RESCUE_ONLY_FLAGS = ['--snapshot', '--no-snapshot', '--rescue-image']
     RESTORE_ONLY_FLAGS = ['--keep-rescue-disk']
     REPAIR_ONLY_FLAGS = []  # repair uses same flags as rescue for now
 
@@ -216,6 +216,14 @@ EXAMPLES
     Rescue without snapshot (faster but riskier):
         $ gce-rescue rescue my-vm --zone=us-central1-a --no-snapshot
 
+    Rescue with a custom image:
+        $ gce-rescue rescue my-vm --zone=us-central1-a \\
+            --rescue-image=projects/my-project/global/images/my-rescue-image
+
+    Rescue with a custom image family:
+        $ gce-rescue rescue my-vm --zone=us-central1-a \\
+            --rescue-image=projects/debian-cloud/global/images/family/debian-11
+
 AFTER RESCUE
     Linux VMs:
         $ gcloud compute ssh my-vm --zone=us-central1-a
@@ -392,6 +400,20 @@ def _add_rescue_args(parser: argparse.ArgumentParser):
         help='Skip snapshot creation (faster but riskier)'
     )
 
+    image_group = parser.add_argument_group('IMAGE FLAGS')
+    image_group.add_argument(
+        '--rescue-image',
+        metavar='IMAGE_URL',
+        dest='rescue_image',
+        default=None,
+        help=(
+            'Custom rescue disk image URL. Overrides the default OS/arch-based'
+            ' image selection. Accepts a specific image URL'
+            ' (projects/PROJECT/global/images/IMAGE) or an image family URL'
+            ' (projects/PROJECT/global/images/family/FAMILY).'
+        )
+    )
+
 
 def _add_repair_args(parser: argparse.ArgumentParser):
     """Add repair-specific arguments."""
@@ -407,6 +429,20 @@ def _add_repair_args(parser: argparse.ArgumentParser):
         dest='snapshot',
         action='store_false',
         help='Skip snapshot creation (faster but riskier)'
+    )
+
+    image_group = parser.add_argument_group('IMAGE FLAGS')
+    image_group.add_argument(
+        '--rescue-image',
+        metavar='IMAGE_URL',
+        dest='rescue_image',
+        default=None,
+        help=(
+            'Custom rescue disk image URL. Overrides the default OS/arch-based'
+            ' image selection. Accepts a specific image URL'
+            ' (projects/PROJECT/global/images/IMAGE) or an image family URL'
+            ' (projects/PROJECT/global/images/family/FAMILY).'
+        )
     )
 
 
@@ -442,6 +478,10 @@ def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:
     # Snapshot setting (only configurable rescue option in beta)
     if hasattr(args, 'snapshot'):
         config.create_snapshot = args.snapshot
+
+    # Custom rescue image (overrides auto OS/arch detection)
+    if hasattr(args, 'rescue_image') and args.rescue_image:
+        config.custom_rescue_image = args.rescue_image
 
     # Force setting (for Local SSD VMs)
     if hasattr(args, 'force'):

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 # Version for usage tracking (SemVer: MAJOR.MINOR.PATCH-PRERELEASE)
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 
 def _sanitize_ua_value(value: str) -> str:

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -86,6 +86,11 @@ class RescueConfig:
     rescue_disk_size_gb: int = 10
     rescue_disk_type: str = 'pd-balanced'
 
+    # Custom rescue image (overrides all auto-selection when set)
+    # Accepts full image URL: projects/PROJECT/global/images/IMAGE
+    # or family URL: projects/PROJECT/global/images/family/FAMILY
+    custom_rescue_image: Optional[str] = None
+
     # Linux rescue image (default)
     rescue_image_family: str = 'debian-12'  # Use newer kernel for XFS/Btrfs compatibility
     rescue_image_project: str = 'debian-cloud'

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -553,27 +553,37 @@ class RescueOrchestrator:
                         context_updates={'rescue_disk_name': rescue_disk_name}
                     )
                 else:
-                    if self.os_type == OS_TYPE_WINDOWS:
+                    if self.config.custom_rescue_image:
+                        # User-supplied image URL (overrides OS/arch auto-selection)
+                        source_image = self.config.custom_rescue_image
+                        rescue_disk_size = self.config.rescue_disk_size_gb
+                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, custom image: {source_image})...")
+                    elif self.os_type == OS_TYPE_WINDOWS:
                         rescue_image_project = self.config.windows_rescue_image_project
                         rescue_image_family = self.config.windows_rescue_image_family
                         rescue_disk_size = self.config.windows_rescue_disk_size_gb
+                        source_image = f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}'
+                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
                     elif self.architecture == ARCH_ARM64:
                         # ARM64 Linux (T2A instances)
                         rescue_image_project = self.config.arm64_rescue_image_project
                         rescue_image_family = self.config.arm64_rescue_image_family
                         rescue_disk_size = self.config.rescue_disk_size_gb
+                        source_image = f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}'
+                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
                     else:
                         # x86_64 Linux (default)
                         rescue_image_project = self.config.rescue_image_project
                         rescue_image_family = self.config.rescue_image_family
                         rescue_disk_size = self.config.rescue_disk_size_gb
+                        source_image = f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}'
+                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
 
-                    self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
                     result = create_disk.execute(
                         disk_name=rescue_disk_name,
                         size_gb=rescue_disk_size,
                         disk_type=self.config.rescue_disk_type,
-                        source_image=f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}',
+                        source_image=source_image,
                         timeout=self.config.disk_create_timeout,
                         tracking_label=self._ua('disk-create-rescue')
                     )

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -769,3 +769,54 @@ class TestHandleRepair:
         args = _parse_args("repair")
         exit_code = cli.handle_repair(args)
         assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# TestRescueImageFlag
+# ---------------------------------------------------------------------------
+
+class TestRescueImageFlag:
+    """Tests for the --rescue-image CLI flag."""
+
+    def setup_method(self):
+        self.parser = cli.create_parser()
+
+    # --- Parsing ---
+
+    def test_rescue_image_accepted_by_rescue_command(self):
+        """--rescue-image is a valid flag for the rescue subcommand."""
+        args = self.parser.parse_args([
+            "rescue", "vm-1", "--zone", "us-central1-a",
+            "--rescue-image", "projects/my-proj/global/images/my-image",
+        ])
+        assert args.rescue_image == "projects/my-proj/global/images/my-image"
+
+    def test_rescue_image_accepted_by_repair_command(self):
+        """--rescue-image is a valid flag for the repair subcommand."""
+        args = self.parser.parse_args([
+            "repair", "vm-1", "--zone", "us-central1-a",
+            "--rescue-image", "projects/my-proj/global/images/family/debian-11",
+        ])
+        assert args.rescue_image == "projects/my-proj/global/images/family/debian-11"
+
+    def test_rescue_image_defaults_to_none(self):
+        """When --rescue-image is omitted, rescue_image is None."""
+        args = self.parser.parse_args(["rescue", "vm-1", "--zone", "us-central1-a"])
+        assert args.rescue_image is None
+
+    # --- args_to_rescue_config wiring ---
+
+    def test_rescue_image_populates_config(self):
+        """args_to_rescue_config copies --rescue-image into RescueConfig.custom_rescue_image."""
+        args = self.parser.parse_args([
+            "rescue", "vm-1", "--zone", "us-central1-a",
+            "--rescue-image", "projects/my-proj/global/images/my-image",
+        ])
+        config = cli.args_to_rescue_config(args)
+        assert config.custom_rescue_image == "projects/my-proj/global/images/my-image"
+
+    def test_no_rescue_image_leaves_config_none(self):
+        """Without the flag, RescueConfig.custom_rescue_image stays None."""
+        args = self.parser.parse_args(["rescue", "vm-1", "--zone", "us-central1-a"])
+        config = cli.args_to_rescue_config(args)
+        assert config.custom_rescue_image is None

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -478,3 +478,79 @@ def test_rescue_rollback_clears_checkpoint(stub_rescue, monkeypatch):
     orch = _make_orch()
     assert orch.execute() is False
     clear_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Custom rescue image tests
+# ---------------------------------------------------------------------------
+
+def test_custom_rescue_image_used_when_set(stub_rescue, monkeypatch):
+    """When custom_rescue_image is set, CreateDiskOperation receives it directly."""
+    captured = SimpleNamespace(source_image=None)
+
+    def _capture_create_disk(self, disk_name, size_gb, disk_type, source_image, **kwargs):
+        captured.source_image = source_image
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={}
+        )
+
+    monkeypatch.setattr(CreateDiskOperation, "execute", _capture_create_disk)
+
+    custom_image = "projects/my-proj/global/images/my-hardened-image"
+    config = RescueConfig(create_snapshot=False, custom_rescue_image=custom_image)
+    orch = _make_orch(config)
+    assert orch.execute() is True
+    assert captured.source_image == custom_image
+
+
+def test_custom_rescue_image_overrides_os_arch_selection(stub_rescue, monkeypatch):
+    """custom_rescue_image takes precedence over OS/arch auto-selection (Windows VM)."""
+    captured = SimpleNamespace(source_image=None)
+
+    def _capture_create_disk(self, disk_name, size_gb, disk_type, source_image, **kwargs):
+        captured.source_image = source_image
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={}
+        )
+
+    monkeypatch.setattr(CreateDiskOperation, "execute", _capture_create_disk)
+
+    # Simulate a Windows VM
+    def _fake_get_disk_info_windows(self):
+        self.vm_info = {"disks": [{"boot": True,
+                                   "source": "projects/p/zones/z/disks/original-boot",
+                                   "deviceName": "sda"}]}
+        self.os_type = "windows"
+        self.architecture = "x86_64"
+        self.original_disk_name = "original-boot"
+        self.original_device_name = "sda"
+
+    monkeypatch.setattr(RescueOrchestrator, "_get_original_disk_info", _fake_get_disk_info_windows)
+
+    custom_image = "projects/my-proj/global/images/family/debian-11"
+    config = RescueConfig(create_snapshot=False, custom_rescue_image=custom_image)
+    orch = _make_orch(config)
+    assert orch.execute() is True
+    # Must use the custom image, not the windows-2022 default
+    assert captured.source_image == custom_image
+    assert "windows" not in captured.source_image
+
+
+def test_no_custom_image_uses_default_auto_selection(stub_rescue, monkeypatch):
+    """Without custom_rescue_image, the default Debian image family URL is used."""
+    captured = SimpleNamespace(source_image=None)
+
+    def _capture_create_disk(self, disk_name, size_gb, disk_type, source_image, **kwargs):
+        captured.source_image = source_image
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={}
+        )
+
+    monkeypatch.setattr(CreateDiskOperation, "execute", _capture_create_disk)
+
+    config = RescueConfig(create_snapshot=False)  # custom_rescue_image=None by default
+    orch = _make_orch(config)
+    assert orch.execute() is True
+    # Should use the default debian-12 family URL
+    assert "debian-cloud" in captured.source_image
+    assert "debian-12" in captured.source_image


### PR DESCRIPTION
## Summary

- Adds a `--rescue-image` flag to the `rescue` and `repair` subcommands (V2) and a `--rescue-image` argument to V1.
- When supplied, the specified image URL is used directly for the rescue disk, bypassing the default OS/architecture-based image selection (Debian 12 / Windows Server 2022 / Debian ARM64).
- No behaviour change when the flag is not used.

## Use cases

- Projects where the default Debian/Windows images are restricted by org policy
- Users who need a hardened or pre-configured rescue environment
- Testing a specific kernel or toolset during rescue

## Accepted formats

```
--rescue-image=projects/PROJECT/global/images/IMAGE          # specific image
--rescue-image=projects/PROJECT/global/images/family/FAMILY  # image family
```

## Files changed

| File | Change |
|------|--------|
| `gce_rescue_v2/core/config.py` | Added `custom_rescue_image: Optional[str] = None` to `RescueConfig` |
| `gce_rescue_v2/cli/__init__.py` | Added `--rescue-image` flag to `rescue` and `repair`; wired through `args_to_rescue_config()` |
| `gce_rescue_v2/orchestration/rescue.py` | Custom image checked first in Step 4 before OS/arch auto-selection |
| `gce_rescue/config.py` | Added `--rescue-image` to V1 argparse and `set_configs()` |
| `gce_rescue/gce.py` | `guess_guest()` returns custom image early when set |

## Test plan

- [x] `gce-rescue rescue VM --zone=ZONE --rescue-image=projects/debian-cloud/global/images/family/debian-11` creates disk from specified image
- [ ] `gce-rescue rescue VM --zone=ZONE` (no flag) still uses default Debian 12 / Windows / ARM64 auto-selection
- [ ] `gce-rescue repair VM --zone=ZONE --rescue-image=...` works the same way
- [ ] V1: `gce-rescue-v1 -n VM -z ZONE --rescue-image=...` uses the custom image