### PR TITLE
feat: pre-flight default rescue image reachability (fail fast under org policy)

### DIFF
--- a/gce_rescue_v2/cli/preflight.py
+++ b/gce_rescue_v2/cli/preflight.py
@@ -111,6 +111,64 @@ def validate_custom_rescue_image(
     return int(image_dict.get('diskSizeGb', 0)), None
 
 
+def validate_default_rescue_image(
+    compute, vm_info, config, session_id, command, mode,
+) -> Optional[str]:
+    """Pre-flight reachability check for the DEFAULT rescue image (issue #122).
+
+    When no --rescue-image is given, the rescue disk is created from a public
+    image (debian-cloud / windows-cloud). If an org policy restricts public
+    images (constraints/compute.trustedImageProjects), the disk creation fails
+    mid-operation, AFTER the VM has been stopped. This catches that up front
+    with an actionable message, before any destructive step.
+
+    Resolves the default image for the VM's OS/arch (same selection the rescue
+    orchestrator uses) and confirms it's accessible.
+
+    Args:
+        compute: Compute API client (will be wrapped for analytics).
+        vm_info: VM resource dict (from _validate_vm_exists).
+        config: RescueConfig (provides default_rescue_image()).
+        session_id, command, mode: analytics tagging.
+
+    Returns:
+        None if the default image is reachable, else an error message string.
+    """
+    from ..utils.os_detection import detect_os_type, detect_architecture
+    from ..orchestration.rescue import RescueOrchestrator
+    from ..core.config import build_user_agent
+    from googleapiclient.errors import HttpError
+
+    os_type = detect_os_type(vm_info)
+    architecture = detect_architecture(vm_info)
+    project, family = config.default_rescue_image(os_type, architecture)
+    image_url = f'projects/{project}/global/images/family/{family}'
+
+    ua = build_user_agent(
+        session_id=session_id, command=command, mode=mode,
+        step='image-preflight-default',
+    )
+    tracked = _create_tracked_client(compute, ua)
+
+    try:
+        RescueOrchestrator.fetch_custom_image(tracked, image_url)
+        return None
+    except HttpError as e:
+        if e.resp.status in (403, 404):
+            return (
+                f"Cannot access the default rescue image ({image_url}).\n"
+                f"      This project may restrict public images"
+                f" (constraints/compute.trustedImageProjects).\n"
+                f"      Specify an approved image with --rescue-image, e.g.:\n"
+                f"        --rescue-image=projects/PROJECT/global/images/family/FAMILY"
+            )
+        # Other errors (transient/5xx/etc.): don't block the operation on a
+        # pre-flight hiccup; the orchestrator will surface real failures.
+        return None
+    except Exception:
+        return None
+
+
 def get_gcloud_config(key: str) -> Optional[str]:
     """
     Read configuration from gcloud config.

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -350,8 +350,8 @@ def handle_repair(args: argparse.Namespace) -> int:
         # Validate --rescue-image BEFORE any destructive ops. Same shared
         # helper used by handle_rescue. Resolved size is mutated onto the
         # orchestrator's config so the inner rescue phase uses it.
+        from . import preflight as _preflight
         if getattr(args, 'rescue_image', None):
-            from . import preflight as _preflight
             size_gb, err = _preflight.validate_custom_rescue_image(
                 compute, vm, args.rescue_image,
                 session_id=session_id, command='repair', mode=mode,
@@ -360,6 +360,16 @@ def handle_repair(args: argparse.Namespace) -> int:
                 print(f"{error_prefix()} {err}", file=sys.stderr)
                 return 1
             orchestrator.config.custom_rescue_image_size_gb = size_gb
+        else:
+            # No custom image: confirm the default public image is reachable
+            # (fail fast under org policy instead of mid-repair). Issue #122.
+            err = _preflight.validate_default_rescue_image(
+                compute, vm, config, session_id=session_id,
+                command='repair', mode=mode,
+            )
+            if err:
+                print(f"{error_prefix()} {err}", file=sys.stderr)
+                return 1
 
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])

--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -49,6 +49,11 @@ def handle_rescue(args: argparse.Namespace) -> int:
         print(f"{error_prefix()} Authentication failed: {e}", file=sys.stderr)
         return 1
 
+    # Build config early so pre-flight checks (e.g. default-image reachability)
+    # can use it. Reads the --fix-script file if given (fail-fast on bad path).
+    from . import args_to_rescue_config
+    config = args_to_rescue_config(args)
+
     # Check for incomplete operation (interactive mode only)
     checkpoint = None
     resuming = False
@@ -116,6 +121,19 @@ def handle_rescue(args: argparse.Namespace) -> int:
                 print(f"{error_prefix()} {err}", file=sys.stderr)
                 return 1
             args.custom_rescue_image_size_gb = size_gb
+            # config was built before this pre-flight, so set the resolved size
+            # on it directly (args_to_rescue_config already ran).
+            config.custom_rescue_image_size_gb = size_gb
+        else:
+            # No custom image: confirm the default public image is reachable
+            # (fail fast under org policy instead of mid-rescue). Issue #122.
+            err = preflight.validate_default_rescue_image(
+                compute, vm_info, config, session_id=session_id,
+                command='rescue', mode=mode,
+            )
+            if err:
+                print(f"{error_prefix()} {err}", file=sys.stderr)
+                return 1
 
     # Interactive confirmation (unless --quiet or resuming)
     if not args.quiet and not resuming:
@@ -163,10 +181,6 @@ def handle_rescue(args: argparse.Namespace) -> int:
             return 0
 
         clear_lines(lines_printed)
-
-    # Convert to config
-    from . import args_to_rescue_config
-    config = args_to_rescue_config(args)
 
     if has_local_ssd:
         config.force = True

--- a/gce_rescue_v2/core/config.py
+++ b/gce_rescue_v2/core/config.py
@@ -168,6 +168,29 @@ class RescueConfig:
             return self.windows_startup_verification_timeout
         return self.startup_verification_timeout
 
+    def default_rescue_image(self, os_type: Optional[str],
+                             architecture: Optional[str]) -> tuple:
+        """Resolve the default rescue image (project, family) for a target VM.
+
+        Single source of truth for default-image selection, shared by the
+        rescue orchestrator (disk creation) and the pre-flight reachability
+        check. Custom images (--rescue-image) bypass this entirely.
+
+        Args:
+            os_type: OS_TYPE_WINDOWS / OS_TYPE_LINUX (or None).
+            architecture: 'arm64' / 'x86_64' (matches os_detection.ARCH_*).
+
+        Returns:
+            (project, family) tuple.
+        """
+        if os_type == OS_TYPE_WINDOWS:
+            return self.windows_rescue_image_project, self.windows_rescue_image_family
+        # 'arm64' mirrors os_detection.ARCH_ARM64 (not imported to avoid a cycle:
+        # os_detection imports from this module).
+        if architecture == 'arm64':
+            return self.arm64_rescue_image_project, self.arm64_rescue_image_family
+        return self.rescue_image_project, self.rescue_image_family
+
 
 @dataclass
 class RestoreConfig:

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -15,7 +15,7 @@ from .compose import (
     compose_startup_script, compose_startup_script_windows, strip_shebang,
 )
 from ..utils.os_detection import (
-    detect_os_type, get_os_display_name, detect_architecture, ARCH_ARM64,
+    detect_os_type, get_os_display_name, detect_architecture,
     get_rescue_disk_type, detect_os_flavor
 )
 from ..validators import (
@@ -705,24 +705,19 @@ class RescueOrchestrator:
                             f"Creating rescue disk ({rescue_disk_size}GB, custom image: {source_image}, "
                             f"image requires {image_required_gb}GB)..."
                         )
-                    elif self.os_type == OS_TYPE_WINDOWS:
-                        rescue_image_project = self.config.windows_rescue_image_project
-                        rescue_image_family = self.config.windows_rescue_image_family
-                        rescue_disk_size = self.config.windows_rescue_disk_size_gb
-                        source_image = f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}'
-                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
-                    elif self.architecture == ARCH_ARM64:
-                        # ARM64 Linux (T2A instances)
-                        rescue_image_project = self.config.arm64_rescue_image_project
-                        rescue_image_family = self.config.arm64_rescue_image_family
-                        rescue_disk_size = self.config.rescue_disk_size_gb
-                        source_image = f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}'
-                        self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
                     else:
-                        # x86_64 Linux (default)
-                        rescue_image_project = self.config.rescue_image_project
-                        rescue_image_family = self.config.rescue_image_family
-                        rescue_disk_size = self.config.rescue_disk_size_gb
+                        # Default image, by OS/arch. Single source of truth shared
+                        # with the pre-flight reachability check (issue #122).
+                        rescue_image_project, rescue_image_family = (
+                            self.config.default_rescue_image(
+                                self.os_type, self.architecture
+                            )
+                        )
+                        rescue_disk_size = (
+                            self.config.windows_rescue_disk_size_gb
+                            if self.os_type == OS_TYPE_WINDOWS
+                            else self.config.rescue_disk_size_gb
+                        )
                         source_image = f'projects/{rescue_image_project}/global/images/family/{rescue_image_family}'
                         self._log_debug(f"Creating rescue disk ({rescue_disk_size}GB, {rescue_image_family})...")
 

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -569,6 +569,20 @@ class TestHandleRescue:
         exit_code = cli.handle_rescue(args)
         assert exit_code == 0
 
+    def test_handle_rescue_blocks_on_inaccessible_default_image(self, monkeypatch, capsys):
+        """Unreachable default image (org policy) blocks before any rescue (issue #122)."""
+        self._setup_rescue(monkeypatch)
+        from gce_rescue_v2.cli import preflight
+        monkeypatch.setattr(
+            preflight, "validate_default_rescue_image",
+            lambda *a, **kw: ("Cannot access the default rescue image ...\n"
+                              "      Specify an approved image with --rescue-image"),
+        )
+        args = _parse_args("rescue")
+        exit_code = cli.handle_rescue(args)
+        assert exit_code == 1
+        assert "--rescue-image" in capsys.readouterr().err
+
     def test_handle_rescue_validation_fails(self, monkeypatch):
         """Validation failure returns 1."""
         self._setup_rescue(monkeypatch, validate=False)
@@ -1255,3 +1269,85 @@ class TestFixScriptRepairPath:
         assert exit_code == 0
         orch.execute_custom.assert_called_once()
         assert orch._suppress_header is True
+
+
+class TestDefaultRescueImage:
+    """Tests for RescueConfig.default_rescue_image (issue #122)."""
+
+    def test_linux_x86(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_LINUX
+        c = RescueConfig()
+        assert c.default_rescue_image(OS_TYPE_LINUX, 'x86_64') == ('debian-cloud', 'debian-12')
+
+    def test_windows(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_WINDOWS
+        c = RescueConfig()
+        assert c.default_rescue_image(OS_TYPE_WINDOWS, 'x86_64') == ('windows-cloud', 'windows-2022')
+
+    def test_arm64(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_LINUX
+        c = RescueConfig()
+        assert c.default_rescue_image(OS_TYPE_LINUX, 'arm64') == ('debian-cloud', 'debian-12-arm64')
+
+    def test_windows_precedes_arm(self):
+        from gce_rescue_v2.core.config import RescueConfig, OS_TYPE_WINDOWS
+        c = RescueConfig()
+        assert c.default_rescue_image(OS_TYPE_WINDOWS, 'arm64') == ('windows-cloud', 'windows-2022')
+
+
+class TestValidateDefaultRescueImage:
+    """Tests for preflight.validate_default_rescue_image (issue #122)."""
+
+    def _vm(self):
+        return {"disks": [{"boot": True, "licenses": ["debian-12"]}], "status": "RUNNING"}
+
+    def test_reachable_returns_none(self, monkeypatch):
+        from gce_rescue_v2.cli import preflight
+        from gce_rescue_v2.core.config import RescueConfig
+        from gce_rescue_v2.orchestration.rescue import RescueOrchestrator
+        monkeypatch.setattr(preflight, "_create_tracked_client", lambda c, ua: Mock())
+        monkeypatch.setattr(RescueOrchestrator, "fetch_custom_image",
+                            lambda c, url: {"diskSizeGb": "10"})
+        err = preflight.validate_default_rescue_image(
+            Mock(), self._vm(), RescueConfig(),
+            session_id="s", command="rescue", mode="auto",
+        )
+        assert err is None
+
+    def test_403_returns_actionable_error(self, monkeypatch):
+        from gce_rescue_v2.cli import preflight
+        from gce_rescue_v2.core.config import RescueConfig
+        from gce_rescue_v2.orchestration.rescue import RescueOrchestrator
+        from googleapiclient.errors import HttpError
+        resp = Mock(status=403)
+
+        def boom(c, url):
+            raise HttpError(resp, b'{"error":{"message":"denied"}}')
+
+        monkeypatch.setattr(preflight, "_create_tracked_client", lambda c, ua: Mock())
+        monkeypatch.setattr(RescueOrchestrator, "fetch_custom_image", boom)
+        err = preflight.validate_default_rescue_image(
+            Mock(), self._vm(), RescueConfig(),
+            session_id="s", command="rescue", mode="auto",
+        )
+        assert err is not None
+        assert "--rescue-image" in err
+
+    def test_transient_error_does_not_block(self, monkeypatch):
+        """A 5xx pre-flight hiccup returns None (don't block on transient errors)."""
+        from gce_rescue_v2.cli import preflight
+        from gce_rescue_v2.core.config import RescueConfig
+        from gce_rescue_v2.orchestration.rescue import RescueOrchestrator
+        from googleapiclient.errors import HttpError
+        resp = Mock(status=503)
+
+        def boom(c, url):
+            raise HttpError(resp, b'{"error":{"message":"unavailable"}}')
+
+        monkeypatch.setattr(preflight, "_create_tracked_client", lambda c, ua: Mock())
+        monkeypatch.setattr(RescueOrchestrator, "fetch_custom_image", boom)
+        err = preflight.validate_default_rescue_image(
+            Mock(), self._vm(), RescueConfig(),
+            session_id="s", command="rescue", mode="auto",
+        )
+        assert err is None


### PR DESCRIPTION
## What

Adds a pre-flight reachability check for the **default** rescue image, so rescue/repair fail fast (before stopping the VM) when an org policy blocks public images.

## Why

Without `--rescue-image`, the rescue disk is created from a public image (`debian-cloud` / `windows-cloud`). Under `constraints/compute.trustedImageProjects`, `disks().insert` is rejected — but only *after* the VM has been stopped and the boot disk detached. The user takes avoidable downtime and sees a raw API error (auto-rollback recovers the VM, but the disruption was pointless). `--rescue-image` already gets a pre-flight check; the default image didn't.

## Changes

- `preflight.validate_default_rescue_image`: resolves the default image for the VM's OS/arch and confirms it's reachable; on 403/404 returns an actionable error ("specify an approved image with `--rescue-image`"). Transient (5xx) errors don't block.
- Wired into `handle_rescue` and `handle_repair` (only when no `--rescue-image`).
- `RescueConfig.default_rescue_image()` — single source of truth for default-image selection; the orchestrator's disk-creation now uses it (collapses the windows/arm64/x86 branches).
- Build the rescue config early so the pre-flight can use it.

## Testing

`python -m pytest gce_rescue_v2/tests/` -> **512 passed** (8 new: config selection, the pre-flight helper incl. 403/transient, and the CLI block path).

Closes #122
