### PR TITLE
feat: add --verification-timeout flag with OS-aware defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ More info: [Application Default Credentials](https://cloud.google.com/docs/authe
 | `--no-snapshot` | Skip safety snapshot (faster) |
 | `--rescue-image` | Custom rescue disk image URL (must match VM's OS family + architecture). Useful for restricted-image org policies or hardened rescue environments. Available for `rescue` and `repair`. |
 | `--fix-script` | Path to a custom fix script (bash on Linux, PowerShell on Windows) to run against the affected disk after it is mounted — skips diagnosis. With `repair` the VM is restored and boot-verified afterwards; with `rescue` it stays in rescue mode for inspection. The affected disk is mounted at `/mnt/sysroot` on Linux; on Windows its partitions get drive letters from `D:` onward (iterate non-`C:` volumes rather than assuming `D:`). |
+| `--verification-timeout` | Seconds to wait for the rescue VM startup script to complete (serial console marker). Overrides the OS-aware default (Linux: 300, Windows: 600). Raise it for slow-booting VMs. Available for `rescue` and `repair`. |
 | `--quiet` | No confirmation prompts (for automation) |
 | `--format` | Output format: `json`, `yaml`, `table` |
 

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -384,6 +384,34 @@ def _add_common_args(parser: argparse.ArgumentParser):
     )
 
 
+def _positive_int(value: str) -> int:
+    """argparse type: a positive integer (for timeout flags)."""
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not an integer")
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {ivalue}")
+    return ivalue
+
+
+def _add_verification_timeout_arg(parser: argparse.ArgumentParser):
+    """Add the --verification-timeout flag (shared by rescue and repair)."""
+    group = parser.add_argument_group('VERIFICATION FLAGS')
+    group.add_argument(
+        '--verification-timeout',
+        metavar='SECONDS',
+        dest='verification_timeout',
+        type=_positive_int,
+        default=None,
+        help=(
+            'Seconds to wait for the rescue VM startup script to report'
+            ' completion via serial console. Overrides the OS-aware default'
+            ' (Linux: 300, Windows: 600). Raise it for slow-booting VMs.'
+        )
+    )
+
+
 def _add_rescue_args(parser: argparse.ArgumentParser):
     """Add rescue-specific arguments."""
 
@@ -432,6 +460,8 @@ def _add_rescue_args(parser: argparse.ArgumentParser):
         )
     )
 
+    _add_verification_timeout_arg(parser)
+
 
 def _add_repair_args(parser: argparse.ArgumentParser):
     """Add repair-specific arguments."""
@@ -479,6 +509,8 @@ def _add_repair_args(parser: argparse.ArgumentParser):
             ' auto-generated fix, then restores the VM and verifies boot.'
         )
     )
+
+    _add_verification_timeout_arg(parser)
 
 
 def _add_restore_args(parser: argparse.ArgumentParser):
@@ -568,6 +600,10 @@ def args_to_rescue_config(args: argparse.Namespace) -> RescueConfig:
     # Force setting (for Local SSD VMs)
     if hasattr(args, 'force'):
         config.force = args.force
+
+    # Explicit startup verification timeout (overrides OS-aware defaults)
+    if getattr(args, 'verification_timeout', None) is not None:
+        config.verification_timeout_override = args.verification_timeout
 
     # Verbosity to log level
     verbosity_map = {

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -125,7 +125,14 @@ class RescueConfig:
     vm_start_timeout: int = 300  # 5 minutes
     disk_create_timeout: int = 300  # 5 minutes
     operation_timeout: int = 600  # 10 minutes
-    startup_verification_timeout: int = 120  # 2 minutes for startup script completion
+    # Startup-script verification (poll serial console for the completion marker).
+    # Linux/general default; Windows boots slower and the Windows mount script can
+    # wait up to 5 min just to detect the affected disk, so it gets a higher default.
+    startup_verification_timeout: int = 300  # 5 minutes (Linux/general)
+    windows_startup_verification_timeout: int = 600  # 10 minutes (Windows)
+    # Explicit override from the --verification-timeout CLI flag. When set, it wins
+    # over the OS-aware defaults above.
+    verification_timeout_override: Optional[int] = None
 
     # Logging settings
     log_level: str = 'INFO'
@@ -140,6 +147,26 @@ class RescueConfig:
     preserve_rescue_disk: bool = False  # Keep rescue disk after restore
     skip_health_check: bool = False  # Skip health checks
     force: bool = False  # Force operation (e.g., stop VM with Local SSDs)
+
+    def effective_verification_timeout(self, os_type: Optional[str]) -> int:
+        """Resolve the startup-script verification timeout for this run.
+
+        An explicit --verification-timeout override always wins. Otherwise the
+        timeout is OS-aware: Windows gets a longer budget than Linux because it
+        boots slower and its mount script can spend minutes detecting the disk.
+
+        Args:
+            os_type: Detected OS of the target VM (OS_TYPE_WINDOWS / OS_TYPE_LINUX
+                or None if not yet detected).
+
+        Returns:
+            Timeout in seconds.
+        """
+        if self.verification_timeout_override is not None:
+            return self.verification_timeout_override
+        if os_type == OS_TYPE_WINDOWS:
+            return self.windows_startup_verification_timeout
+        return self.startup_verification_timeout
 
 
 @dataclass

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -296,6 +296,11 @@ class RepairOrchestrator:
             # Custom fix script (--fix-script): composed per-OS by the rescue
             # orchestrator's startup-script generation
             rescue_config.fix_script = fix_script
+            # Propagate explicit --verification-timeout (issue #123); OS-aware
+            # defaults come from RescueConfig itself.
+            rescue_config.verification_timeout_override = (
+                self.config.verification_timeout_override
+            )
 
             rescue = RescueOrchestrator(
                 compute=self.compute, project=self.project, zone=self.zone,

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -934,7 +934,7 @@ class RescueOrchestrator:
                 verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
                 result = verify_startup.execute(
                     vm_name=self.vm_name,
-                    timeout=self.config.startup_verification_timeout,
+                    timeout=self.config.effective_verification_timeout(self.os_type),
                     tracking_label=self._ua('vm-verify-startup')
                 )
                 self.verification_succeeded = result.success

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -1052,6 +1052,96 @@ class TestFixScriptFlag:
         with pytest.raises(ValueError, match="file not found"):
             cli.read_fix_script("/nonexistent/path/to/fix.sh")
 
+
+class TestVerificationTimeoutFlag:
+    """Tests for --verification-timeout flag and OS-aware timeout resolution."""
+
+    def setup_method(self):
+        self.parser = cli.create_parser()
+
+    def test_parsed_on_rescue(self):
+        """rescue accepts --verification-timeout and stores it on args."""
+        args = self.parser.parse_args([
+            "rescue", "vm-1", "--zone", "us-central1-a",
+            "--verification-timeout", "900",
+        ])
+        assert args.verification_timeout == 900
+
+    def test_parsed_on_repair(self):
+        """repair accepts --verification-timeout and stores it on args."""
+        args = self.parser.parse_args([
+            "repair", "vm-1", "--zone", "us-central1-a",
+            "--verification-timeout", "900",
+        ])
+        assert args.verification_timeout == 900
+
+    def test_defaults_to_none(self):
+        """Without the flag, verification_timeout is None (use OS-aware default)."""
+        args = self.parser.parse_args(["rescue", "vm-1", "--zone", "us-central1-a"])
+        assert args.verification_timeout is None
+
+    def test_rejects_zero(self):
+        """--verification-timeout rejects non-positive values."""
+        with pytest.raises(SystemExit):
+            self.parser.parse_args([
+                "rescue", "vm-1", "--zone", "us-central1-a",
+                "--verification-timeout", "0",
+            ])
+
+    def test_rejects_non_integer(self):
+        """--verification-timeout rejects non-integer values."""
+        with pytest.raises(SystemExit):
+            self.parser.parse_args([
+                "rescue", "vm-1", "--zone", "us-central1-a",
+                "--verification-timeout", "abc",
+            ])
+
+    def test_populates_config_override(self):
+        """args_to_rescue_config copies the flag into verification_timeout_override."""
+        args = self.parser.parse_args([
+            "rescue", "vm-1", "--zone", "us-central1-a",
+            "--verification-timeout", "900",
+        ])
+        config = cli.args_to_rescue_config(args)
+        assert config.verification_timeout_override == 900
+
+    def test_no_flag_leaves_override_none(self):
+        """Without the flag, verification_timeout_override stays None."""
+        args = self.parser.parse_args(["rescue", "vm-1", "--zone", "us-central1-a"])
+        config = cli.args_to_rescue_config(args)
+        assert config.verification_timeout_override is None
+
+
+class TestEffectiveVerificationTimeout:
+    """Tests for RescueConfig.effective_verification_timeout (OS-aware + override)."""
+
+    def test_linux_default(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_LINUX
+        config = RescueConfig()
+        assert config.effective_verification_timeout(OS_TYPE_LINUX) == 300
+
+    def test_windows_default_is_higher(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_WINDOWS
+        config = RescueConfig()
+        assert config.effective_verification_timeout(OS_TYPE_WINDOWS) == 600
+
+    def test_unknown_os_falls_back_to_general_default(self):
+        from gce_rescue_v2.core.config import RescueConfig
+        config = RescueConfig()
+        assert config.effective_verification_timeout(None) == 300
+
+    def test_override_wins_over_windows_default(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_WINDOWS
+        config = RescueConfig()
+        config.verification_timeout_override = 900
+        assert config.effective_verification_timeout(OS_TYPE_WINDOWS) == 900
+
+    def test_override_wins_over_linux_default(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_LINUX
+        config = RescueConfig()
+        config.verification_timeout_override = 45
+        assert config.effective_verification_timeout(OS_TYPE_LINUX) == 45
+
     def test_read_fix_script_empty_file_raises(self, tmp_path):
         """read_fix_script raises ValueError for an empty file."""
         empty = tmp_path / "empty.sh"


### PR DESCRIPTION
## What

Adds a `--verification-timeout=SECONDS` flag to `rescue` and `repair`, and makes the startup-script verification timeout OS-aware.

## Why

The verification timeout (how long we poll the serial console for the `GCE-RESCUE-COMPLETE` marker) was a single hardcoded default with no CLI control. Windows rescue VMs boot slowly, and the Windows mount script can wait up to ~5 minutes just to detect the affected disk before mounting and emitting the marker. A fixed short timeout caused **intermittent false failures on Windows** even when the rescue was healthy.

## Changes

- **`--verification-timeout=SECONDS`** on `rescue` and `repair` (positive integer; rejects 0/negative/non-int)
- **OS-aware defaults**: Linux 300s, Windows 600s. An explicit `--verification-timeout` overrides both.
- `RescueConfig.effective_verification_timeout(os_type)` resolves the effective value (override > Windows default > Linux default)
- Override propagated through the `repair -> rescue` flow
- README flags table + tests (flag parsing, validation, config wiring, OS-aware resolution)

## Testing

- `python -m pytest gce_rescue_v2/tests/` -> **504 passed**
- New tests in `test_cli.py`: `TestVerificationTimeoutFlag`, `TestEffectiveVerificationTimeout`

Closes #123
