### PR TITLE
feat(v2): add --fix-script for custom fix scripts on rescue and repair

### DIFF
--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -426,9 +426,9 @@ def _add_rescue_args(parser: argparse.ArgumentParser):
         help=(
             'Path to a custom fix script to run against the affected (broken)'
             ' disk after it is mounted in rescue mode. The disk is mounted at'
-            ' /mnt/sysroot (Linux). On "repair", this skips diagnosis and'
-            ' applies your script instead of an auto-generated fix. Currently'
-            ' supported for Linux VMs.'
+            ' /mnt/sysroot (Linux, bash script) or D:\\ (Windows, PowerShell'
+            ' script). The script runs after the mount completes; the VM'
+            ' stays in rescue mode for inspection.'
         )
     )
 
@@ -474,9 +474,9 @@ def _add_repair_args(parser: argparse.ArgumentParser):
         help=(
             'Path to a custom fix script to run against the affected (broken)'
             ' disk after it is mounted in rescue mode. The disk is mounted at'
-            ' /mnt/sysroot (Linux). Skips diagnosis and applies your script'
-            ' instead of an auto-generated fix. Currently supported for Linux'
-            ' VMs.'
+            ' /mnt/sysroot (Linux, bash script) or D:\\ (Windows, PowerShell'
+            ' script). Skips diagnosis and applies your script instead of an'
+            ' auto-generated fix, then restores the VM and verifies boot.'
         )
     )
 

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -527,7 +527,9 @@ def read_fix_script(path: str) -> str:
         raise ValueError(f"--fix-script: could not read {path}: {e}") from e
     if not content.strip():
         raise ValueError(f"--fix-script: file is empty: {path}")
-    return content
+    # Normalize Windows line endings: the script runs on the rescue VM, where
+    # bash treats stray \r as part of the command and fails confusingly.
+    return content.replace('\r\n', '\n')
 
 
 def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -14,6 +14,7 @@ Current standalone usage:
 
 import argparse
 import sys
+from pathlib import Path
 from ..core.config import RescueConfig, RestoreConfig, VERSION
 from ..utils.colors import error_prefix
 
@@ -416,6 +417,21 @@ def _add_rescue_args(parser: argparse.ArgumentParser):
         )
     )
 
+    fix_group = parser.add_argument_group('FIX SCRIPT FLAGS')
+    fix_group.add_argument(
+        '--fix-script',
+        metavar='PATH',
+        dest='fix_script',
+        default=None,
+        help=(
+            'Path to a custom fix script to run against the affected (broken)'
+            ' disk after it is mounted in rescue mode. The disk is mounted at'
+            ' /mnt/sysroot (Linux). On "repair", this skips diagnosis and'
+            ' applies your script instead of an auto-generated fix. Currently'
+            ' supported for Linux VMs.'
+        )
+    )
+
 
 def _add_repair_args(parser: argparse.ArgumentParser):
     """Add repair-specific arguments."""
@@ -449,6 +465,21 @@ def _add_repair_args(parser: argparse.ArgumentParser):
         )
     )
 
+    fix_group = parser.add_argument_group('FIX SCRIPT FLAGS')
+    fix_group.add_argument(
+        '--fix-script',
+        metavar='PATH',
+        dest='fix_script',
+        default=None,
+        help=(
+            'Path to a custom fix script to run against the affected (broken)'
+            ' disk after it is mounted in rescue mode. The disk is mounted at'
+            ' /mnt/sysroot (Linux). Skips diagnosis and applies your script'
+            ' instead of an auto-generated fix. Currently supported for Linux'
+            ' VMs.'
+        )
+    )
+
 
 def _add_restore_args(parser: argparse.ArgumentParser):
     """Add restore-specific arguments."""
@@ -475,6 +506,30 @@ def validate_args(args: argparse.Namespace) -> bool:
     return True
 
 
+def read_fix_script(path: str) -> str:
+    """Read and validate a custom fix script file, returning its content.
+
+    Args:
+        path: Filesystem path to the fix script (from --fix-script).
+
+    Returns:
+        The script content.
+
+    Raises:
+        ValueError: If the file does not exist, cannot be read, or is empty.
+    """
+    script_path = Path(path)
+    if not script_path.is_file():
+        raise ValueError(f"--fix-script: file not found: {path}")
+    try:
+        content = script_path.read_text(encoding='utf-8')
+    except OSError as e:
+        raise ValueError(f"--fix-script: could not read {path}: {e}") from e
+    if not content.strip():
+        raise ValueError(f"--fix-script: file is empty: {path}")
+    return content
+
+
 def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:
     """Convert arguments to RescueConfig."""
     config = RescueConfig()
@@ -489,6 +544,11 @@ def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:
         # Pre-resolved disk size from CLI pre-flight (avoids orchestrator re-lookup)
         if getattr(args, 'custom_rescue_image_size_gb', None) is not None:
             config.custom_rescue_image_size_gb = args.custom_rescue_image_size_gb
+
+    # Custom fix script: read the file and store its CONTENT on the config so
+    # the orchestrator stays I/O-free. Invalid paths fail fast here.
+    if getattr(args, 'fix_script', None):
+        config.fix_script = read_fix_script(args.fix_script)
 
     # Force setting (for Local SSD VMs)
     if hasattr(args, 'force'):

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -506,6 +506,11 @@ def validate_args(args: argparse.Namespace) -> bool:
     return True
 
 
+# The combined startup script is delivered via VM metadata, which caps values
+# at 256 KB. Leave headroom for the mount script and composition overhead.
+MAX_FIX_SCRIPT_BYTES = 200 * 1024
+
+
 def read_fix_script(path: str) -> str:
     """Read and validate a custom fix script file, returning its content.
 
@@ -516,7 +521,8 @@ def read_fix_script(path: str) -> str:
         The script content.
 
     Raises:
-        ValueError: If the file does not exist, cannot be read, or is empty.
+        ValueError: If the file does not exist, cannot be read, is empty, or
+            exceeds the metadata size budget.
     """
     script_path = Path(path)
     if not script_path.is_file():
@@ -527,6 +533,13 @@ def read_fix_script(path: str) -> str:
         raise ValueError(f"--fix-script: could not read {path}: {e}") from e
     if not content.strip():
         raise ValueError(f"--fix-script: file is empty: {path}")
+    size = len(content.encode('utf-8'))
+    if size > MAX_FIX_SCRIPT_BYTES:
+        raise ValueError(
+            f"--fix-script: file is too large ({size} bytes, max "
+            f"{MAX_FIX_SCRIPT_BYTES}). The script is delivered via VM "
+            f"metadata (256 KB limit); reduce the script size."
+        )
     # Normalize Windows line endings: the script runs on the rescue VM, where
     # bash treats stray \r as part of the command and fails confusingly.
     return content.replace('\r\n', '\n')

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from collections import Counter
 from datetime import datetime
+from pathlib import Path
 from typing import Optional, Dict, Any, List
 from ..core.config import build_user_agent
 from ..utils.colors import error_prefix, warning_prefix, clear_lines, green, bold
@@ -174,6 +175,67 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         if error:
             print(f"  {error}", file=sys.stderr)
         return 1
+
+
+def _run_custom_fix_script(args: argparse.Namespace, orchestrator,
+                           project: str, fix_script: str) -> int:
+    """Run repair with a custom fix script (--fix-script), skipping diagnosis.
+
+    Shows the supplied script and the repair plan, asks for confirmation
+    (skipped with --quiet), then runs rescue -> custom fix -> restore.
+    """
+    script_lines = fix_script.splitlines()
+    script_name = Path(args.fix_script).name
+
+    if not args.quiet:
+        print(f"Repair: {args.instance_name} ({args.zone})")
+        print("")
+        print(f"  Custom fix script: {args.fix_script} "
+              f"({len(script_lines)} lines)")
+        preview = script_lines[:15]
+        for line in preview:
+            print(f"    | {line}")
+        if len(script_lines) > len(preview):
+            print(f"    | ... ({len(script_lines) - len(preview)} more lines)")
+        print("")
+        print("  Repair plan:")
+        step = 1
+        if getattr(args, 'snapshot', True):
+            print(f"    {step}. Create backup snapshot of boot disk")
+            step += 1
+        print(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
+        step += 1
+        print(f"    {step}. Run the custom fix script against the affected disk")
+        step += 1
+        print(f"    {step}. Restore original boot disk and start VM")
+        print("")
+        print("  Diagnosis is skipped: the script runs exactly as provided.")
+        print("")
+
+        try:
+            response = input("  Proceed? [y/N]: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            return 0
+        if response not in ('y', 'yes'):
+            print("\nAborted by user.")
+            return 0
+        print("")
+
+    # Concise repair header
+    print(f"Repairing instance [{args.instance_name}]:")
+    print(f"  Fix:    Custom script ({script_name})")
+    plan_parts = []
+    if getattr(args, 'snapshot', True):
+        plan_parts.append("Snapshot")
+    plan_parts.extend(["Rescue", "Custom fix", "Restore"])
+    print(f"  Plan:   {' -> '.join(plan_parts)}")
+    print("")
+
+    orchestrator._suppress_header = True
+    result = orchestrator.execute_custom()
+    return _show_repair_results(result, args.instance_name,
+                                zone=args.zone, project=project)
 
 
 def handle_repair(args: argparse.Namespace) -> int:
@@ -395,6 +457,11 @@ def handle_repair(args: argparse.Namespace) -> int:
         spinner.stop()
     if not valid:
         return 1
+
+    # Custom fix script (--fix-script): skip diagnosis, run the supplied fix
+    if config.fix_script:
+        return _run_custom_fix_script(args, orchestrator, project,
+                                      config.fix_script)
 
     # Diagnose
     spinner = _Spinner("Analyzing serial console output")

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -320,14 +320,20 @@ def handle_repair(args: argparse.Namespace) -> int:
         spinner.stop()
 
     if vm:
-        # Linux-only check (before any spinners or prompts)
+        # Diagnosis-driven repair is Linux-only; Windows requires a custom
+        # fix script (--fix-script). Checked before any spinners or prompts.
         from ..utils.os_detection import detect_os_type
         os_type = detect_os_type(vm)
-        if os_type == 'windows':
-            print(f"{error_prefix()} Repair is only supported for Linux VMs.",
-                  file=sys.stderr)
+        if os_type == 'windows' and not config.fix_script:
+            print(f"{error_prefix()} Automated repair is only supported for"
+                  f" Linux VMs.", file=sys.stderr)
             print("", file=sys.stderr)
-            print("For Windows VMs, use rescue mode for manual repair:", file=sys.stderr)
+            print("For Windows VMs, supply a custom fix script (PowerShell):",
+                  file=sys.stderr)
+            print(f"  $ gce-rescue repair {args.instance_name} --zone={args.zone}"
+                  f" --project={project} --fix-script=FIX.ps1", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("Or use rescue mode for manual repair:", file=sys.stderr)
             print(f"  $ gce-rescue rescue {args.instance_name} --zone={args.zone}"
                   f" --project={project}", file=sys.stderr)
             print("", file=sys.stderr)

--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -117,21 +117,6 @@ def handle_rescue(args: argparse.Namespace) -> int:
                 return 1
             args.custom_rescue_image_size_gb = size_gb
 
-        # --fix-script is Linux-only for now (fail fast, before any
-        # destructive operation)
-        if getattr(args, 'fix_script', None):
-            from ..utils.os_detection import detect_os_type
-            if detect_os_type(vm_info) == OS_TYPE_WINDOWS:
-                print(f"{error_prefix()} --fix-script is only supported for"
-                      f" Linux VMs.", file=sys.stderr)
-                print("", file=sys.stderr)
-                print("For Windows VMs, use rescue mode and apply the fix"
-                      " manually over RDP:", file=sys.stderr)
-                print(f"  $ gce-rescue rescue {args.instance_name}"
-                      f" --zone={args.zone} --project={project}",
-                      file=sys.stderr)
-                return 1
-
     # Interactive confirmation (unless --quiet or resuming)
     if not args.quiet and not resuming:
         lines_printed = 0

--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -117,6 +117,21 @@ def handle_rescue(args: argparse.Namespace) -> int:
                 return 1
             args.custom_rescue_image_size_gb = size_gb
 
+        # --fix-script is Linux-only for now (fail fast, before any
+        # destructive operation)
+        if getattr(args, 'fix_script', None):
+            from ..utils.os_detection import detect_os_type
+            if detect_os_type(vm_info) == OS_TYPE_WINDOWS:
+                print(f"{error_prefix()} --fix-script is only supported for"
+                      f" Linux VMs.", file=sys.stderr)
+                print("", file=sys.stderr)
+                print("For Windows VMs, use rescue mode and apply the fix"
+                      " manually over RDP:", file=sys.stderr)
+                print(f"  $ gce-rescue rescue {args.instance_name}"
+                      f" --zone={args.zone} --project={project}",
+                      file=sys.stderr)
+                return 1
+
     # Interactive confirmation (unless --quiet or resuming)
     if not args.quiet and not resuming:
         lines_printed = 0
@@ -143,6 +158,10 @@ def handle_rescue(args: argparse.Namespace) -> int:
         lines_printed += 1
         print(" - Start the VM and attach original disk as secondary for repair.")
         lines_printed += 1
+        if getattr(args, 'fix_script', None):
+            print(f" - Run the custom fix script [{args.fix_script}] against"
+                  f" the mounted disk.")
+            lines_printed += 1
 
         if has_local_ssd:
             print(f" - {warning_prefix()} Data on Local SSDs"
@@ -218,6 +237,8 @@ def handle_rescue(args: argparse.Namespace) -> int:
 
         mount_path = "D:\\" if orchestrator.os_type == OS_TYPE_WINDOWS else "/mnt/sysroot"
         logger.info(f"Affected disk mounted at: {mount_path}")
+        if config.fix_script and orchestrator.verification_succeeded:
+            logger.info(f"Custom fix script completed: {args.fix_script}")
         if orchestrator.snapshot_name:
             logger.info(f"Backup snapshot: {orchestrator.snapshot_name}")
         logger.info("")

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -94,6 +94,12 @@ class RescueConfig:
     # a redundant API lookup in the orchestrator. If None, orchestrator looks it up.
     custom_rescue_image_size_gb: Optional[int] = None
 
+    # Custom fix script (from --fix-script). Holds the script CONTENT, not the
+    # path: the CLI reads and validates the file, then stores its text here so
+    # the orchestrator stays I/O-free. When set, repair skips diagnosis and runs
+    # this script against the affected disk after mount.
+    fix_script: Optional[str] = None
+
     # Linux rescue image (default)
     rescue_image_family: str = 'debian-12'  # Use newer kernel for XFS/Btrfs compatibility
     rescue_image_project: str = 'debian-cloud'

--- a/gce_rescue_v2/orchestration/compose.py
+++ b/gce_rescue_v2/orchestration/compose.py
@@ -70,3 +70,36 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
     combined += 'log "=== Startup script completed successfully ==="\n'
 
     return combined
+
+
+def compose_startup_script_windows(base_script: str,
+                                   fix_scripts: List[str]) -> str:
+    """Combine the Windows mount script with fix script(s) (PowerShell).
+
+    Unlike the Linux script, the Windows mount script has content AFTER its
+    completion marker (RDP credentials, desktop instructions), so instead of
+    relocating the marker to the end, the fix script(s) are INSERTED directly
+    before the marker line. Verification still only succeeds after the fixes
+    have run, and the post-marker content is preserved.
+
+    Args:
+        base_script: rescue_mount_windows.ps1 content, placeholders resolved.
+        fix_scripts: PowerShell fix script bodies to insert.
+
+    Returns:
+        The combined startup script.
+    """
+    marker_line = f'Write-Log "{RESCUE_COMPLETE_MARKER}"'
+
+    fix_block = '# === GCE Repair Fix Scripts ===\n'
+    fix_block += 'Write-Log "=== Starting repair fixes ==="\n\n'
+    for fix_script in fix_scripts:
+        fix_block += fix_script + '\n\n'
+    fix_block += 'Write-Log "=== Repair fixes completed ==="\n\n'
+
+    if marker_line in base_script:
+        return base_script.replace(marker_line, fix_block + marker_line, 1)
+
+    # Fallback: marker not found in base script — append fixes + marker so
+    # verification still gates on fix completion.
+    return base_script + '\n' + fix_block + marker_line + '\n'

--- a/gce_rescue_v2/orchestration/compose.py
+++ b/gce_rescue_v2/orchestration/compose.py
@@ -1,0 +1,72 @@
+"""
+GCE Rescue - Startup script composition.
+
+Combines the base mount script with fix script(s) into a single startup
+script, relocating the completion marker so verification (and any restore
+that follows) only proceeds after all fixes have finished.
+
+Shared by the repair orchestrator (diagnosis-driven fixes) and the rescue
+orchestrator (custom fix scripts via --fix-script).
+"""
+
+from typing import List, Optional
+
+# Completion marker emitted by the base mount script to the serial console
+RESCUE_COMPLETE_MARKER = 'GCE-RESCUE-COMPLETE'
+
+
+def strip_shebang(script: str) -> str:
+    """Remove a leading shebang line (already present in the base script)."""
+    if script.startswith('#!'):
+        parts = script.split('\n', 1)
+        return parts[1] if len(parts) > 1 else ''
+    return script
+
+
+def compose_startup_script(base_script: str, fix_scripts: List[str],
+                           repair_targets: Optional[List[str]] = None) -> str:
+    """Combine the base mount script with fix script(s) into one startup script.
+
+    The base script's GCE-RESCUE-COMPLETE marker is relocated to the very end
+    so the orchestrator's verification (and any restore that follows) only
+    proceeds after ALL fix scripts have finished — never mid-fix.
+
+    Args:
+        base_script: The mount script, with disk placeholder already resolved.
+        fix_scripts: Fix script bodies to append (shebangs already stripped).
+        repair_targets: Identifiers extracted from diagnosis for targeted
+            fixing. Pass a list (possibly empty) to inject the REPAIR_TARGETS
+            variable for diagnosis-driven fixes; pass None for self-contained
+            (custom) fix scripts that need no targets.
+
+    Returns:
+        The combined startup script.
+    """
+    # Remove the completion marker line (re-added at the very end)
+    combined = base_script.replace(
+        f'echo "{RESCUE_COMPLETE_MARKER}" >&2',
+        f'# GCE-RESCUE-COMPLETE marker moved to end (repair mode)'
+    )
+
+    combined += '\n'
+    combined += '\n# === GCE Repair Fix Scripts ===\n'
+    combined += 'log "=== Starting repair fixes ==="\n\n'
+
+    # Inject REPAIR_TARGETS variable for targeted fstab fixing (diagnosis mode)
+    if repair_targets is not None:
+        if repair_targets:
+            targets_str = '\n'.join(repair_targets)
+            combined += '# Repair targets extracted from diagnosis\n'
+            combined += f'REPAIR_TARGETS="{targets_str}"\n\n'
+        else:
+            combined += '# No specific repair targets extracted from diagnosis\n'
+            combined += 'REPAIR_TARGETS=""\n\n'
+
+    for fix_script in fix_scripts:
+        combined += fix_script + '\n\n'
+
+    combined += 'log "=== Repair fixes completed ==="\n'
+    combined += f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
+    combined += 'log "=== Startup script completed successfully ==="\n'
+
+    return combined

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -56,6 +56,63 @@ RESTORE_SUBSTEP_LABELS = {
 }
 
 
+def strip_shebang(script: str) -> str:
+    """Remove a leading shebang line (already present in the base script)."""
+    if script.startswith('#!'):
+        parts = script.split('\n', 1)
+        return parts[1] if len(parts) > 1 else ''
+    return script
+
+
+def compose_startup_script(base_script: str, fix_scripts: List[str],
+                           repair_targets: Optional[List[str]] = None) -> str:
+    """Combine the base mount script with fix script(s) into one startup script.
+
+    The base script's GCE-RESCUE-COMPLETE marker is relocated to the very end
+    so the orchestrator's verification (and any restore that follows) only
+    proceeds after ALL fix scripts have finished — never mid-fix.
+
+    Args:
+        base_script: The mount script, with disk placeholder already resolved.
+        fix_scripts: Fix script bodies to append (shebangs already stripped).
+        repair_targets: Identifiers extracted from diagnosis for targeted
+            fixing. Pass a list (possibly empty) to inject the REPAIR_TARGETS
+            variable for diagnosis-driven fixes; pass None for self-contained
+            (custom) fix scripts that need no targets.
+
+    Returns:
+        The combined startup script.
+    """
+    # Remove the completion marker line (re-added at the very end)
+    combined = base_script.replace(
+        f'echo "{RESCUE_COMPLETE_MARKER}" >&2',
+        f'# GCE-RESCUE-COMPLETE marker moved to end (repair mode)'
+    )
+
+    combined += '\n'
+    combined += '\n# === GCE Repair Fix Scripts ===\n'
+    combined += 'log "=== Starting repair fixes ==="\n\n'
+
+    # Inject REPAIR_TARGETS variable for targeted fstab fixing (diagnosis mode)
+    if repair_targets is not None:
+        if repair_targets:
+            targets_str = '\n'.join(repair_targets)
+            combined += '# Repair targets extracted from diagnosis\n'
+            combined += f'REPAIR_TARGETS="{targets_str}"\n\n'
+        else:
+            combined += '# No specific repair targets extracted from diagnosis\n'
+            combined += 'REPAIR_TARGETS=""\n\n'
+
+    for fix_script in fix_scripts:
+        combined += fix_script + '\n\n'
+
+    combined += 'log "=== Repair fixes completed ==="\n'
+    combined += f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
+    combined += 'log "=== Startup script completed successfully ==="\n'
+
+    return combined
+
+
 class RepairOrchestrator:
     """Orchestrates diagnose -> rescue (with fix) -> restore."""
 
@@ -572,11 +629,15 @@ class RepairOrchestrator:
 
         return targets
 
-    def _generate_repair_script(self, diagnosis: Dict[str, Any]) -> str:
-        """Generate combined startup script: rescue_mount.sh + fix script(s).
+    def _load_base_script(self) -> str:
+        """Load rescue_mount.sh with the disk placeholder resolved.
 
-        Loads rescue_mount.sh, replaces the completion marker with a comment,
-        appends fix script(s), then appends the completion marker at the end.
+        Looks up the VM's boot disk name via the API, validates it, and
+        substitutes it into the base mount script.
+
+        Raises:
+            ValueError: If the boot disk cannot be determined or has an
+                invalid name.
         """
         # Load base rescue mount script
         script_dir = Path(__file__).parent.parent / 'startup_scripts'
@@ -604,14 +665,15 @@ class RepairOrchestrator:
             raise ValueError(f"Disk name contains invalid characters: {original_disk}")
 
         # Replace disk placeholder
-        base_script = base_script.replace('DISK_NAME_PLACEHOLDER', original_disk)
+        return base_script.replace('DISK_NAME_PLACEHOLDER', original_disk)
 
-        # Remove the completion marker line (we'll add it at the very end)
-        # The marker is: echo "GCE-RESCUE-COMPLETE" >&2
-        base_script = base_script.replace(
-            f'echo "{RESCUE_COMPLETE_MARKER}" >&2',
-            f'# GCE-RESCUE-COMPLETE marker moved to end (repair mode)'
-        )
+    def _generate_repair_script(self, diagnosis: Dict[str, Any]) -> str:
+        """Generate combined startup script: rescue_mount.sh + fix script(s).
+
+        Loads rescue_mount.sh, appends the fix script(s) selected from
+        diagnosis, and relocates the completion marker to the very end.
+        """
+        base_script = self._load_base_script()
 
         # Get fix scripts for fixable categories
         fixable = self.get_fixable_categories(diagnosis)
@@ -629,28 +691,19 @@ class RepairOrchestrator:
         # Extract repair targets from diagnosis for targeted fixing
         targets = self._extract_fstab_targets(diagnosis)
 
-        # Combine: base script + targets + fix scripts + completion marker
-        combined = base_script + '\n'
-        combined += '\n# === GCE Repair Fix Scripts ===\n'
-        combined += 'log "=== Starting repair fixes ==="\n\n'
+        return compose_startup_script(base_script, fix_scripts, targets)
 
-        # Inject REPAIR_TARGETS variable for targeted fstab fixing
-        if targets:
-            targets_str = '\n'.join(targets)
-            combined += '# Repair targets extracted from diagnosis\n'
-            combined += f'REPAIR_TARGETS="{targets_str}"\n\n'
-        else:
-            combined += '# No specific repair targets extracted from diagnosis\n'
-            combined += 'REPAIR_TARGETS=""\n\n'
+    def _generate_custom_fix_script(self, fix_script_content: str) -> str:
+        """Generate combined startup script: rescue_mount.sh + custom fix script.
 
-        for fix_script in fix_scripts:
-            combined += fix_script + '\n\n'
-
-        combined += 'log "=== Repair fixes completed ==="\n'
-        combined += f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
-        combined += 'log "=== Startup script completed successfully ==="\n'
-
-        return combined
+        Used by --fix-script: the engineer supplies the fix, so diagnosis is
+        skipped and no REPAIR_TARGETS are injected (the script is
+        self-contained).
+        """
+        base_script = self._load_base_script()
+        fix_body = strip_shebang(fix_script_content)
+        return compose_startup_script(base_script, [fix_body],
+                                      repair_targets=None)
 
     def _get_fix_script(self, category: str) -> str:
         """Load fix script template for a category.

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -152,17 +152,26 @@ class RepairOrchestrator:
             results.print_failures()
             return False
 
-        # Check Linux-only
+        # Diagnosis-driven repair is Linux-only; Windows is supported only
+        # with a custom fix script (--fix-script)
         from ..utils.os_detection import detect_os_type
         compute = self._create_tracked_client(self._ua('val-os'))
         vm_info = compute.instances().get(
             project=self.project, zone=self.zone, instance=self.vm_name
         ).execute()
         os_type = detect_os_type(vm_info)
-        if os_type == 'windows':
-            self._log_error("Repair is only supported for Linux VMs.")
+        if os_type == 'windows' and not self.config.fix_script:
+            self._log_error("Automated repair is only supported for Linux VMs.")
             print("", file=sys.stderr)
-            print("For Windows VMs, use rescue mode for manual repair:", file=sys.stderr)
+            print("For Windows VMs, supply a custom fix script:", file=sys.stderr)
+            print(
+                f"  $ gce-rescue repair {self.vm_name} "
+                f"--zone={self.zone} --project={self.project} "
+                f"--fix-script=FIX.ps1",
+                file=sys.stderr
+            )
+            print("", file=sys.stderr)
+            print("Or use rescue mode for manual repair:", file=sys.stderr)
             print(
                 f"  $ gce-rescue rescue {self.vm_name} "
                 f"--zone={self.zone} --project={self.project}",
@@ -249,23 +258,27 @@ class RepairOrchestrator:
         Skips diagnosis entirely: the engineer supplied the fix, so the flow is
         rescue (mount + custom script) -> parse results -> restore -> verify.
 
+        The fix script is propagated onto the inner rescue config (instead of
+        a full startup-script override) so the rescue orchestrator composes it
+        per-OS — bash for Linux, PowerShell for Windows — with all placeholders
+        (disk name, Windows rescue password) resolved as usual.
+
         Returns:
             Dict with keys: status, fixed_count, fix_lines, error,
             snapshot_name, duration_seconds
         """
-        repair_script = self._generate_custom_fix_script(self.config.fix_script)
-        self._log_debug(
-            f"Generated custom repair script ({len(repair_script)} bytes)"
-        )
+        return self._run_repair_flow(fix_script=self.config.fix_script)
 
-        return self._run_repair_flow(repair_script)
+    def _run_repair_flow(self, repair_script: Optional[str] = None,
+                         fix_script: Optional[str] = None) -> Dict[str, Any]:
+        """Run the repair flow with the given fix payload.
 
-    def _run_repair_flow(self, repair_script: str) -> Dict[str, Any]:
-        """Run the repair flow with the given startup script.
-
-        Shared by diagnosis-driven repair (execute) and custom fix scripts
-        (execute_custom): rescue with the script embedded -> parse repair
-        results from serial console -> restore -> post-restore boot check.
+        Shared by diagnosis-driven repair (execute), which passes a fully
+        composed startup script as repair_script, and custom fix scripts
+        (execute_custom), which pass fix_script for per-OS composition inside
+        the rescue orchestrator. Flow: rescue with the fix embedded -> parse
+        repair results from serial console -> restore -> post-restore boot
+        check.
         """
         # Initialize progress display
         self._init_progress()
@@ -280,6 +293,9 @@ class RepairOrchestrator:
             # Propagate custom rescue image settings (issue #102)
             rescue_config.custom_rescue_image = self.config.custom_rescue_image
             rescue_config.custom_rescue_image_size_gb = self.config.custom_rescue_image_size_gb
+            # Custom fix script (--fix-script): composed per-OS by the rescue
+            # orchestrator's startup-script generation
+            rescue_config.fix_script = fix_script
 
             rescue = RescueOrchestrator(
                 compute=self.compute, project=self.project, zone=self.zone,
@@ -664,18 +680,6 @@ class RepairOrchestrator:
         targets = self._extract_fstab_targets(diagnosis)
 
         return compose_startup_script(base_script, fix_scripts, targets)
-
-    def _generate_custom_fix_script(self, fix_script_content: str) -> str:
-        """Generate combined startup script: rescue_mount.sh + custom fix script.
-
-        Used by --fix-script: the engineer supplies the fix, so diagnosis is
-        skipped and no REPAIR_TARGETS are injected (the script is
-        self-contained).
-        """
-        base_script = self._load_base_script()
-        fix_body = strip_shebang(fix_script_content)
-        return compose_startup_script(base_script, [fix_body],
-                                      repair_targets=None)
 
     def _get_fix_script(self, category: str) -> str:
         """Load fix script template for a category.

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -295,6 +295,32 @@ class RepairOrchestrator:
         repair_script = self._generate_repair_script(diagnosis)
         self._log_debug(f"Generated repair script ({len(repair_script)} bytes)")
 
+        return self._run_repair_flow(repair_script)
+
+    def execute_custom(self) -> Dict[str, Any]:
+        """Execute repair with the custom fix script from config (--fix-script).
+
+        Skips diagnosis entirely: the engineer supplied the fix, so the flow is
+        rescue (mount + custom script) -> parse results -> restore -> verify.
+
+        Returns:
+            Dict with keys: status, fixed_count, fix_lines, error,
+            snapshot_name, duration_seconds
+        """
+        repair_script = self._generate_custom_fix_script(self.config.fix_script)
+        self._log_debug(
+            f"Generated custom repair script ({len(repair_script)} bytes)"
+        )
+
+        return self._run_repair_flow(repair_script)
+
+    def _run_repair_flow(self, repair_script: str) -> Dict[str, Any]:
+        """Run the repair flow with the given startup script.
+
+        Shared by diagnosis-driven repair (execute) and custom fix scripts
+        (execute_custom): rescue with the script embedded -> parse repair
+        results from serial console -> restore -> post-restore boot check.
+        """
         # Initialize progress display
         self._init_progress()
         start_time = time.time()

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -31,15 +31,18 @@ from ..core.config import RescueConfig, RestoreConfig, VERSION, build_user_agent
 from ..core.fix_catalog import SUPPORTED_FIX_CATEGORIES
 from ..operations import DiagnoseOperation
 from ..utils.colors import green, red
+# Composition helpers shared with the rescue orchestrator (re-exported here
+# for backward compatibility; RESCUE_COMPLETE_MARKER is the marker used by
+# the rescue startup script).
+from .compose import (
+    RESCUE_COMPLETE_MARKER, compose_startup_script, strip_shebang,
+)
 from .rescue import RescueOrchestrator
 from .restore import RestoreOrchestrator
 
 # Marker prefixes emitted by fix scripts to serial console
 REPAIR_LINE_MARKER = 'GCE-REPAIR-LINE:'
 REPAIR_RESULT_MARKER = 'GCE-REPAIR-RESULT:'
-
-# Completion marker used by rescue startup script
-RESCUE_COMPLETE_MARKER = 'GCE-RESCUE-COMPLETE'
 
 # Maps raw rescue/restore step labels to user-friendly display names
 RESCUE_SUBSTEP_LABELS = {
@@ -54,63 +57,6 @@ RESTORE_SUBSTEP_LABELS = {
     'Restoring affected disk': 'Restoring boot disk',
     'Starting': 'Starting VM',
 }
-
-
-def strip_shebang(script: str) -> str:
-    """Remove a leading shebang line (already present in the base script)."""
-    if script.startswith('#!'):
-        parts = script.split('\n', 1)
-        return parts[1] if len(parts) > 1 else ''
-    return script
-
-
-def compose_startup_script(base_script: str, fix_scripts: List[str],
-                           repair_targets: Optional[List[str]] = None) -> str:
-    """Combine the base mount script with fix script(s) into one startup script.
-
-    The base script's GCE-RESCUE-COMPLETE marker is relocated to the very end
-    so the orchestrator's verification (and any restore that follows) only
-    proceeds after ALL fix scripts have finished — never mid-fix.
-
-    Args:
-        base_script: The mount script, with disk placeholder already resolved.
-        fix_scripts: Fix script bodies to append (shebangs already stripped).
-        repair_targets: Identifiers extracted from diagnosis for targeted
-            fixing. Pass a list (possibly empty) to inject the REPAIR_TARGETS
-            variable for diagnosis-driven fixes; pass None for self-contained
-            (custom) fix scripts that need no targets.
-
-    Returns:
-        The combined startup script.
-    """
-    # Remove the completion marker line (re-added at the very end)
-    combined = base_script.replace(
-        f'echo "{RESCUE_COMPLETE_MARKER}" >&2',
-        f'# GCE-RESCUE-COMPLETE marker moved to end (repair mode)'
-    )
-
-    combined += '\n'
-    combined += '\n# === GCE Repair Fix Scripts ===\n'
-    combined += 'log "=== Starting repair fixes ==="\n\n'
-
-    # Inject REPAIR_TARGETS variable for targeted fstab fixing (diagnosis mode)
-    if repair_targets is not None:
-        if repair_targets:
-            targets_str = '\n'.join(repair_targets)
-            combined += '# Repair targets extracted from diagnosis\n'
-            combined += f'REPAIR_TARGETS="{targets_str}"\n\n'
-        else:
-            combined += '# No specific repair targets extracted from diagnosis\n'
-            combined += 'REPAIR_TARGETS=""\n\n'
-
-    for fix_script in fix_scripts:
-        combined += fix_script + '\n\n'
-
-    combined += 'log "=== Repair fixes completed ==="\n'
-    combined += f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
-    combined += 'log "=== Startup script completed successfully ==="\n'
-
-    return combined
 
 
 class RepairOrchestrator:

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -11,7 +11,9 @@ Coordinates the rescue workflow:
 
 import time
 from ..core.config import RescueConfig, OS_TYPE_WINDOWS, OS_TYPE_LINUX, build_user_agent
-from .compose import compose_startup_script, strip_shebang
+from .compose import (
+    compose_startup_script, compose_startup_script_windows, strip_shebang,
+)
 from ..utils.os_detection import (
     detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64,
     get_rescue_disk_type, detect_os_flavor
@@ -1031,14 +1033,21 @@ class RescueOrchestrator:
                 # Replace password placeholder for Windows
                 if self.os_type == OS_TYPE_WINDOWS and self.windows_rescue_password:
                     script = script.replace('PASSWORD_PLACEHOLDER', self.windows_rescue_password)
-                # Append custom fix script (--fix-script) after the mount part.
-                # The completion marker is relocated to the end so verification
-                # only succeeds after the fix has run. Linux only (Phase 1).
-                if self.config.fix_script and self.os_type != OS_TYPE_WINDOWS:
-                    script = compose_startup_script(
-                        script, [strip_shebang(self.config.fix_script)],
-                        repair_targets=None
-                    )
+                # Combine with the custom fix script (--fix-script) so the
+                # fix runs after the mount part, and verification only
+                # succeeds after the fix has run.
+                if self.config.fix_script:
+                    if self.os_type == OS_TYPE_WINDOWS:
+                        # PowerShell: insert before the completion marker
+                        script = compose_startup_script_windows(
+                            script, [self.config.fix_script]
+                        )
+                    else:
+                        # Bash: append with the marker relocated to the end
+                        script = compose_startup_script(
+                            script, [strip_shebang(self.config.fix_script)],
+                            repair_targets=None
+                        )
                 return script
 
         # Fallback: inline script if template not found

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -11,6 +11,7 @@ Coordinates the rescue workflow:
 
 import time
 from ..core.config import RescueConfig, OS_TYPE_WINDOWS, OS_TYPE_LINUX, build_user_agent
+from .compose import compose_startup_script, strip_shebang
 from ..utils.os_detection import (
     detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64,
     get_rescue_disk_type, detect_os_flavor
@@ -1030,6 +1031,14 @@ class RescueOrchestrator:
                 # Replace password placeholder for Windows
                 if self.os_type == OS_TYPE_WINDOWS and self.windows_rescue_password:
                     script = script.replace('PASSWORD_PLACEHOLDER', self.windows_rescue_password)
+                # Append custom fix script (--fix-script) after the mount part.
+                # The completion marker is relocated to the end so verification
+                # only succeeds after the fix has run. Linux only (Phase 1).
+                if self.config.fix_script and self.os_type != OS_TYPE_WINDOWS:
+                    script = compose_startup_script(
+                        script, [strip_shebang(self.config.fix_script)],
+                        repair_targets=None
+                    )
                 return script
 
         # Fallback: inline script if template not found

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -1059,6 +1059,12 @@ class TestFixScriptFlag:
         with pytest.raises(ValueError, match="empty"):
             cli.read_fix_script(str(empty))
 
+    def test_read_fix_script_normalizes_crlf(self, tmp_path):
+        """Windows CRLF line endings are normalized to LF (script runs in bash)."""
+        script = tmp_path / "fix.sh"
+        script.write_bytes(b"echo one\r\necho two\r\n")
+        assert cli.read_fix_script(str(script)) == "echo one\necho two\n"
+
 
 class TestFixScriptRepairPath:
     """--fix-script on repair: diagnosis bypass and confirmation flow."""

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -1065,6 +1065,13 @@ class TestFixScriptFlag:
         script.write_bytes(b"echo one\r\necho two\r\n")
         assert cli.read_fix_script(str(script)) == "echo one\necho two\n"
 
+    def test_read_fix_script_too_large_raises(self, tmp_path):
+        """Scripts over the metadata size budget fail at pre-flight."""
+        big = tmp_path / "big.sh"
+        big.write_text("# x\n" * (cli.MAX_FIX_SCRIPT_BYTES // 4 + 1))
+        with pytest.raises(ValueError, match="too large"):
+            cli.read_fix_script(str(big))
+
 
 class TestFixScriptRepairPath:
     """--fix-script on repair: diagnosis bypass and confirmation flow."""

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -1058,3 +1058,97 @@ class TestFixScriptFlag:
         empty.write_text("   \n")
         with pytest.raises(ValueError, match="empty"):
             cli.read_fix_script(str(empty))
+
+
+class TestFixScriptRepairPath:
+    """--fix-script on repair: diagnosis bypass and confirmation flow."""
+
+    SUCCESS_RESULT = {
+        "status": "unknown", "fixed_count": 0, "fix_lines": [],
+        "error": None, "snapshot_name": "snap-1", "duration_seconds": 10,
+        "boot_verified": True, "boot_errors_after": [],
+    }
+
+    def _setup_base(self, monkeypatch):
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(preflight, "get_gcloud_config", lambda key: "test-proj")
+        mock_compute = _mock_auth(monkeypatch)
+        monkeypatch.setattr(preflight, "_create_tracked_client",
+                            lambda c, label: mock_compute)
+        mock_compute.instances.return_value.get.return_value.execute.return_value = {
+            "status": "RUNNING",
+            "disks": [{"boot": True, "source": "disk", "deviceName": "sda"}],
+            "metadata": {"items": []},
+        }
+        return mock_compute
+
+    def _make_fake_orch(self, result=None):
+        calls = {"execute_custom": 0, "diagnose": 0}
+        outer_result = result or self.SUCCESS_RESULT
+
+        class FakeOrch:
+            _suppress_header = False
+            call_log = calls
+
+            def __init__(self, **kwargs):
+                self.config = kwargs.get("config")
+
+            def validate(self):
+                return True
+
+            def diagnose(self):
+                calls["diagnose"] += 1
+                raise AssertionError("diagnose must be bypassed with --fix-script")
+
+            def execute_custom(self):
+                calls["execute_custom"] += 1
+                return outer_result
+
+        return FakeOrch
+
+    def test_repair_fix_script_bypasses_diagnosis(self, monkeypatch, tmp_path):
+        """--fix-script runs execute_custom and never calls diagnose."""
+        self._setup_base(monkeypatch)
+        Fake = self._make_fake_orch()
+        monkeypatch.setattr(
+            "gce_rescue_v2.orchestration.repair.RepairOrchestrator", Fake
+        )
+
+        script = tmp_path / "fix.sh"
+        script.write_text("echo custom-fix\n")
+        args = _parse_args("repair", extra=["--fix-script", str(script)])
+
+        exit_code = cli.handle_repair(args)
+        assert exit_code == 0
+        assert Fake.call_log["execute_custom"] == 1
+        assert Fake.call_log["diagnose"] == 0
+
+    def test_confirmation_abort_does_not_execute(self, monkeypatch, tmp_path):
+        """Answering 'n' at the confirmation never touches the VM."""
+        from gce_rescue_v2.cli.repair import _run_custom_fix_script
+
+        orch = Mock()
+        args = _parse_args("repair", extra=["--fix-script", "/tmp/fix.sh"])
+        args.quiet = False
+        monkeypatch.setattr("builtins.input", lambda *a: "n")
+
+        exit_code = _run_custom_fix_script(args, orch, "test-proj",
+                                           "echo fix\n")
+        assert exit_code == 0
+        orch.execute_custom.assert_not_called()
+
+    def test_confirmation_yes_executes(self, monkeypatch, tmp_path):
+        """Answering 'y' proceeds to execute_custom."""
+        from gce_rescue_v2.cli.repair import _run_custom_fix_script
+
+        orch = Mock()
+        orch.execute_custom.return_value = dict(self.SUCCESS_RESULT)
+        args = _parse_args("repair", extra=["--fix-script", "/tmp/fix.sh"])
+        args.quiet = False
+        monkeypatch.setattr("builtins.input", lambda *a: "y")
+
+        exit_code = _run_custom_fix_script(args, orch, "test-proj",
+                                           "echo fix\n")
+        assert exit_code == 0
+        orch.execute_custom.assert_called_once()
+        assert orch._suppress_header is True

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -1003,3 +1003,58 @@ class TestRescueImageFlag:
         args = self.parser.parse_args(["rescue", "vm-1", "--zone", "us-central1-a"])
         config = cli.args_to_rescue_config(args)
         assert config.custom_rescue_image is None
+
+
+class TestFixScriptFlag:
+    """Tests for the --fix-script flag wiring on rescue and repair."""
+
+    def setup_method(self):
+        self.parser = cli.create_parser()
+
+    def _write_script(self, tmp_path, content="echo fixing\n"):
+        script = tmp_path / "fix.sh"
+        script.write_text(content)
+        return str(script)
+
+    def test_fix_script_parsed_on_rescue(self, tmp_path):
+        """rescue accepts --fix-script and stores the path on args."""
+        path = self._write_script(tmp_path)
+        args = self.parser.parse_args([
+            "rescue", "vm-1", "--zone", "us-central1-a", "--fix-script", path,
+        ])
+        assert args.fix_script == path
+
+    def test_fix_script_parsed_on_repair(self, tmp_path):
+        """repair accepts --fix-script and stores the path on args."""
+        path = self._write_script(tmp_path)
+        args = self.parser.parse_args([
+            "repair", "vm-1", "--zone", "us-central1-a", "--fix-script", path,
+        ])
+        assert args.fix_script == path
+
+    def test_fix_script_content_populates_config(self, tmp_path):
+        """args_to_rescue_config reads the file and stores its content on config."""
+        path = self._write_script(tmp_path, content="echo hello\n")
+        args = self.parser.parse_args([
+            "repair", "vm-1", "--zone", "us-central1-a", "--fix-script", path,
+        ])
+        config = cli.args_to_rescue_config(args)
+        assert config.fix_script == "echo hello\n"
+
+    def test_no_fix_script_leaves_config_none(self):
+        """Without the flag, RescueConfig.fix_script stays None."""
+        args = self.parser.parse_args(["rescue", "vm-1", "--zone", "us-central1-a"])
+        config = cli.args_to_rescue_config(args)
+        assert config.fix_script is None
+
+    def test_read_fix_script_missing_file_raises(self):
+        """read_fix_script raises ValueError for a non-existent path."""
+        with pytest.raises(ValueError, match="file not found"):
+            cli.read_fix_script("/nonexistent/path/to/fix.sh")
+
+    def test_read_fix_script_empty_file_raises(self, tmp_path):
+        """read_fix_script raises ValueError for an empty file."""
+        empty = tmp_path / "empty.sh"
+        empty.write_text("   \n")
+        with pytest.raises(ValueError, match="empty"):
+            cli.read_fix_script(str(empty))

--- a/gce_rescue_v2/tests/test_compose.py
+++ b/gce_rescue_v2/tests/test_compose.py
@@ -3,6 +3,7 @@
 from gce_rescue_v2.orchestration.compose import (
     RESCUE_COMPLETE_MARKER,
     compose_startup_script,
+    compose_startup_script_windows,
     strip_shebang,
 )
 
@@ -88,3 +89,49 @@ class TestComposeStartupScript:
         # Marker still after the LAST fix
         assert script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"') > \
             script.index('second fix')
+
+
+# Minimal stand-in for rescue_mount_windows.ps1: mount + marker + trailing
+# content (RDP credentials) that must be preserved after composition.
+BASE_SCRIPT_WINDOWS = (
+    'Write-Log "mounting disk"\n'
+    'Set-Partition -NewDriveLetter D\n'
+    f'Write-Log "{RESCUE_COMPLETE_MARKER}"\n'
+    'Write-Log "RDP CONNECTION CREDENTIALS"\n'
+    'Write-Log "Password: hunter2"\n'
+)
+
+
+class TestComposeStartupScriptWindows:
+    """Windows composition: fix inserted BEFORE the marker, tail preserved."""
+
+    def test_fix_inserted_before_marker(self):
+        fix = 'Remove-Item D:\\Windows\\bad-driver.sys'
+        script = compose_startup_script_windows(BASE_SCRIPT_WINDOWS, [fix])
+        marker_pos = script.index(f'Write-Log "{RESCUE_COMPLETE_MARKER}"')
+        assert script.index(fix) < marker_pos
+
+    def test_mount_logic_runs_before_fix(self):
+        fix = 'Write-Log "fixing"'
+        script = compose_startup_script_windows(BASE_SCRIPT_WINDOWS, [fix])
+        assert script.index('Set-Partition') < script.index(fix)
+
+    def test_post_marker_content_preserved(self):
+        """RDP credentials etc. after the marker must survive composition."""
+        script = compose_startup_script_windows(BASE_SCRIPT_WINDOWS, ['fix'])
+        marker_pos = script.index(f'Write-Log "{RESCUE_COMPLETE_MARKER}"')
+        assert 'RDP CONNECTION CREDENTIALS' in script
+        assert script.index('RDP CONNECTION CREDENTIALS') > marker_pos
+
+    def test_single_marker_emission(self):
+        """The marker is not duplicated by composition."""
+        script = compose_startup_script_windows(BASE_SCRIPT_WINDOWS, ['fix'])
+        assert script.count(f'Write-Log "{RESCUE_COMPLETE_MARKER}"') == 1
+
+    def test_marker_missing_falls_back_to_append(self):
+        """If the base has no marker, fixes + marker are appended at the end."""
+        base = 'Write-Log "mount only"\n'
+        script = compose_startup_script_windows(base, ['fix body'])
+        assert 'fix body' in script
+        assert script.rindex(f'Write-Log "{RESCUE_COMPLETE_MARKER}"') > \
+            script.index('fix body')

--- a/gce_rescue_v2/tests/test_compose.py
+++ b/gce_rescue_v2/tests/test_compose.py
@@ -1,0 +1,90 @@
+"""Tests for the startup-script composer (orchestration/compose.py)."""
+
+from gce_rescue_v2.orchestration.compose import (
+    RESCUE_COMPLETE_MARKER,
+    compose_startup_script,
+    strip_shebang,
+)
+
+
+# Minimal stand-in for rescue_mount.sh: mount logic + completion marker
+BASE_SCRIPT = (
+    'log "mounting disk"\n'
+    'mount /dev/sdb1 /mnt/sysroot\n'
+    f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
+    'log "startup done"\n'
+)
+
+
+class TestStripShebang:
+    """strip_shebang removes a leading shebang line only."""
+
+    def test_strips_bash_shebang(self):
+        assert strip_shebang('#!/bin/bash\necho hi\n') == 'echo hi\n'
+
+    def test_strips_sh_shebang(self):
+        assert strip_shebang('#!/bin/sh\necho hi\n') == 'echo hi\n'
+
+    def test_no_shebang_unchanged(self):
+        assert strip_shebang('echo hi\n') == 'echo hi\n'
+
+    def test_shebang_only_returns_empty(self):
+        assert strip_shebang('#!/bin/bash') == ''
+
+    def test_comment_not_stripped(self):
+        """A normal comment line is not a shebang."""
+        script = '# not a shebang\necho hi\n'
+        assert strip_shebang(script) == script
+
+
+class TestComposeStartupScript:
+    """compose_startup_script combines mount + fix with marker relocation."""
+
+    def test_marker_relocated_after_fix(self):
+        """The active completion marker must come AFTER the fix body."""
+        fix = 'sed -i "s/bad/good/" /mnt/sysroot/etc/fstab'
+        script = compose_startup_script(BASE_SCRIPT, [fix], repair_targets=None)
+        marker_pos = script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"')
+        assert marker_pos > script.index(fix), \
+            "completion marker must fire only after the fix has run"
+
+    def test_original_marker_commented(self):
+        """The base script's marker line is replaced with a comment."""
+        script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=None)
+        assert 'marker moved to end' in script
+        # Exactly one ACTIVE echo of the marker remains (the relocated one)
+        assert script.count(f'echo "{RESCUE_COMPLETE_MARKER}"') == 1
+
+    def test_mount_logic_preserved(self):
+        """Base mount logic is kept intact ahead of the fix."""
+        fix = 'fix body'
+        script = compose_startup_script(BASE_SCRIPT, [fix], repair_targets=None)
+        assert 'mount /dev/sdb1 /mnt/sysroot' in script
+        assert script.index('mount /dev/sdb1') < script.index(fix)
+
+    def test_none_targets_omits_repair_targets(self):
+        """Custom (self-contained) scripts get no REPAIR_TARGETS variable."""
+        script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=None)
+        assert 'REPAIR_TARGETS' not in script
+
+    def test_empty_targets_injects_empty_variable(self):
+        """Diagnosis mode with no extracted targets injects REPAIR_TARGETS=""."""
+        script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=[])
+        assert 'REPAIR_TARGETS=""' in script
+
+    def test_targets_injected_newline_separated(self):
+        """Diagnosis-extracted targets are newline-joined into the variable."""
+        script = compose_startup_script(
+            BASE_SCRIPT, ['fix'], repair_targets=['uuid-1', '/dev/sdb1']
+        )
+        assert 'REPAIR_TARGETS="uuid-1\n/dev/sdb1"' in script
+
+    def test_multiple_fix_scripts_in_order(self):
+        """Multiple fix bodies are appended in the given order."""
+        script = compose_startup_script(
+            BASE_SCRIPT, ['first fix', 'second fix'], repair_targets=[]
+        )
+        assert script.index('first fix') < script.index('second fix')
+        # Marker still after the LAST fix
+        assert script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"') > \
+            script.index('second fix')

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -1453,3 +1453,74 @@ class TestFindRescueSnapshot:
         orch._create_tracked_client = lambda label: compute
 
         assert orch._find_rescue_snapshot() is None
+
+
+# ---------------------------------------------------------------------------
+# TestCustomFixScript
+# ---------------------------------------------------------------------------
+
+class TestCustomFixScript:
+    """Custom fix script path (--fix-script): orchestrator side."""
+
+    def _make_orchestrator(self, fix_script='echo custom-fix'):
+        vm_info = {
+            'status': 'TERMINATED',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/test-boot-disk',
+                'deviceName': 'test-boot-disk',
+                'licenses': ['projects/debian-cloud/global/licenses/debian-12'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+        config = RescueConfig()
+        config.fix_script = fix_script
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', config=config,
+            logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        return orch
+
+    def test_custom_script_contains_fix_body(self):
+        """Generated script embeds the supplied fix after the mount part."""
+        orch = self._make_orchestrator('touch /mnt/sysroot/etc/fixed')
+        script = orch._generate_custom_fix_script(orch.config.fix_script)
+        assert 'touch /mnt/sysroot/etc/fixed' in script
+        assert 'test-boot-disk' in script
+        assert 'DISK_NAME_PLACEHOLDER' not in script
+
+    def test_custom_script_no_repair_targets(self):
+        """Custom scripts are self-contained: no REPAIR_TARGETS injected."""
+        orch = self._make_orchestrator()
+        script = orch._generate_custom_fix_script(orch.config.fix_script)
+        assert 'REPAIR_TARGETS' not in script
+
+    def test_custom_script_marker_after_fix(self):
+        """Completion marker must fire only after the custom fix has run."""
+        fix = 'sed -i "s/bad/good/" /mnt/sysroot/etc/fstab'
+        orch = self._make_orchestrator(fix)
+        script = orch._generate_custom_fix_script(fix)
+        marker_pos = script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"')
+        assert marker_pos > script.index(fix)
+
+    def test_custom_script_shebang_stripped(self):
+        """A shebang in the supplied script is removed (base has one)."""
+        orch = self._make_orchestrator()
+        script = orch._generate_custom_fix_script('#!/bin/bash\necho fix')
+        assert script.count('#!/bin/bash') == 1  # only the base script's
+
+    def test_execute_custom_runs_shared_flow(self):
+        """execute_custom composes the script and delegates to the flow."""
+        orch = self._make_orchestrator('echo custom-fix')
+        sentinel = {'status': 'success', 'fixed_count': 1, 'fix_lines': [],
+                    'error': None, 'snapshot_name': 's', 'duration_seconds': 1}
+        with patch.object(orch, '_generate_custom_fix_script',
+                          return_value='SCRIPT') as gen, \
+             patch.object(orch, '_run_repair_flow',
+                          return_value=sentinel) as flow:
+            result = orch.execute_custom()
+        gen.assert_called_once_with('echo custom-fix')
+        flow.assert_called_once_with('SCRIPT')
+        assert result is sentinel

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -1483,44 +1483,83 @@ class TestCustomFixScript:
         orch._create_tracked_client = lambda label: compute
         return orch
 
-    def test_custom_script_contains_fix_body(self):
-        """Generated script embeds the supplied fix after the mount part."""
-        orch = self._make_orchestrator('touch /mnt/sysroot/etc/fixed')
-        script = orch._generate_custom_fix_script(orch.config.fix_script)
-        assert 'touch /mnt/sysroot/etc/fixed' in script
-        assert 'test-boot-disk' in script
-        assert 'DISK_NAME_PLACEHOLDER' not in script
-
-    def test_custom_script_no_repair_targets(self):
-        """Custom scripts are self-contained: no REPAIR_TARGETS injected."""
-        orch = self._make_orchestrator()
-        script = orch._generate_custom_fix_script(orch.config.fix_script)
-        assert 'REPAIR_TARGETS' not in script
-
-    def test_custom_script_marker_after_fix(self):
-        """Completion marker must fire only after the custom fix has run."""
-        fix = 'sed -i "s/bad/good/" /mnt/sysroot/etc/fstab'
-        orch = self._make_orchestrator(fix)
-        script = orch._generate_custom_fix_script(fix)
-        marker_pos = script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"')
-        assert marker_pos > script.index(fix)
-
-    def test_custom_script_shebang_stripped(self):
-        """A shebang in the supplied script is removed (base has one)."""
-        orch = self._make_orchestrator()
-        script = orch._generate_custom_fix_script('#!/bin/bash\necho fix')
-        assert script.count('#!/bin/bash') == 1  # only the base script's
-
-    def test_execute_custom_runs_shared_flow(self):
-        """execute_custom composes the script and delegates to the flow."""
+    def test_execute_custom_propagates_fix_script(self):
+        """execute_custom hands the fix script to the shared flow (no
+        startup-script override; composition happens per-OS in rescue)."""
         orch = self._make_orchestrator('echo custom-fix')
         sentinel = {'status': 'success', 'fixed_count': 1, 'fix_lines': [],
                     'error': None, 'snapshot_name': 's', 'duration_seconds': 1}
-        with patch.object(orch, '_generate_custom_fix_script',
-                          return_value='SCRIPT') as gen, \
-             patch.object(orch, '_run_repair_flow',
+        with patch.object(orch, '_run_repair_flow',
                           return_value=sentinel) as flow:
             result = orch.execute_custom()
-        gen.assert_called_once_with('echo custom-fix')
-        flow.assert_called_once_with('SCRIPT')
+        flow.assert_called_once_with(fix_script='echo custom-fix')
         assert result is sentinel
+
+    def test_run_repair_flow_sets_fix_script_on_rescue_config(self):
+        """The inner rescue config carries the fix script for composition."""
+        orch = self._make_orchestrator('echo custom-fix')
+        captured = {}
+
+        class FakeRescue:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def execute(self):
+                return False  # stop the flow right after construction
+
+            snapshot_name = None
+
+        with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator',
+                   FakeRescue):
+            orch._init_progress = lambda: None
+            orch._update_progress = lambda phase: None
+            orch._finish_progress = lambda ok=True: None
+            orch._run_repair_flow(fix_script='echo custom-fix')
+
+        assert captured['config'].fix_script == 'echo custom-fix'
+        assert captured['startup_script_override'] is None
+
+    def test_validate_windows_blocked_without_fix_script(self):
+        """Windows VMs are blocked unless a custom fix script is supplied."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/win-disk',
+                'deviceName': 'win-disk',
+                'licenses': ['projects/windows-cloud/global/licenses/windows-server-2022'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        with patch('gce_rescue_v2.validators.ValidationRunner') as runner_cls:
+            runner_cls.return_value.run_all.return_value.all_passed.return_value = True
+            assert orch.validate() is False
+
+    def test_validate_windows_allowed_with_fix_script(self):
+        """Windows VMs pass validation when --fix-script is supplied."""
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/win-disk',
+                'deviceName': 'win-disk',
+                'licenses': ['projects/windows-cloud/global/licenses/windows-server-2022'],
+            }],
+            'metadata': {'items': [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info)
+        config = RescueConfig()
+        config.fix_script = 'Write-Log "custom fix"'
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', config=config,
+            logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        with patch('gce_rescue_v2.validators.ValidationRunner') as runner_cls:
+            runner_cls.return_value.run_all.return_value.all_passed.return_value = True
+            assert orch.validate() is True

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -701,10 +701,22 @@ class TestFixScriptComposition:
                                        override='OVERRIDE')
         assert orch._generate_startup_script() == 'OVERRIDE'
 
-    def test_windows_fix_script_not_composed(self):
-        """Windows VMs do not get the fix script appended (Phase 2)."""
-        orch = self._make_orchestrator(fix_script='echo fix',
+    def test_windows_fix_script_inserted_before_marker(self):
+        """Windows: fix script is inserted BEFORE the completion marker."""
+        fix = 'Remove-Item D:\\Windows\\bad-driver.sys'
+        orch = self._make_orchestrator(fix_script=fix, os_type='windows')
+        script = orch._generate_startup_script()
+        assert fix in script
+        marker_pos = script.index('Write-Log "GCE-RESCUE-COMPLETE"')
+        assert script.index(fix) < marker_pos
+        # Post-marker content (RDP credentials) is preserved
+        assert 'RDP CONNECTION CREDENTIALS' in script
+        assert script.index('RDP CONNECTION CREDENTIALS') > marker_pos
+
+    def test_windows_fix_script_placeholders_resolved(self):
+        """Windows composition still resolves disk + password placeholders."""
+        orch = self._make_orchestrator(fix_script='Write-Log "fix"',
                                        os_type='windows')
         script = orch._generate_startup_script()
-        assert 'GCE Repair Fix Scripts' not in script
-        assert 'echo fix' not in script
+        assert 'DISK_NAME_PLACEHOLDER' not in script
+        assert 'PASSWORD_PLACEHOLDER' not in script

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -654,3 +654,57 @@ def test_custom_image_invalid_url_aborts_before_disk_creation(stub_rescue, monke
     assert orch.execute() is False
     assert create_called.value is False  # disk creation never attempted
     assert rollback_called.value is True  # cleanup ran
+
+
+class TestFixScriptComposition:
+    """--fix-script composition inside _generate_startup_script."""
+
+    def _make_orchestrator(self, fix_script=None, os_type='linux',
+                           override=None):
+        from gce_rescue_v2.core.config import OS_TYPE_LINUX, OS_TYPE_WINDOWS
+        config = RescueConfig()
+        config.fix_script = fix_script
+        orch = RescueOrchestrator(
+            compute=object(), project='p', zone='z', vm_name='vm-1',
+            config=config, startup_script_override=override,
+        )
+        orch.os_type = OS_TYPE_WINDOWS if os_type == 'windows' else OS_TYPE_LINUX
+        orch.original_disk_name = 'vm-boot-disk'
+        return orch
+
+    def test_linux_fix_script_composed(self):
+        """Linux + fix script: fix body embedded, marker relocated after it."""
+        fix = 'touch /mnt/sysroot/etc/fixed'
+        orch = self._make_orchestrator(fix_script=fix)
+        script = orch._generate_startup_script()
+        assert fix in script
+        assert script.rindex('echo "GCE-RESCUE-COMPLETE"') > script.index(fix)
+        assert 'REPAIR_TARGETS' not in script
+
+    def test_disk_placeholder_resolved_before_composition(self):
+        """Composed script has the real disk name, not the placeholder."""
+        orch = self._make_orchestrator(fix_script='echo fix')
+        script = orch._generate_startup_script()
+        assert 'DISK_NAME_PLACEHOLDER' not in script
+        assert 'vm-boot-disk' in script
+
+    def test_no_fix_script_unchanged(self):
+        """Without --fix-script the mount script is not modified."""
+        orch = self._make_orchestrator()
+        script = orch._generate_startup_script()
+        assert 'GCE Repair Fix Scripts' not in script
+        assert script.count('echo "GCE-RESCUE-COMPLETE"') == 1
+
+    def test_override_takes_precedence(self):
+        """startup_script_override (repair path) wins over fix_script."""
+        orch = self._make_orchestrator(fix_script='echo fix',
+                                       override='OVERRIDE')
+        assert orch._generate_startup_script() == 'OVERRIDE'
+
+    def test_windows_fix_script_not_composed(self):
+        """Windows VMs do not get the fix script appended (Phase 2)."""
+        orch = self._make_orchestrator(fix_script='echo fix',
+                                       os_type='windows')
+        script = orch._generate_startup_script()
+        assert 'GCE Repair Fix Scripts' not in script
+        assert 'echo fix' not in script


### PR DESCRIPTION
## Summary

Adds a `--fix-script=PATH` flag to the `rescue` and `repair` commands so an engineer can run a known fix against the affected boot disk without waiting for diagnosis. Built for large-scale events where many VMs fail the same known way — e.g., a faulty driver or security-agent update that leaves a fleet of VMs unbootable at once — and for one-off repairs the fix catalog does not cover.

```
gce-rescue repair VM --zone=ZONE --fix-script=fix.sh    # mount -> run fix -> restore -> verify boot
gce-rescue rescue VM --zone=ZONE --fix-script=fix.sh    # mount -> run fix -> stay mounted to inspect
```

## How it works

The rescue startup script already runs in two parts: a mount part (always) and a fix part (repair only, generated from diagnosis). This change makes the fix part user-suppliable:

- The CLI reads and validates the script (exists, non-empty, under the 256 KB metadata budget, CRLF normalized) and stores its content on `RescueConfig.fix_script` — fail-fast before any destructive operation.
- A new shared composer (`orchestration/compose.py`) combines mount + fix per OS:
  - **Linux (bash):** fix appended, completion marker relocated to the end so verification (and restore) only proceed after the fix has run.
  - **Windows (PowerShell):** fix inserted *before* the marker — the Windows mount script emits RDP credentials after the marker, which must be preserved.
- `repair --fix-script` skips diagnosis, previews the script in the confirmation (`--quiet` skips for automation), and runs the standard rescue -> restore -> boot-verify flow. The custom path propagates the fix script via the rescue config rather than a startup-script override, so disk-name and Windows-password placeholders resolve as usual.
- Scripts may optionally emit the existing `GCE-REPAIR-RESULT:`/`GCE-REPAIR-LINE:` markers for a per-VM fix summary; otherwise success falls back to post-restore boot verification.
- Diagnosis-driven repair on Windows remains blocked; Windows is allowed only with `--fix-script`.

## Testing

- 38 new unit tests (composer, orchestrator paths, CLI flows, validation); suite at 492 passing.
- **Linux end-to-end on real VMs:** three separate incidents repaired with custom scripts — a broken fstab entry, deleted SSH host keys (`ssh-keygen -A` in chroot), and a truncated sudoers file + guest-agent state reset. Each: mount -> fix -> restore -> boot-verified, 4-7 minutes.
- **Windows end-to-end smoke on a real Windows Server VM:** PowerShell fix executed against the disk mounted at D:, result markers parsed from serial console, automatic restore, VM healthy (7m08s).

## Notes

- Closes #63 (`rescue --fix-script` covers the custom-script-after-rescue use case).
- Follow-up (not in this PR): Windows-specific boot-verification patterns — post-restore verification currently confirms by absence of known error patterns on Windows.

