### PR TITLE
feat: capture serial output + explicit message on verification timeout

### DIFF
--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -233,7 +233,16 @@ def handle_rescue(args: argparse.Namespace) -> int:
             wait_time = "1-2 minutes" if is_win else "30 seconds"
             rescue_log = "C:\\gce-rescue.log" if is_win else "/var/log/gce-rescue.log"
             creds_note = ", credentials" if is_win else ""
-            logger.info(f"{note_prefix()} Disk mount is still in progress.")
+            # Be explicit when verification actually timed out (vs. an unknown
+            # state), including how long we waited so the user can decide whether
+            # to extend it with --verification-timeout.
+            vr = getattr(orchestrator, 'verification_result', None)
+            if vr and vr.details and vr.details.get('timed_out'):
+                secs = vr.details.get('timeout_seconds')
+                logger.info(f"{note_prefix()} Startup verification timed out after"
+                            f" {secs}s; disk mount may still be in progress.")
+            else:
+                logger.info(f"{note_prefix()} Disk mount is still in progress.")
             logger.info(f"      Wait ~{wait_time} before connecting."
                         f" If disk is not available, check:")
             logger.info(f"      - Rescue log: {rescue_log}")

--- a/gce_rescue_v2/operations/base.py
+++ b/gce_rescue_v2/operations/base.py
@@ -95,6 +95,7 @@ class OperationResult:
     message: str
     rollback_data: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    details: Optional[Dict[str, Any]] = None  # Structured extras (e.g. timeout info)
 
     def __str__(self):
         """String representation."""

--- a/gce_rescue_v2/operations/verify_startup.py
+++ b/gce_rescue_v2/operations/verify_startup.py
@@ -44,6 +44,11 @@ class VerifyStartupOperation(BaseOperation):
 
         start_time = time.time()
         poll_interval = 5  # Poll every 5 seconds (consistent with V2 patterns)
+        # Most recent serial output seen; dumped to the log on timeout so
+        # failures are diagnosable from the log alone (no separate serial pull).
+        last_serial = ''
+        # How much trailing serial output to keep for diagnostics.
+        serial_tail_chars = 4000
 
         try:
             # Use tracked client if tracking_label provided
@@ -54,11 +59,30 @@ class VerifyStartupOperation(BaseOperation):
 
                 # Check timeout
                 if elapsed > timeout:
+                    serial_tail = last_serial[-serial_tail_chars:] if last_serial else ''
+                    self._log_info(
+                        f"Startup verification timed out after {timeout}s "
+                        f"(marker '{completion_marker}' not seen)"
+                    )
+                    if serial_tail:
+                        # DEBUG so it always lands in the log file (file handler
+                        # is DEBUG) without spamming the console.
+                        self._log_debug(
+                            f"Last serial console output (tail) at timeout:\n"
+                            f"{'-' * 60}\n{serial_tail}\n{'-' * 60}"
+                        )
+                    else:
+                        self._log_debug("No serial console output captured before timeout")
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
                         message=f"Timeout waiting for startup script ({timeout}s)",
-                        error=f"Startup script did not complete within {timeout}s"
+                        error=f"Startup script did not complete within {timeout}s",
+                        details={
+                            'timed_out': True,
+                            'timeout_seconds': timeout,
+                            'serial_tail': serial_tail,
+                        }
                     )
 
                 # Poll serial console
@@ -70,6 +94,8 @@ class VerifyStartupOperation(BaseOperation):
                     ).execute()
 
                     contents = result.get('contents', '')
+                    if contents:
+                        last_serial = contents
 
                     # Check for completion marker
                     if completion_marker in contents:

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -128,6 +128,7 @@ class RescueOrchestrator:
 
         # Verification status (set after startup verification)
         self.verification_succeeded = None
+        self.verification_result = None  # Full OperationResult (timeout details, etc.)
 
         # Snapshot name (set if snapshot created successfully)
         self.snapshot_name = None
@@ -938,6 +939,7 @@ class RescueOrchestrator:
                     tracking_label=self._ua('vm-verify-startup')
                 )
                 self.verification_succeeded = result.success
+                self.verification_result = result
                 # Don't fail on verification timeout - continue
                 # Update checkpoint (final step)
                 self.checkpoint_manager.update_checkpoint(

--- a/gce_rescue_v2/tests/test_verify_startup.py
+++ b/gce_rescue_v2/tests/test_verify_startup.py
@@ -122,6 +122,48 @@ class TestVerifyStartupOperation:
         assert result.success is False
         assert "Timeout" in result.message
 
+    def test_timeout_returns_structured_details(self):
+        """On timeout, result carries structured timeout details (issue #132)."""
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'booting...\nwaiting for disk\n'
+        }
+        with patch('time.sleep'):
+            with patch('time.time', side_effect=[0, 5, 121]):
+                result = self.operation.execute(vm_name='test-vm', timeout=120)
+        assert result.success is False
+        assert result.details is not None
+        assert result.details['timed_out'] is True
+        assert result.details['timeout_seconds'] == 120
+
+    def test_timeout_captures_serial_tail(self):
+        """The last serial output seen is captured in the timeout details."""
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'booting...\nwaiting for affected disk\n'
+        }
+        with patch('time.sleep'):
+            with patch('time.time', side_effect=[0, 5, 121]):
+                result = self.operation.execute(vm_name='test-vm', timeout=120)
+        assert 'waiting for affected disk' in result.details['serial_tail']
+
+    def test_timeout_empty_serial_has_empty_tail(self):
+        """Empty serial output yields an empty (not missing) tail."""
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': ''
+        }
+        with patch('time.sleep'):
+            with patch('time.time', side_effect=[0, 5, 121]):
+                result = self.operation.execute(vm_name='test-vm', timeout=120)
+        assert result.details['serial_tail'] == ''
+
+    def test_success_has_no_timeout_details(self):
+        """On success, details stays None (only set on timeout)."""
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'GCE-RESCUE-COMPLETE'
+        }
+        result = self.operation.execute(vm_name='test-vm', timeout=10)
+        assert result.success is True
+        assert result.details is None
+
     def test_tracking_label_used(self):
         """Test that tracking label creates custom User-Agent."""
         # Arrange


### PR DESCRIPTION
## What

Makes a startup-script verification timeout observable, for both `rescue` and `repair`:

1. **Serial output captured to the log.** `VerifyStartupOperation` now keeps the last serial console output it saw and, on timeout, dumps the tail to the log at DEBUG level (the file handler is always DEBUG, so it lands in the `*-rescue/repair-*.log` without spamming the console). The failure becomes diagnosable from the log alone.
2. **Explicit user message.** Instead of the vague `Note: Disk mount is still in progress.`, the user now sees `Startup verification timed out after Ns; disk mount may still be in progress.` — pointing them at `--verification-timeout`.

## Why

Found during #131 real-VM validation: when the verify timeout fires (mainly on slow Windows boots), the tool gave almost no signal — the serial output was discarded and the explicit timeout message was dropped at `rescue.py` (only `result.success` was read). This directly improves diagnosability of the Windows BCT verify-timeout failure.

## Changes

- `OperationResult`: optional `details` field for structured extras
- `verify_startup.py`: track last serial output; on timeout log the tail (DEBUG) + return `details={timed_out, timeout_seconds, serial_tail}`
- `rescue.py`: expose the full verification result (`verification_result`)
- `cli/rescue.py`: explicit timeout message when `details.timed_out`
- 4 new tests in `test_verify_startup.py`

## Testing

`python -m pytest gce_rescue_v2/tests/` -> **508 passed**

Closes #132
