### PR TITLE
fix: repair should pre-flight Local SSDs like rescue

### DIFF
--- a/gce_rescue_v2/cli/preflight.py
+++ b/gce_rescue_v2/cli/preflight.py
@@ -285,6 +285,43 @@ def _check_local_ssds(vm_info: dict) -> list:
     return local_ssds
 
 
+def check_local_ssd_quiet_gate(vm_info, instance_name, zone, command,
+                               quiet, force) -> tuple:
+    """Shared Local SSD safety gate for rescue/repair (quiet mode).
+
+    Stopping a VM with Local SSDs permanently destroys their data. In --quiet
+    mode there's no prompt, so require --force to opt into the loss explicitly
+    (otherwise the stop fails mid-operation with a raw discard-local-ssd API
+    error). Used by both handle_rescue and handle_repair so the gate stays
+    identical across subcommands.
+
+    Args:
+        vm_info: VM resource dict (from _validate_vm_exists).
+        instance_name, zone: for the actionable --force command hint.
+        command: 'rescue' or 'repair' (used in the hint).
+        quiet: whether --quiet was given.
+        force: whether --force was given.
+
+    Returns:
+        (local_ssds, error_message): error_message is non-None only when the
+        caller must abort (quiet + Local SSDs + no --force). local_ssds is the
+        detected list (possibly empty) for the caller's interactive handling.
+    """
+    local_ssds = _check_local_ssds(vm_info)
+    if local_ssds and quiet and not force:
+        msg = (
+            "VM has Local SSDs attached.\n\n"
+            f"Local SSDs found: {', '.join(local_ssds)}\n\n"
+            "WARNING: Stopping this VM will PERMANENTLY LOSE all data on"
+            " Local SSDs!\n\n"
+            "To proceed in quiet mode, use --force flag:\n"
+            f"  $ gce-rescue {command} {instance_name} --zone={zone}"
+            f" --quiet --force"
+        )
+        return local_ssds, msg
+    return local_ssds, None
+
+
 def _validate_vm_for_restore(compute, project: str, zone: str, vm_name: str,
                              user_agent: str = None) -> tuple:
     """

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -180,7 +180,8 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
 
 
 def _run_custom_fix_script(args: argparse.Namespace, orchestrator,
-                           project: str, fix_script: str) -> int:
+                           project: str, fix_script: str,
+                           local_ssds: list = None) -> int:
     """Run repair with a custom fix script (--fix-script), skipping diagnosis.
 
     Shows the supplied script and the repair plan, asks for confirmation
@@ -212,6 +213,10 @@ def _run_custom_fix_script(args: argparse.Namespace, orchestrator,
         print(f"    {step}. Restore original boot disk and start VM")
         print("")
         print("  Diagnosis is skipped: the script runs exactly as provided.")
+        if local_ssds:
+            print("")
+            print(f"  {warning_prefix()} Data on Local SSDs"
+                  f" ({', '.join(local_ssds)}) will be permanently lost.")
         print("")
 
         try:
@@ -375,13 +380,9 @@ def handle_repair(args: argparse.Namespace) -> int:
             return 1
         if local_ssds:
             # Stopping the VM destroys Local SSD data; force the discard so the
-            # stop succeeds (matches rescue). The interactive Proceed prompt
-            # below is the confirmation; surface the loss before it.
+            # stop succeeds (matches rescue). The data-loss warning is shown in
+            # the confirmation plan blocks below, right before the Proceed prompt.
             config.force = True
-            if not args.quiet:
-                print(f"{warning_prefix()} Data on Local SSDs"
-                      f" ({', '.join(local_ssds)}) will be permanently lost when"
-                      f" the VM is stopped.")
 
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])
@@ -489,7 +490,7 @@ def handle_repair(args: argparse.Namespace) -> int:
     # Custom fix script (--fix-script): skip diagnosis, run the supplied fix
     if config.fix_script:
         return _run_custom_fix_script(args, orchestrator, project,
-                                      config.fix_script)
+                                      config.fix_script, local_ssds=local_ssds)
 
     # Diagnose
     spinner = _Spinner("Analyzing serial console output")
@@ -634,6 +635,10 @@ def handle_repair(args: argparse.Namespace) -> int:
             step += 1
         print(f"    {step}. Restore original boot disk and start VM")
         lines_to_clear += 1
+        if local_ssds:
+            print(f"  {warning_prefix()} Data on Local SSDs"
+                  f" ({', '.join(local_ssds)}) will be permanently lost.")
+            lines_to_clear += 1
         print("")
         lines_to_clear += 1
 

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -361,6 +361,31 @@ def handle_repair(args: argparse.Namespace) -> int:
                 return 1
             orchestrator.config.custom_rescue_image_size_gb = size_gb
 
+        # Local SSD pre-flight (same as rescue): stopping a VM with Local SSDs
+        # permanently destroys their data. In --quiet mode require --force so
+        # automation opts into the loss explicitly, instead of failing mid-stop
+        # with a raw "undefined value for discard-local-ssd" API error.
+        from . import preflight as _preflight
+        local_ssds = _preflight._check_local_ssds(vm)
+        if local_ssds and args.quiet and not getattr(args, 'force', False):
+            print(f"{error_prefix()} VM has Local SSDs attached.", file=sys.stderr)
+            print("", file=sys.stderr)
+            print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("WARNING: Repairing this VM stops it, which will PERMANENTLY"
+                  " LOSE all data on Local SSDs!", file=sys.stderr)
+            print("", file=sys.stderr)
+            print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
+            print(f"  $ gce-rescue repair {args.instance_name} --zone={args.zone}"
+                  f" --quiet --force", file=sys.stderr)
+            return 1
+        if local_ssds:
+            # Proceeding (interactive, or --force in quiet): make the data loss
+            # explicit. The interactive confirmation prompt follows.
+            print(f"{warning_prefix()} Local SSDs attached"
+                  f" ({', '.join(local_ssds)}) — their data will be PERMANENTLY"
+                  f" LOST when the VM is stopped.", file=sys.stderr)
+
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])
         in_rescue = any(item.get('key') == 'rescue-mode' for item in metadata_items)

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -191,53 +191,45 @@ def _run_custom_fix_script(args: argparse.Namespace, orchestrator,
     script_name = Path(args.fix_script).name
 
     if not args.quiet:
-        lines_printed = 0
-        print(f"Repair: {args.instance_name} ({args.zone})")
-        lines_printed += 1
-        print("")
-        lines_printed += 1
-        print(f"  Custom fix script: {args.fix_script} "
-              f"({len(script_lines)} lines)")
-        lines_printed += 1
+        # Build the confirmation block as a list so we can clear exactly as many
+        # lines as we printed, without a manual running tally.
         preview = script_lines[:15]
-        for line in preview:
-            print(f"    | {line}")
-            lines_printed += 1
+        block = [
+            f"Repair: {args.instance_name} ({args.zone})",
+            "",
+            f"  Custom fix script: {args.fix_script} ({len(script_lines)} lines)",
+        ]
+        block += [f"    | {line}" for line in preview]
         if len(script_lines) > len(preview):
-            print(f"    | ... ({len(script_lines) - len(preview)} more lines)")
-            lines_printed += 1
-        print("")
-        lines_printed += 1
-        print("  Repair plan:")
-        lines_printed += 1
+            block.append(
+                f"    | ... ({len(script_lines) - len(preview)} more lines)"
+            )
+        block += ["", "  Repair plan:"]
         step = 1
         if getattr(args, 'snapshot', True):
-            print(f"    {step}. Create backup snapshot of boot disk")
-            lines_printed += 1
+            block.append(f"    {step}. Create backup snapshot of boot disk")
             step += 1
-        print(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
-        lines_printed += 1
+        block.append(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
         step += 1
-        print(f"    {step}. Run the custom fix script against the affected disk")
-        lines_printed += 1
+        block.append(
+            f"    {step}. Run the custom fix script against the affected disk"
+        )
         step += 1
-        print(f"    {step}. Restore original boot disk and start VM")
-        lines_printed += 1
-        print("")
-        lines_printed += 1
-        print("  Diagnosis is skipped: the script runs exactly as provided.")
-        lines_printed += 1
+        block.append(f"    {step}. Restore original boot disk and start VM")
+        block += ["", "  Diagnosis is skipped: the script runs exactly as provided."]
         if local_ssds:
-            print("")
-            print(f"  {warning_prefix()} Data on Local SSDs"
-                  f" ({', '.join(local_ssds)}) will be permanently lost.")
-            lines_printed += 2
-        print("")
-        lines_printed += 1
+            block += [
+                "",
+                f"  {warning_prefix()} Data on Local SSDs"
+                f" ({', '.join(local_ssds)}) will be permanently lost.",
+            ]
+        block.append("")
+
+        for line in block:
+            print(line)
 
         try:
             response = input("  Proceed? [y/N]: ").strip().lower()
-            lines_printed += 1
         except (KeyboardInterrupt, EOFError):
             print("\nAborted.")
             return 0
@@ -245,8 +237,9 @@ def _run_custom_fix_script(args: argparse.Namespace, orchestrator,
             print("\nAborted by user.")
             return 0
 
-        # Clear the confirmation block; the concise header below replaces it.
-        clear_lines(lines_printed)
+        # Clear the confirmation block (+1 for the prompt line); the concise
+        # header below replaces it.
+        clear_lines(len(block) + 1)
 
     # Concise repair header
     print(f"Repairing instance [{args.instance_name}]:")
@@ -584,13 +577,9 @@ def handle_repair(args: argparse.Namespace) -> int:
 
     # Repair path: show compact summary + plan, get confirmation, then clear
     if not args.quiet:
-        lines_to_clear = 0
-
-        # Header
-        print(f"Repair: {args.instance_name} ({args.zone})")
-        lines_to_clear += 1
-        print("")
-        lines_to_clear += 1
+        # Build the confirmation block as a list so we can clear exactly as many
+        # lines as we printed, without a manual running tally.
+        block = [f"Repair: {args.instance_name} ({args.zone})", ""]
 
         # Compact issue summary grouped by category
         category_counts: Dict[str, int] = Counter(
@@ -611,32 +600,21 @@ def handle_repair(args: argparse.Namespace) -> int:
                     sev_parts.append(f"{severity_counts[cat][sev]} {sev}")
             sev_str = ', '.join(sev_parts)
             issue_word = 'issue' if count == 1 else 'issues'
-            print(f"  Found {count} {cat} {issue_word} ({sev_str})")
-            lines_to_clear += 1
+            block.append(f"  Found {count} {cat} {issue_word} ({sev_str})")
 
         # Unfixable warnings
         if unfixable:
             for cat in unfixable:
-                print(
+                block.append(
                     f"  {warning_prefix()} [{cat.upper()}] requires manual repair"
                 )
-                lines_to_clear += 1
 
-        print("  Run 'diagnose' for details.")
-        lines_to_clear += 1
-        print("")
-        lines_to_clear += 1
-
-        # Repair plan
-        print("  Repair plan:")
-        lines_to_clear += 1
+        block += ["  Run 'diagnose' for details.", "", "  Repair plan:"]
         step = 1
         if snapshot_enabled:
-            print(f"    {step}. Create backup snapshot of boot disk")
-            lines_to_clear += 1
+            block.append(f"    {step}. Create backup snapshot of boot disk")
             step += 1
-        print(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
-        lines_to_clear += 1
+        block.append(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
         step += 1
         # Build fix descriptions with extracted identifiers
         if fstab_targets:
@@ -663,23 +641,20 @@ def handle_repair(args: argparse.Namespace) -> int:
             }
         for cat in fixable:
             desc = fix_descriptions.get(cat, f'Fix {cat}')
-            print(f"    {step}. {desc}")
-            lines_to_clear += 1
+            block.append(f"    {step}. {desc}")
             step += 1
-        print(f"    {step}. Restore original boot disk and start VM")
-        lines_to_clear += 1
+        block.append(f"    {step}. Restore original boot disk and start VM")
         if local_ssds:
-            print(f"  {warning_prefix()} Data on Local SSDs"
-                  f" ({', '.join(local_ssds)}) will be permanently lost.")
-            lines_to_clear += 1
-        print("")
-        lines_to_clear += 1
+            block.append(f"  {warning_prefix()} Data on Local SSDs"
+                         f" ({', '.join(local_ssds)}) will be permanently lost.")
+        block.append("")
+
+        for line in block:
+            print(line)
 
         # Confirmation
         try:
-            response = input(
-                "  Proceed? [y/N]: "
-            ).strip().lower()
+            response = input("  Proceed? [y/N]: ").strip().lower()
         except (KeyboardInterrupt, EOFError):
             print("\nAborted.")
             return 0
@@ -688,10 +663,8 @@ def handle_repair(args: argparse.Namespace) -> int:
             print("\nAborted by user.")
             return 0
 
-        lines_to_clear += 1  # input line
-
-        # Clear diagnosis + plan + confirmation
-        clear_lines(lines_to_clear)
+        # Clear diagnosis + plan + confirmation (+1 for the prompt line)
+        clear_lines(len(block) + 1)
 
     # Print concise repair header
     print(f"Repairing instance [{args.instance_name}]:")

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -13,7 +13,9 @@ from ..utils.colors import error_prefix, warning_prefix, clear_lines, green, bol
 from ..utils.logger import setup_logging
 from ..orchestration.checkpoint import CheckpointManager
 from .output import _Spinner, _format_duration
-from .preflight import get_gcloud_config, _create_tracked_client
+from .preflight import (
+    get_gcloud_config, _create_tracked_client, check_local_ssd_quiet_gate,
+)
 from .checkpoint_ui import _handle_checkpoint_rollback
 
 
@@ -361,30 +363,25 @@ def handle_repair(args: argparse.Namespace) -> int:
                 return 1
             orchestrator.config.custom_rescue_image_size_gb = size_gb
 
-        # Local SSD pre-flight (same as rescue): stopping a VM with Local SSDs
-        # permanently destroys their data. In --quiet mode require --force so
-        # automation opts into the loss explicitly, instead of failing mid-stop
-        # with a raw "undefined value for discard-local-ssd" API error.
-        from . import preflight as _preflight
-        local_ssds = _preflight._check_local_ssds(vm)
-        if local_ssds and args.quiet and not getattr(args, 'force', False):
-            print(f"{error_prefix()} VM has Local SSDs attached.", file=sys.stderr)
-            print("", file=sys.stderr)
-            print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
-            print("", file=sys.stderr)
-            print("WARNING: Repairing this VM stops it, which will PERMANENTLY"
-                  " LOSE all data on Local SSDs!", file=sys.stderr)
-            print("", file=sys.stderr)
-            print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
-            print(f"  $ gce-rescue repair {args.instance_name} --zone={args.zone}"
-                  f" --quiet --force", file=sys.stderr)
+        # Local SSD safety gate (shared with rescue). In --quiet mode require
+        # --force; otherwise proceed but make the data loss explicit and ensure
+        # the stop discards Local SSDs (force) so it doesn't fail mid-operation.
+        local_ssds, ssd_err = check_local_ssd_quiet_gate(
+            vm, args.instance_name, args.zone, 'repair',
+            args.quiet, getattr(args, 'force', False),
+        )
+        if ssd_err:
+            print(f"{error_prefix()} {ssd_err}", file=sys.stderr)
             return 1
         if local_ssds:
-            # Proceeding (interactive, or --force in quiet): make the data loss
-            # explicit. The interactive confirmation prompt follows.
-            print(f"{warning_prefix()} Local SSDs attached"
-                  f" ({', '.join(local_ssds)}) — their data will be PERMANENTLY"
-                  f" LOST when the VM is stopped.", file=sys.stderr)
+            # Stopping the VM destroys Local SSD data; force the discard so the
+            # stop succeeds (matches rescue). The interactive Proceed prompt
+            # below is the confirmation; surface the loss before it.
+            config.force = True
+            if not args.quiet:
+                print(f"{warning_prefix()} Data on Local SSDs"
+                      f" ({', '.join(local_ssds)}) will be permanently lost when"
+                      f" the VM is stopped.")
 
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -191,43 +191,62 @@ def _run_custom_fix_script(args: argparse.Namespace, orchestrator,
     script_name = Path(args.fix_script).name
 
     if not args.quiet:
+        lines_printed = 0
         print(f"Repair: {args.instance_name} ({args.zone})")
+        lines_printed += 1
         print("")
+        lines_printed += 1
         print(f"  Custom fix script: {args.fix_script} "
               f"({len(script_lines)} lines)")
+        lines_printed += 1
         preview = script_lines[:15]
         for line in preview:
             print(f"    | {line}")
+            lines_printed += 1
         if len(script_lines) > len(preview):
             print(f"    | ... ({len(script_lines) - len(preview)} more lines)")
+            lines_printed += 1
         print("")
+        lines_printed += 1
         print("  Repair plan:")
+        lines_printed += 1
         step = 1
         if getattr(args, 'snapshot', True):
             print(f"    {step}. Create backup snapshot of boot disk")
+            lines_printed += 1
             step += 1
         print(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
+        lines_printed += 1
         step += 1
         print(f"    {step}. Run the custom fix script against the affected disk")
+        lines_printed += 1
         step += 1
         print(f"    {step}. Restore original boot disk and start VM")
+        lines_printed += 1
         print("")
+        lines_printed += 1
         print("  Diagnosis is skipped: the script runs exactly as provided.")
+        lines_printed += 1
         if local_ssds:
             print("")
             print(f"  {warning_prefix()} Data on Local SSDs"
                   f" ({', '.join(local_ssds)}) will be permanently lost.")
+            lines_printed += 2
         print("")
+        lines_printed += 1
 
         try:
             response = input("  Proceed? [y/N]: ").strip().lower()
+            lines_printed += 1
         except (KeyboardInterrupt, EOFError):
             print("\nAborted.")
             return 0
         if response not in ('y', 'yes'):
             print("\nAborted by user.")
             return 0
-        print("")
+
+        # Clear the confirmation block; the concise header below replaces it.
+        clear_lines(lines_printed)
 
     # Concise repair header
     print(f"Repairing instance [{args.instance_name}]:")

--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -85,22 +85,15 @@ def handle_rescue(args: argparse.Namespace) -> int:
             print(f"{error_prefix()} {error_msg}", file=sys.stderr)
             return 1
 
-        # Check for Local SSDs using validated VM info
-        local_ssds = preflight._check_local_ssds(vm_info)
-        has_local_ssd = len(local_ssds) > 0
-
-        # In quiet mode with Local SSDs, require --force
-        if args.quiet and has_local_ssd and not args.force:
-            print(f"{error_prefix()} VM has Local SSDs attached.", file=sys.stderr)
-            print("", file=sys.stderr)
-            print(f"Local SSDs found: {', '.join(local_ssds)}", file=sys.stderr)
-            print("", file=sys.stderr)
-            print("WARNING: Stopping this VM will PERMANENTLY LOSE all data on"
-                  " Local SSDs!", file=sys.stderr)
-            print("", file=sys.stderr)
-            print("To proceed in quiet mode, use --force flag:", file=sys.stderr)
-            print(f"  $ gce-rescue rescue {args.instance_name} --zone={args.zone}"
-                  f" --quiet --force", file=sys.stderr)
+        # Local SSD safety gate (shared with repair). In --quiet mode, require
+        # --force; the interactive path warns + confirms below.
+        local_ssds, ssd_err = preflight.check_local_ssd_quiet_gate(
+            vm_info, args.instance_name, args.zone, 'rescue',
+            args.quiet, args.force,
+        )
+        has_local_ssd = bool(local_ssds)
+        if ssd_err:
+            print(f"{error_prefix()} {ssd_err}", file=sys.stderr)
             return 1
 
         # Validate --rescue-image BEFORE confirmation (fast-fail on bad URL,

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -1294,3 +1294,56 @@ class TestFixScriptRepairPath:
         assert exit_code == 0
         orch.execute_custom.assert_called_once()
         assert orch._suppress_header is True
+
+
+class TestLocalSsdQuietGate:
+    """Tests for the shared Local SSD quiet-mode gate (issue #134 / Todd review)."""
+
+    def _vm(self, with_ssd=True):
+        disks = [{"boot": True, "deviceName": "sda"}]
+        if with_ssd:
+            disks.append({"type": "SCRATCH", "deviceName": "local-ssd-0"})
+        return {"disks": disks, "status": "RUNNING"}
+
+    def test_no_local_ssd_passes(self):
+        from gce_rescue_v2.cli import preflight
+        ssds, err = preflight.check_local_ssd_quiet_gate(
+            self._vm(with_ssd=False), "vm-1", "us-central1-a", "rescue",
+            quiet=True, force=False,
+        )
+        assert ssds == []
+        assert err is None
+
+    def test_quiet_local_ssd_no_force_blocks(self):
+        from gce_rescue_v2.cli import preflight
+        ssds, err = preflight.check_local_ssd_quiet_gate(
+            self._vm(), "vm-1", "us-central1-a", "repair", quiet=True, force=False,
+        )
+        assert ssds == ["local-ssd-0"]
+        assert err is not None
+        assert "--force" in err
+        assert "repair" in err  # command-specific hint
+
+    def test_quiet_local_ssd_with_force_passes(self):
+        from gce_rescue_v2.cli import preflight
+        ssds, err = preflight.check_local_ssd_quiet_gate(
+            self._vm(), "vm-1", "us-central1-a", "rescue", quiet=True, force=True,
+        )
+        assert ssds == ["local-ssd-0"]
+        assert err is None  # force opts in
+
+    def test_interactive_local_ssd_no_error(self):
+        """Interactive (not quiet) returns the list but no error (caller confirms)."""
+        from gce_rescue_v2.cli import preflight
+        ssds, err = preflight.check_local_ssd_quiet_gate(
+            self._vm(), "vm-1", "us-central1-a", "rescue", quiet=False, force=False,
+        )
+        assert ssds == ["local-ssd-0"]
+        assert err is None
+
+    def test_command_in_hint(self):
+        from gce_rescue_v2.cli import preflight
+        _, err = preflight.check_local_ssd_quiet_gate(
+            self._vm(), "vm-1", "us-central1-a", "rescue", quiet=True, force=False,
+        )
+        assert "gce-rescue rescue vm-1" in err

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -886,6 +886,45 @@ class TestHandleRepair:
         exit_code = cli.handle_repair(args)
         assert exit_code == 1
 
+    # --- Local SSD pre-flight (issue #134) ---
+
+    def test_handle_repair_local_ssd_quiet_requires_force(self, monkeypatch, capsys):
+        """repair --quiet on a Local SSD VM fails fast asking for --force."""
+        self._setup_repair_base(monkeypatch)
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(preflight, "_check_local_ssds", lambda vm: ["local-ssd-0"])
+        Fake = self._make_fake_repair_orch()
+        monkeypatch.setattr(
+            "gce_rescue_v2.orchestration.repair.RepairOrchestrator", Fake
+        )
+
+        args = _parse_args("repair")  # --quiet, no --force
+        exit_code = cli.handle_repair(args)
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "Local SSD" in captured.err
+        assert "--force" in captured.err
+
+    def test_handle_repair_local_ssd_force_proceeds(self, monkeypatch):
+        """repair --quiet --force on a Local SSD VM proceeds past the stop guard."""
+        self._setup_repair_base(monkeypatch)
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(preflight, "_check_local_ssds", lambda vm: ["local-ssd-0"])
+        Fake = self._make_fake_repair_orch(
+            boot_errors=[{"category": "fstab", "severity": "error",
+                          "description": "Bad UUID in /etc/fstab",
+                          "detected_pattern": "UUID=bad-uuid"}],
+            fixable=["fstab"],
+            fstab_targets=["UUID=bad-uuid"],
+        )
+        monkeypatch.setattr(
+            "gce_rescue_v2.orchestration.repair.RepairOrchestrator", Fake
+        )
+
+        args = _parse_args("repair", extra=["--force"])
+        exit_code = cli.handle_repair(args)
+        assert exit_code == 0
+
     # --- --rescue-image pre-flight (issue #102) ---
 
     def test_handle_repair_rescue_image_invalid_blocks_pre_flight(


### PR DESCRIPTION
## What

Adds a Local SSD pre-flight to `repair`, mirroring what `rescue` already does.

## Why

`repair` on a VM with a Local SSD attached failed mid-operation during the rescue phase's stop step, with a raw GCP API error:

```
VM has a Local SSD attached but an undefined value for `discard-local-ssd`.
```

`rescue` guards this up front (`cli/rescue.py:88-104`) — in `--quiet` mode it requires `--force` (accepting the permanent Local SSD data loss) and otherwise fails fast with guidance. `repair` skipped that check, so it proceeded into the destructive flow and died on the stop.

## Changes

- `handle_repair`: detect Local SSDs before the repair flow. In `--quiet` mode, require `--force` and fail fast with a clear "data will be PERMANENTLY LOST" message + the `--force` hint, instead of a raw mid-stop API error.
- Surface the Local SSD data-loss warning when proceeding (interactive, or `--force` in quiet) — repair now shows the warning rescue already did.
- Tests: `--quiet` blocks without `--force`; `--quiet --force` proceeds.

## Testing

`python -m pytest gce_rescue_v2/tests/` -> **506 passed**

Workaround until this lands: pass `--force` with `--quiet`.

Closes #134
