### PR TITLE
fix(v2): support NVMe target extraction for fstab repair

### DIFF
--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -525,6 +525,8 @@ class RepairOrchestrator:
             (r'dev-disk-by-partuuid-([\w-]+)\.device', 1),
             # Raw device like /dev/sdb1
             (r'/dev/(sd[a-z]+\d*)', 1),
+            # Raw NVMe devices (e.g. /dev/nvme0n1, /dev/nvme1n1p2)
+            (r'/dev/(nvme\d+n\d+(?:p\d+)?)', 1),
             # Systemd unit name -> mount point (e.g., "mnt-data.mount" -> /mnt/data)
             (r'for ([\w.-]+)\.mount', 1),
             # Disk label from /dev/disk/by-label/xxx

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -563,6 +563,20 @@ class TestExtractFstabTargets:
         targets = orch._extract_fstab_targets(diagnosis)
         assert 'sdb1' in targets
 
+    def test_extract_nvme_device_path(self):
+        """Should extract raw NVMe device like /dev/nvme0n2 from systemd timeout logs."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [{
+                'category': 'fstab',
+                'severity': 'critical',
+                'detected_pattern': 'Timed out waiting for device nvme0n2.device - /dev/nvme0n2.',
+            }]
+        }
+        targets = orch._extract_fstab_targets(diagnosis)
+        assert 'nvme0n2' in targets
+
+
     def test_extract_mount_from_systemd_unit(self):
         """Should extract mount point from systemd unit name."""
         orch = self._make_orchestrator()


### PR DESCRIPTION
Fixes #97

## Summary
- Adds NVMe device path parsing support (`/dev/nvme*`) to `_extract_fstab_targets` in `gce_rescue_v2/orchestration/repair.py`.
- Previously, the code only supported SCSI device identifiers (such as `/dev/sd*`), which caused automatic fstab repair to abort on modern VM families that use NVMe exclusively.
- Adds a unit test in `test_repair.py` using a real-world serial log from an unbootable C3 VM to guarantee correct target extraction.
## Use cases
- Automatic `/etc/fstab` boot repair on modern VM families (like C3 and M3) that natively use NVMe persistent disks.
## Files changed
| File | Change |
|------|--------|
| `gce_rescue_v2/orchestration/repair.py` | Added NVMe regex pattern `(r'/dev/(nvme\d+n\d+(?:p\d+)?)', 1)` to `extraction_patterns` inside `_extract_fstab_targets()`. |
| `gce_rescue_v2/tests/test_repair.py` | Added unit test `test_extract_nvme_device_path` validating target extraction with real serial logs. |
