### PR TITLE
chore: configure dependabot to target develop, add github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Python dependencies (setup.py)
+  - package-ecosystem: pip
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Group all minor + patch bumps into one weekly PR (less noise).
+      # Major updates stay as separate PRs (breaking, worth individual review).
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions (workflow files)
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so dependabot stops targeting `main` and starts tracking workflow files too.

Closes #106

## What changes

| Before | After |
|---|---|
| No `.github/dependabot.yml` — uses defaults | Explicit config |
| Pip deps → `main` (causes sync burden each release) | Pip deps → `develop` (matches develop → main flow) |
| Only pip scanned (`setup.py`) | Pip + github-actions (workflow files) |
| 1 PR per individual dep bump | Minor + patch grouped into 1 weekly PR per ecosystem |
| Major updates → individual PRs | Same — breaking changes still get their own PR |

## Test plan

- [x] YAML validates (committed as-is)
- [ ] First post-merge dependabot run lands on `develop` (verify after merge)
- [ ] Workflow files in `.github/workflows/` show up in dependabot scans