### PR TITLE
fix: validate --rescue-image and apply to both rescue and repair

### DIFF
--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -482,6 +482,9 @@ def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:
     # Custom rescue image (overrides auto OS/arch detection)
     if hasattr(args, 'rescue_image') and args.rescue_image:
         config.custom_rescue_image = args.rescue_image
+        # Pre-resolved disk size from CLI pre-flight (avoids orchestrator re-lookup)
+        if getattr(args, 'custom_rescue_image_size_gb', None) is not None:
+            config.custom_rescue_image_size_gb = args.custom_rescue_image_size_gb
 
     # Force setting (for Local SSD VMs)
     if hasattr(args, 'force'):

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -407,9 +407,11 @@ def _add_rescue_args(parser: argparse.ArgumentParser):
         dest='rescue_image',
         default=None,
         help=(
-            'Custom rescue disk image URL. Overrides the default OS/arch-based'
-            ' image selection. Accepts a specific image URL'
-            ' (projects/PROJECT/global/images/IMAGE) or an image family URL'
+            'Custom rescue disk image URL. Image OS family (linux/windows)'
+            ' and architecture (x86_64/arm64) must match the target VM,'
+            ' otherwise the rescue is blocked at pre-flight. Accepts a'
+            ' specific image URL (projects/PROJECT/global/images/IMAGE)'
+            ' or an image family URL'
             ' (projects/PROJECT/global/images/family/FAMILY).'
         )
     )
@@ -438,9 +440,11 @@ def _add_repair_args(parser: argparse.ArgumentParser):
         dest='rescue_image',
         default=None,
         help=(
-            'Custom rescue disk image URL. Overrides the default OS/arch-based'
-            ' image selection. Accepts a specific image URL'
-            ' (projects/PROJECT/global/images/IMAGE) or an image family URL'
+            'Custom rescue disk image URL. Image OS family (linux/windows)'
+            ' and architecture (x86_64/arm64) must match the target VM,'
+            ' otherwise the rescue is blocked at pre-flight. Accepts a'
+            ' specific image URL (projects/PROJECT/global/images/IMAGE)'
+            ' or an image family URL'
             ' (projects/PROJECT/global/images/family/FAMILY).'
         )
     )

--- a/gce_rescue_v2/cli/preflight.py
+++ b/gce_rescue_v2/cli/preflight.py
@@ -42,6 +42,75 @@ def _create_tracked_client(compute, user_agent: str):
         return compute
 
 
+def validate_custom_rescue_image(
+    compute, vm_info, image_url, session_id, command, mode,
+) -> tuple:
+    """Pre-flight validation of --rescue-image (URL, existence, OS, arch).
+
+    Performs a single Compute API call (tagged for analytics) and checks:
+        - URL format is parseable
+        - Image exists and is accessible (HTTP 403/404 handled cleanly)
+        - Image OS family matches VM OS family
+        - Image architecture matches VM architecture
+
+    Used by both handle_rescue and handle_repair so the validation logic
+    stays consistent across subcommands.
+
+    Args:
+        compute: Compute API client (will be wrapped for analytics).
+        vm_info: VM resource dict (from _validate_vm_exists).
+        image_url: User-supplied --rescue-image value.
+        session_id: Session id for analytics tagging.
+        command: 'rescue' or 'repair' (analytics).
+        mode: 'interactive' or 'auto' (analytics).
+
+    Returns:
+        (size_gb, None) on success, (None, error_message) on failure.
+    """
+    from ..utils.os_detection import detect_os_type, detect_architecture
+    from ..orchestration.rescue import RescueOrchestrator
+    from ..core.config import build_user_agent
+    from googleapiclient.errors import HttpError
+
+    ua = build_user_agent(
+        session_id=session_id, command=command, mode=mode,
+        step='image-preflight-custom',
+    )
+    tracked = _create_tracked_client(compute, ua)
+
+    try:
+        image_dict = RescueOrchestrator.fetch_custom_image(tracked, image_url)
+    except ValueError as e:
+        return None, str(e)
+    except HttpError as e:
+        if e.resp.status == 404:
+            return None, f"Rescue image not found: {image_url}"
+        elif e.resp.status == 403:
+            return None, f"No permission to access rescue image: {image_url}"
+        else:
+            return None, f"Failed to inspect rescue image ({image_url}): {e}"
+
+    vm_os = detect_os_type(vm_info)
+    image_os = RescueOrchestrator.get_custom_image_os(image_dict)
+    if image_os != vm_os:
+        return None, (
+            f"--rescue-image OS mismatch: VM is {vm_os}, "
+            f"but image is {image_os}.\n"
+            f"      Rescue image OS must match the VM's OS family."
+        )
+
+    vm_arch = detect_architecture(vm_info)
+    image_arch = RescueOrchestrator.get_custom_image_architecture(image_dict)
+    if image_arch != vm_arch:
+        return None, (
+            f"--rescue-image architecture mismatch: VM is {vm_arch}, "
+            f"but image is {image_arch}.\n"
+            f"      Rescue image architecture must match the VM's."
+        )
+
+    return int(image_dict.get('diskSizeGb', 0)), None
+
+
 def get_gcloud_config(key: str) -> Optional[str]:
     """
     Read configuration from gcloud config.

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -223,7 +223,8 @@ def handle_repair(args: argparse.Namespace) -> int:
     logger.debug(f"Log file: {log_file}")
     logger.debug(f"VM: {args.instance_name}, Zone: {args.zone}, Project: {project}")
 
-    # Create repair orchestrator
+    # Create repair orchestrator. Custom-image resolved size (if any) is
+    # mutated onto orchestrator.config after the pre-flight check below.
     from ..orchestration.repair import RepairOrchestrator
     from . import args_to_rescue_config
     config = args_to_rescue_config(args)
@@ -277,6 +278,20 @@ def handle_repair(args: argparse.Namespace) -> int:
                   f"instancesDetail/zones/{args.zone}/instances/{args.instance_name}"
                   f"/console?project={project}&port=1", file=sys.stderr)
             return 1
+
+        # Validate --rescue-image BEFORE any destructive ops. Same shared
+        # helper used by handle_rescue. Resolved size is mutated onto the
+        # orchestrator's config so the inner rescue phase uses it.
+        if getattr(args, 'rescue_image', None):
+            from . import preflight as _preflight
+            size_gb, err = _preflight.validate_custom_rescue_image(
+                compute, vm, args.rescue_image,
+                session_id=session_id, command='repair', mode=mode,
+            )
+            if err:
+                print(f"{error_prefix()} {err}", file=sys.stderr)
+                return 1
+            orchestrator.config.custom_rescue_image_size_gb = size_gb
 
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])

--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -103,6 +103,20 @@ def handle_rescue(args: argparse.Namespace) -> int:
                   f" --quiet --force", file=sys.stderr)
             return 1
 
+        # Validate --rescue-image BEFORE confirmation (fast-fail on bad URL,
+        # non-existent image, or OS/arch mismatch; no destructive operations
+        # performed). Shared helper used by both rescue and repair handlers.
+        args.custom_rescue_image_size_gb = None
+        if getattr(args, 'rescue_image', None):
+            size_gb, err = preflight.validate_custom_rescue_image(
+                compute, vm_info, args.rescue_image,
+                session_id=session_id, command='rescue', mode=mode,
+            )
+            if err:
+                print(f"{error_prefix()} {err}", file=sys.stderr)
+                return 1
+            args.custom_rescue_image_size_gb = size_gb
+
     # Interactive confirmation (unless --quiet or resuming)
     if not args.quiet and not resuming:
         lines_printed = 0

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -90,6 +90,9 @@ class RescueConfig:
     # Accepts full image URL: projects/PROJECT/global/images/IMAGE
     # or family URL: projects/PROJECT/global/images/family/FAMILY
     custom_rescue_image: Optional[str] = None
+    # Disk size required by custom_rescue_image, pre-resolved by CLI to avoid
+    # a redundant API lookup in the orchestrator. If None, orchestrator looks it up.
+    custom_rescue_image_size_gb: Optional[int] = None
 
     # Linux rescue image (default)
     rescue_image_family: str = 'debian-12'  # Use newer kernel for XFS/Btrfs compatibility

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -248,6 +248,9 @@ class RepairOrchestrator:
             rescue_config = RescueConfig()
             rescue_config.create_snapshot = self.config.create_snapshot
             rescue_config.force = self.config.force
+            # Propagate custom rescue image settings (issue #102)
+            rescue_config.custom_rescue_image = self.config.custom_rescue_image
+            rescue_config.custom_rescue_image_size_gb = self.config.custom_rescue_image_size_gb
 
             rescue = RescueOrchestrator(
                 compute=self.compute, project=self.project, zone=self.zone,

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -268,6 +268,39 @@ class RescueOrchestrator:
         if self.logger:
             self.logger.error(message)
 
+    def _create_tracked_compute(self, user_agent: str):
+        """Wrap self.compute with a custom User-Agent header for analytics.
+
+        Mirrors BaseOperation._create_tracked_client; kept here so the
+        orchestrator can tag its own (non-operation) API calls.
+        """
+        try:
+            from googleapiclient import discovery
+            import googleapiclient.http
+            import google_auth_httplib2
+            import httplib2
+
+            if not isinstance(getattr(self.compute, '_http', None),
+                              google_auth_httplib2.AuthorizedHttp):
+                return self.compute  # likely a test mock — no wrapping
+
+            credentials = self.compute._http.credentials
+
+            def _request_builder(http, *args, **kwargs):
+                headers = kwargs.setdefault('headers', {})
+                headers['user-agent'] = user_agent
+                auth_http = google_auth_httplib2.AuthorizedHttp(
+                    credentials, http=httplib2.Http()
+                )
+                return googleapiclient.http.HttpRequest(auth_http, *args, **kwargs)
+
+            return discovery.build(
+                'compute', 'v1', credentials=credentials,
+                cache_discovery=False, requestBuilder=_request_builder
+            )
+        except Exception:
+            return self.compute
+
     def _ua(self, step: str) -> str:
         """Build User-Agent string for the given step."""
         return build_user_agent(
@@ -329,6 +362,90 @@ class RescueOrchestrator:
             return True
         except Exception:
             return False
+
+    @staticmethod
+    def fetch_custom_image(compute, image_url: str) -> dict:
+        """Look up a custom rescue image and return its full metadata dict.
+
+        Accepts two URL forms:
+            projects/PROJECT/global/images/IMAGE
+            projects/PROJECT/global/images/family/FAMILY
+
+        Returns:
+            The image resource dict (includes diskSizeGb, guestOsFeatures,
+            licenses, architecture, etc.).
+
+        Raises:
+            ValueError: If the URL cannot be parsed into a known form.
+            HttpError: If the API call fails (image not found, no permission, etc.).
+        """
+        _format_error = (
+            f"Unrecognized rescue image URL format: {image_url}\n"
+            "Expected:\n"
+            "  projects/PROJECT/global/images/IMAGE\n"
+            "  projects/PROJECT/global/images/family/FAMILY"
+        )
+
+        parts = image_url.split('/')
+        # Just enough validation to know which API endpoint to call
+        try:
+            if parts[0] != 'projects' or parts[2] != 'global' or parts[3] != 'images':
+                raise ValueError(_format_error)
+        except IndexError:
+            raise ValueError(_format_error)
+
+        project = parts[1]
+
+        if len(parts) == 6 and parts[4] == 'family':
+            return compute.images().getFromFamily(
+                project=project, family=parts[5]
+            ).execute()
+        elif len(parts) == 5:
+            return compute.images().get(
+                project=project, image=parts[4]
+            ).execute()
+        else:
+            raise ValueError(_format_error)
+
+    @staticmethod
+    def get_custom_image_disk_size(compute, image_url: str) -> int:
+        """Look up minimum disk size required by a custom rescue image.
+
+        Thin wrapper over fetch_custom_image for callers that only need size.
+        """
+        return int(
+            RescueOrchestrator.fetch_custom_image(compute, image_url)
+            .get('diskSizeGb', 0)
+        )
+
+    @staticmethod
+    def get_custom_image_os(image: dict) -> str:
+        """Return 'windows' or 'linux' for an image resource dict.
+
+        Detection (most reliable first):
+            - guestOsFeatures contains type='WINDOWS' -> windows
+            - licenses contains 'windows-' substring -> windows
+            - otherwise -> linux
+        """
+        features = image.get('guestOsFeatures') or []
+        if any((f.get('type') or '') == 'WINDOWS' for f in features):
+            return OS_TYPE_WINDOWS
+        licenses = image.get('licenses') or []
+        if any('windows' in (lic or '').lower() for lic in licenses):
+            return OS_TYPE_WINDOWS
+        return OS_TYPE_LINUX
+
+    @staticmethod
+    def get_custom_image_architecture(image: dict) -> str:
+        """Return 'x86_64' or 'arm64' for an image resource dict.
+
+        Reads the explicit `architecture` field (GCP populates this for
+        ARM64 images). Defaults to x86_64 when unset/unknown.
+        """
+        arch = (image.get('architecture') or '').upper()
+        if arch == 'ARM64':
+            return 'arm64'
+        return 'x86_64'
 
     def _get_vm_status(self) -> str:
         """Get current VM status."""
@@ -556,8 +673,35 @@ class RescueOrchestrator:
                     if self.config.custom_rescue_image:
                         # User-supplied image URL (overrides OS/arch auto-selection)
                         source_image = self.config.custom_rescue_image
-                        rescue_disk_size = self.config.rescue_disk_size_gb
-                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, custom image: {source_image})...")
+                        # Prefer CLI-pre-resolved size; fall back to lookup if absent
+                        # (defensive for direct API users who skipped the CLI pre-flight).
+                        if self.config.custom_rescue_image_size_gb is not None:
+                            image_required_gb = self.config.custom_rescue_image_size_gb
+                        else:
+                            # Direct-API path: tag lookup so analytics can
+                            # distinguish from CLI-driven preflight.
+                            tracked = self._create_tracked_compute(
+                                self._ua('image-lookup-custom')
+                            )
+                            try:
+                                image_required_gb = self.get_custom_image_disk_size(
+                                    tracked, source_image
+                                )
+                            except ValueError as e:
+                                self._log_error(str(e))
+                                self._finish_progress(False)
+                                self._rollback()
+                                return False
+                            except Exception as e:
+                                self._log_error(f"Failed to inspect custom rescue image: {e}")
+                                self._finish_progress(False)
+                                self._rollback()
+                                return False
+                        rescue_disk_size = max(image_required_gb, self.config.rescue_disk_size_gb)
+                        self._log_debug(
+                            f"Creating rescue disk ({rescue_disk_size}GB, custom image: {source_image}, "
+                            f"image requires {image_required_gb}GB)..."
+                        )
                     elif self.os_type == OS_TYPE_WINDOWS:
                         rescue_image_project = self.config.windows_rescue_image_project
                         rescue_image_family = self.config.windows_rescue_image_family

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -583,6 +583,122 @@ class TestHandleRescue:
         exit_code = cli.handle_rescue(args)
         assert exit_code == 1
 
+    def _setup_rescue_with_image(self, monkeypatch, validate_returns=(50, None)):
+        """Variant of _setup_rescue with mockable image pre-flight outcome.
+
+        validate_returns: (size_gb, error_message) tuple returned by the
+            mocked preflight.validate_custom_rescue_image helper.
+        """
+        captured_config = {}
+
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(preflight, "get_gcloud_config", lambda key: "test-proj")
+        _mock_auth(monkeypatch)
+        monkeypatch.setattr(
+            preflight, "_validate_vm_exists",
+            lambda c, p, z, vm, user_agent=None: (
+                True,
+                {"disks": [{"boot": True, "licenses": ["debian-12"]}],
+                 "status": "RUNNING", "metadata": {"items": []}},
+                None,
+            ),
+        )
+        monkeypatch.setattr(preflight, "_check_local_ssds", lambda vm: [])
+        # Mock the shared image pre-flight helper directly (the unit under
+        # test here is the CLI handler, not the helper).
+        monkeypatch.setattr(
+            preflight, "validate_custom_rescue_image",
+            lambda *a, **kw: validate_returns,
+        )
+
+        class FakeOrchestrator:
+            def __init__(self, **kwargs):
+                captured_config['config'] = kwargs.get('config')
+                self.os_type = 'linux'
+                self.snapshot_name = None
+                self.verification_succeeded = True
+            def validate(self): return True
+            def execute(self): return True
+
+        monkeypatch.setattr(
+            "gce_rescue_v2.cli.rescue.RescueOrchestrator", FakeOrchestrator
+        )
+        return captured_config
+
+    def test_handle_rescue_invalid_rescue_image_url(self, monkeypatch, capsys):
+        """Bad --rescue-image URL is rejected with clean error, exit 1."""
+        self._setup_rescue_with_image(
+            monkeypatch,
+            validate_returns=(None, "Unrecognized rescue image URL format: oops"),
+        )
+        args = _parse_args("rescue", extra=["--rescue-image", "oops"])
+        exit_code = cli.handle_rescue(args)
+        assert exit_code == 1
+        assert "Unrecognized rescue image URL format" in capsys.readouterr().err
+
+    def test_handle_rescue_rescue_image_not_found(self, monkeypatch, capsys):
+        """Non-existent rescue image (404) shows clean error, exit 1."""
+        self._setup_rescue_with_image(
+            monkeypatch,
+            validate_returns=(None, "Rescue image not found: projects/my-proj/global/images/does-not-exist"),
+        )
+        args = _parse_args(
+            "rescue",
+            extra=["--rescue-image", "projects/my-proj/global/images/does-not-exist"],
+        )
+        exit_code = cli.handle_rescue(args)
+        assert exit_code == 1
+        assert "not found" in capsys.readouterr().err.lower()
+
+    def test_handle_rescue_resolved_size_flows_to_config(self, monkeypatch):
+        """Successful image pre-check passes resolved size into RescueConfig."""
+        captured_config = self._setup_rescue_with_image(
+            monkeypatch, validate_returns=(50, None),
+        )
+        args = _parse_args(
+            "rescue",
+            extra=["--rescue-image", "projects/debian-cloud/global/images/family/debian-12"],
+        )
+        exit_code = cli.handle_rescue(args)
+        assert exit_code == 0
+        assert captured_config['config'].custom_rescue_image_size_gb == 50
+
+    def test_handle_rescue_blocks_linux_vm_windows_image(self, monkeypatch, capsys):
+        """Linux VM + Windows custom image is rejected (issue #101)."""
+        self._setup_rescue_with_image(
+            monkeypatch,
+            validate_returns=(None,
+                "--rescue-image OS mismatch: VM is linux, but image is windows.\n"
+                "      Rescue image OS must match the VM's OS family."),
+        )
+        args = _parse_args(
+            "rescue",
+            extra=["--rescue-image", "projects/windows-cloud/global/images/family/windows-2019"],
+        )
+        exit_code = cli.handle_rescue(args)
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "OS mismatch" in err
+        assert "linux" in err.lower() and "windows" in err.lower()
+
+    def test_handle_rescue_blocks_arch_mismatch(self, monkeypatch, capsys):
+        """x86 VM + ARM64 custom image is rejected (issue #101)."""
+        self._setup_rescue_with_image(
+            monkeypatch,
+            validate_returns=(None,
+                "--rescue-image architecture mismatch: VM is x86_64, but image is arm64.\n"
+                "      Rescue image architecture must match the VM's."),
+        )
+        args = _parse_args(
+            "rescue",
+            extra=["--rescue-image", "projects/debian-cloud/global/images/family/debian-12-arm64"],
+        )
+        exit_code = cli.handle_rescue(args)
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "architecture mismatch" in err
+        assert "x86_64" in err and "arm64" in err
+
 
 class TestHandleRestore:
     """Tests for handle_restore CLI handler."""
@@ -769,6 +885,73 @@ class TestHandleRepair:
         args = _parse_args("repair")
         exit_code = cli.handle_repair(args)
         assert exit_code == 1
+
+    # --- --rescue-image pre-flight (issue #102) ---
+
+    def test_handle_repair_rescue_image_invalid_blocks_pre_flight(
+        self, monkeypatch, capsys,
+    ):
+        """Bad --rescue-image URL is blocked by shared pre-flight helper."""
+        self._setup_repair_base(monkeypatch)
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(
+            preflight, "validate_custom_rescue_image",
+            lambda *a, **kw: (None, "Unrecognized rescue image URL format: oops"),
+        )
+
+        Fake = self._make_fake_repair_orch()
+        monkeypatch.setattr(
+            "gce_rescue_v2.orchestration.repair.RepairOrchestrator", Fake
+        )
+
+        args = _parse_args("repair", extra=["--rescue-image", "oops"])
+        exit_code = cli.handle_repair(args)
+        assert exit_code == 1
+        assert "Unrecognized rescue image URL format" in capsys.readouterr().err
+
+    def test_handle_repair_rescue_image_size_mutated_onto_orchestrator(
+        self, monkeypatch,
+    ):
+        """Successful pre-flight mutates orchestrator.config.custom_rescue_image_size_gb."""
+        self._setup_repair_base(monkeypatch)
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(
+            preflight, "validate_custom_rescue_image",
+            lambda *a, **kw: (50, None),  # resolved 50 GB, no error
+        )
+
+        captured = {}
+
+        class FakeRepairOrch:
+            _suppress_header = False
+            def __init__(self, **kwargs):
+                # Save instance so we can inspect config mutation
+                self.config = kwargs.get('config')
+                captured['orch'] = self
+            def validate(self): return True
+            def diagnose(self):
+                return {"instance_name": "vm-1", "zone": "us-central1-a",
+                        "boot_errors": [], "boot_status": "healthy"}
+            def get_fixable_categories(self, d): return []
+            def get_unfixable_categories(self, d): return []
+            def _extract_fstab_targets(self, d): return []
+            def execute(self, d):
+                return {"status": "success", "fixed_count": 0,
+                        "fix_lines": [], "error": None,
+                        "snapshot_name": "s", "duration_seconds": 1}
+
+        monkeypatch.setattr(
+            "gce_rescue_v2.orchestration.repair.RepairOrchestrator", FakeRepairOrch
+        )
+
+        args = _parse_args(
+            "repair",
+            extra=["--rescue-image", "projects/debian-cloud/global/images/family/debian-12"],
+        )
+        exit_code = cli.handle_repair(args)
+        assert exit_code == 0
+        # Confirm the mutation happened on the orchestrator's config
+        assert captured['orch'].config.custom_rescue_image_size_gb == 50
 
 
 # ---------------------------------------------------------------------------

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -195,6 +195,50 @@ class TestRepairOrchestrator:
         assert result['status'] == 'no_fix'
         assert result['fixed_count'] == 0
 
+    def test_execute_propagates_custom_rescue_image_to_inner_rescue(self):
+        """Repair must pass --rescue-image fields through to inner rescue (issue #102)."""
+        from unittest.mock import patch, MagicMock
+        from gce_rescue_v2.core.config import RescueConfig
+
+        compute = _make_compute()
+        outer_config = RescueConfig(
+            create_snapshot=True,
+            custom_rescue_image="projects/debian-cloud/global/images/family/debian-12",
+            custom_rescue_image_size_gb=20,
+        )
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1',
+            config=outer_config, logger=_make_logger(),
+        )
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'error',
+                             'detected_pattern': 'UUID=bad'}]
+        }
+
+        captured = {}
+
+        # Capture the RescueConfig passed to the inner RescueOrchestrator
+        def _fake_rescue_ctor(**kwargs):
+            captured['rescue_config'] = kwargs.get('config')
+            mock = MagicMock()
+            mock.execute.return_value = False  # short-circuit, we only care about config
+            return mock
+
+        with patch(
+            'gce_rescue_v2.orchestration.repair.RescueOrchestrator',
+            side_effect=_fake_rescue_ctor,
+        ):
+            # Bypass fix-script generation to avoid extra setup
+            with patch.object(orch, '_generate_repair_script', return_value="#!/bin/bash"):
+                orch.execute(diagnosis)
+
+        # The inner rescue_config must carry the custom image fields
+        assert captured['rescue_config'].custom_rescue_image == (
+            "projects/debian-cloud/global/images/family/debian-12"
+        )
+        assert captured['rescue_config'].custom_rescue_image_size_gb == 20
+
 
 # ---------------------------------------------------------------------------
 # TestRepairCLI

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -147,6 +147,12 @@ def stub_rescue(monkeypatch):
     monkeypatch.setattr(RescueOrchestrator, "_is_disk_attached", lambda self, n: False)
     monkeypatch.setattr(RescueOrchestrator, "_get_vm_status", lambda self: "TERMINATED")
     monkeypatch.setattr(RescueOrchestrator, "_generate_startup_script", lambda self: "echo test")
+    # Default custom-image size lookup returns 10GB (Linux default); individual
+    # tests override this to verify size-handling logic.
+    monkeypatch.setattr(
+        RescueOrchestrator, "get_custom_image_disk_size",
+        staticmethod(lambda compute, url: 10),
+    )
 
     # Stub _get_original_disk_info to set disk/os info without API call
     def _fake_get_disk_info(self):
@@ -554,3 +560,97 @@ def test_no_custom_image_uses_default_auto_selection(stub_rescue, monkeypatch):
     # Should use the default debian-12 family URL
     assert "debian-cloud" in captured.source_image
     assert "debian-12" in captured.source_image
+
+
+# ---------------------------------------------------------------------------
+# Custom image disk-size handling (issue #95)
+# ---------------------------------------------------------------------------
+
+def test_custom_image_disk_size_honors_image_requirement(stub_rescue, monkeypatch):
+    """Custom image requiring 50GB (e.g. Windows) creates a 50GB rescue disk."""
+    captured = SimpleNamespace(size_gb=None)
+
+    def _capture(self, disk_name, size_gb, disk_type, source_image, **kwargs):
+        captured.size_gb = size_gb
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={}
+        )
+    monkeypatch.setattr(CreateDiskOperation, "execute", _capture)
+
+    # Image reports 50GB required
+    monkeypatch.setattr(
+        RescueOrchestrator, "get_custom_image_disk_size",
+        staticmethod(lambda compute, url: 50),
+    )
+
+    config = RescueConfig(
+        create_snapshot=False,
+        custom_rescue_image="projects/windows-cloud/global/images/family/windows-2019",
+    )
+    orch = _make_orch(config)
+    assert orch.execute() is True
+    assert captured.size_gb == 50
+
+
+def test_custom_image_disk_size_never_below_default(stub_rescue, monkeypatch):
+    """Image requiring less than 10GB is bumped up to the Linux default."""
+    captured = SimpleNamespace(size_gb=None)
+
+    def _capture(self, disk_name, size_gb, disk_type, source_image, **kwargs):
+        captured.size_gb = size_gb
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={}
+        )
+    monkeypatch.setattr(CreateDiskOperation, "execute", _capture)
+
+    # Tiny image reports only 5GB
+    monkeypatch.setattr(
+        RescueOrchestrator, "get_custom_image_disk_size",
+        staticmethod(lambda compute, url: 5),
+    )
+
+    config = RescueConfig(
+        create_snapshot=False,
+        custom_rescue_image="projects/my-proj/global/images/tiny-image",
+    )
+    orch = _make_orch(config)
+    assert orch.execute() is True
+    # max(5, 10) == 10
+    assert captured.size_gb == 10
+
+
+def test_custom_image_invalid_url_aborts_before_disk_creation(stub_rescue, monkeypatch):
+    """Bad URL format raises ValueError; orchestrator aborts without creating a disk.
+
+    Note: stop/detach/snapshot run before this check (they're steps 1-3); rollback
+    handles cleanup. The point is to prevent the cryptic GCP API error and the
+    pointless attempt to create a disk with an unparseable source_image.
+    """
+    create_called = SimpleNamespace(value=False)
+    rollback_called = SimpleNamespace(value=False)
+
+    def _track_create(self, *args, **kwargs):
+        create_called.value = True
+        return OperationResult(
+            operation_name=self.name, success=True, message="OK", rollback_data={}
+        )
+
+    monkeypatch.setattr(CreateDiskOperation, "execute", _track_create)
+    monkeypatch.setattr(
+        RescueOrchestrator, "_rollback",
+        lambda self: setattr(rollback_called, "value", True)
+    )
+
+    # Image lookup raises ValueError for bad URL
+    def _raise_invalid(compute, url):
+        raise ValueError(f"Unrecognized rescue image URL format: {url}")
+    monkeypatch.setattr(
+        RescueOrchestrator, "get_custom_image_disk_size",
+        staticmethod(_raise_invalid),
+    )
+
+    config = RescueConfig(create_snapshot=False, custom_rescue_image="oops")
+    orch = _make_orch(config)
+    assert orch.execute() is False
+    assert create_called.value is False  # disk creation never attempted
+    assert rollback_called.value is True  # cleanup ran


### PR DESCRIPTION
## Summary

Resolves four gaps in the `--rescue-image` flag (introduced by PR #94) and extends it to actually work for the `repair` subcommand.

Closes #95, Closes #96, Closes #101, Closes #102

## What changed

| # | Issue | Fix |
|---|---|---|
| **#95** | Disk size was always Linux default (10 GB) → Windows custom images failed | Read `diskSizeGb` from the image, use `max(image, default)` so under-sizing can't happen |
| **#96** | Invalid URLs produced cryptic GCP API errors *after* stop+snapshot+detach | Pre-flight validation: bad URL/404/403 caught in <2 sec with clear message, no destructive ops |
| **#101** | OS or architecture mismatch produced a silently-broken rescue (e.g. Linux VM + Windows image) | Pre-flight compares image OS (`guestOsFeatures`/`licenses`) and `architecture` to the VM, blocks with specific error |
| **#102** | `repair --rescue-image=...` was accepted but silently ignored (config dropped in `RepairOrchestrator`) | Propagate `custom_rescue_image` + `custom_rescue_image_size_gb` to the inner rescue config; share the pre-flight helper between rescue and repair |

## How the fix works

A single Compute API call in `cli/preflight.validate_custom_rescue_image` fetches the image once and extracts **size + OS + architecture** together. The resolved size flows to the orchestrator via `RescueConfig.custom_rescue_image_size_gb`, so no second lookup happens mid-rescue. The orchestrator retains a fallback lookup for direct-API users who bypass the CLI.

The shared helper is used by both `handle_rescue` and `handle_repair`, ensuring consistent behaviour across subcommands.

## Behaviour matrix

| Input | Result | Time | VM state |
|---|---|---|---|
| `--rescue-image=oops` | "Unrecognized URL format" | <1 sec | untouched |
| `--rescue-image=projects/X/.../missing` | "Rescue image not found" | <2 sec | untouched |
| Linux VM + `windows-2019` image | "OS mismatch: VM is linux, but image is windows" | <2 sec | untouched |
| Windows VM + Linux image | "OS mismatch: VM is windows, but image is linux" | <2 sec | untouched |
| x86 VM + ARM64 image | "architecture mismatch: VM is x86_64, but image is arm64" | <2 sec | untouched |
| Matched custom image (any size) | Success with properly-sized rescue disk | normal | normal |
| `repair --rescue-image=...` on matched Linux image | Repair uses the custom image (was previously silently ignored) | normal | normal |

## Test plan

- [x] Full V2 suite passes (454/454)
- [x] +8 new tests covering: bad URL, 404, OS mismatch (both directions), arch mismatch, size flow through config, repair pre-flight blocks, repair orchestrator propagation regression guard
- [ ] Manual: `rescue --rescue-image=oops` on a real VM fails fast, no VM touched
- [ ] Manual: `rescue --rescue-image=<Windows image>` on a Linux VM blocked with OS-mismatch error
- [ ] Manual: `rescue --rescue-image=<internal hardened Windows image>` on a Windows VM succeeds (this was the original #95 failing case)
- [ ] Manual: `repair --rescue-image=<custom Linux image>` actually uses the custom image (was silently ignored before #102 fix)

## Out of scope (deferred)

- Trust/security review of custom images (currently we trust any image the user supplies access to)
- Custom image family deprecation (open question whether family URLs should warn since they resolve to "latest")
- Documentation of minimum requirements for custom rescue images (tooling expected on the image)