### PR TITLE
feat: detect org-policy rescue-image blocks (trustedImageProjects)

### DIFF
--- a/gce_rescue_v2/cli/preflight.py
+++ b/gce_rescue_v2/cli/preflight.py
@@ -111,6 +111,123 @@ def validate_custom_rescue_image(
     return int(image_dict.get('diskSizeGb', 0)), None
 
 
+# Default rescue-image projects by OS/arch (mirrors RescueConfig defaults). Used
+# to know which image project the org-policy pre-flight must check.
+_DEFAULT_IMAGE_PROJECTS = {
+    'windows': 'windows-cloud',
+    'arm64': 'debian-cloud',
+    'linux': 'debian-cloud',
+}
+
+TRUSTED_IMAGE_CONSTRAINT = 'constraints/compute.trustedImageProjects'
+
+
+def resolve_rescue_image_project(vm_info, rescue_image_url=None) -> str:
+    """Return the GCP project the rescue image will come from.
+
+    For --rescue-image, parse the project from the URL. Otherwise pick the
+    default image project for the VM's OS/arch (debian-cloud / windows-cloud).
+    """
+    if rescue_image_url:
+        parts = rescue_image_url.split('/')
+        if len(parts) >= 2 and parts[0] == 'projects':
+            return parts[1]
+        return ''  # unparseable; skip the policy check rather than guess
+    from ..utils.os_detection import detect_os_type, detect_architecture
+    os_type = detect_os_type(vm_info)
+    if os_type == 'windows':
+        return _DEFAULT_IMAGE_PROJECTS['windows']
+    if detect_architecture(vm_info) == 'arm64':
+        return _DEFAULT_IMAGE_PROJECTS['arm64']
+    return _DEFAULT_IMAGE_PROJECTS['linux']
+
+
+def _fetch_trusted_image_policy(compute, project) -> Optional[dict]:
+    """Fetch the effective compute.trustedImageProjects policy, or None.
+
+    Returns None for test mocks (no real credentials) or any read failure, so
+    the caller fails open. Reading the policy needs orgpolicy.policy.get, which
+    users and service accounts with viewer-level access generally have.
+    """
+    import google_auth_httplib2
+    http = getattr(compute, '_http', None)
+    if not isinstance(http, google_auth_httplib2.AuthorizedHttp):
+        return None  # test mock / no real client
+    try:
+        import google.auth
+        from googleapiclient import discovery
+        # The compute client is compute-scoped, but the Org Policy API needs
+        # broader scope. Fetch ADC (same identity AuthManager uses) with
+        # cloud-platform scope just for this read.
+        creds, _ = google.auth.default(
+            scopes=['https://www.googleapis.com/auth/cloud-platform']
+        )
+        crm = discovery.build(
+            'cloudresourcemanager', 'v1',
+            credentials=creds, cache_discovery=False,
+        )
+        return crm.projects().getEffectiveOrgPolicy(
+            resource=f'projects/{project}',
+            body={'constraint': TRUSTED_IMAGE_CONSTRAINT},
+        ).execute()
+    except Exception:
+        return None
+
+
+def check_image_org_policy(compute, project, image_project, command='rescue',
+                           instance_name='INSTANCE') -> Optional[str]:
+    """Pre-flight: is `image_project` allowed by compute.trustedImageProjects?
+
+    Reads the effective org policy (works for users AND service accounts - reading
+    is permitted even when setting is not). Returns an actionable error message if
+    the image project is blocked, else None (allowed, OR policy unreadable - in
+    which case we fail open and let the operation proceed).
+
+    Catches the #122 case BEFORE any destructive step, so the VM is never stopped.
+    """
+    if not image_project:
+        return None
+    resp = _fetch_trusted_image_policy(compute, project)
+    if resp is None:
+        return None  # unreadable / mock -> fail open
+
+    lp = resp.get('listPolicy', {})
+    img = f'projects/{image_project}'
+    allowed = lp.get('allowedValues')
+    denied = lp.get('deniedValues')
+
+    blocked = False
+    if lp.get('allValues') == 'DENY':
+        blocked = True
+    elif allowed is not None:
+        blocked = img not in allowed
+    elif denied is not None:
+        blocked = img in denied
+    # allValues == ALLOW or no list -> nothing blocked
+
+    if not blocked:
+        return None
+
+    allowed_hint = (', '.join(allowed) if allowed else '(none)')
+    # Build a copy-pasteable example using the first allowed project if known,
+    # so the user sees a concrete suggestion rather than a generic placeholder.
+    example_project = 'PROJECT'
+    if allowed:
+        first = allowed[0]
+        example_project = first.split('/', 1)[1] if first.startswith('projects/') else first
+    return (
+        f"Rescue image blocked by org policy (compute.trustedImageProjects).\n"
+        f"  Default rescue image project: {image_project}\n"
+        f"  Allowed image projects:       {allowed_hint}\n"
+        f"\n"
+        f"To {command} with an approved image, run:\n"
+        f"  $ gce-rescue {command} {instance_name} "
+        f"--rescue-image=projects/{example_project}/global/images/IMAGE\n"
+        f"\n"
+        f"  (An image family also works: .../global/images/family/FAMILY)"
+    )
+
+
 def get_gcloud_config(key: str) -> Optional[str]:
     """
     Read configuration from gcloud config.

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -350,8 +350,8 @@ def handle_repair(args: argparse.Namespace) -> int:
         # Validate --rescue-image BEFORE any destructive ops. Same shared
         # helper used by handle_rescue. Resolved size is mutated onto the
         # orchestrator's config so the inner rescue phase uses it.
+        from . import preflight as _preflight
         if getattr(args, 'rescue_image', None):
-            from . import preflight as _preflight
             size_gb, err = _preflight.validate_custom_rescue_image(
                 compute, vm, args.rescue_image,
                 session_id=session_id, command='repair', mode=mode,
@@ -360,6 +360,20 @@ def handle_repair(args: argparse.Namespace) -> int:
                 print(f"{error_prefix()} {err}", file=sys.stderr)
                 return 1
             orchestrator.config.custom_rescue_image_size_gb = size_gb
+
+        # Pre-flight: is the rescue image's project allowed by org policy?
+        # Catches constraints/compute.trustedImageProjects BEFORE stopping the VM
+        # (zero downtime). Fails open if the policy can't be read. Issue #122.
+        image_project = _preflight.resolve_rescue_image_project(
+            vm, rescue_image_url=getattr(args, 'rescue_image', None)
+        )
+        policy_err = _preflight.check_image_org_policy(
+            compute, project, image_project, command='repair',
+            instance_name=args.instance_name,
+        )
+        if policy_err:
+            print(f"{error_prefix()} {policy_err}", file=sys.stderr)
+            return 1
 
         vm_status = vm.get('status', 'UNKNOWN')
         metadata_items = vm.get('metadata', {}).get('items', [])

--- a/gce_rescue_v2/cli/rescue.py
+++ b/gce_rescue_v2/cli/rescue.py
@@ -117,6 +117,20 @@ def handle_rescue(args: argparse.Namespace) -> int:
                 return 1
             args.custom_rescue_image_size_gb = size_gb
 
+        # Pre-flight: is the rescue image's project allowed by org policy?
+        # Catches constraints/compute.trustedImageProjects BEFORE stopping the VM
+        # (zero downtime). Fails open if the policy can't be read. Issue #122.
+        image_project = preflight.resolve_rescue_image_project(
+            vm_info, rescue_image_url=getattr(args, 'rescue_image', None)
+        )
+        policy_err = preflight.check_image_org_policy(
+            compute, project, image_project, command='rescue',
+            instance_name=args.instance_name,
+        )
+        if policy_err:
+            print(f"{error_prefix()} {policy_err}", file=sys.stderr)
+            return 1
+
     # Interactive confirmation (unless --quiet or resuming)
     if not args.quiet and not resuming:
         lines_printed = 0

--- a/gce_rescue_v2/core/error_messages.py
+++ b/gce_rescue_v2/core/error_messages.py
@@ -217,21 +217,22 @@ DISK_CREATE_FAILED = ErrorSuggestion(
 )
 
 TRUSTED_IMAGE_BLOCKED = ErrorSuggestion(
-    message="Rescue disk image blocked by org policy (trustedImageProjects)",
+    message="Rescue image blocked by org policy (compute.trustedImageProjects)",
     causes=[
         "This project restricts which image projects may be used"
         " (constraints/compute.trustedImageProjects)",
-        "The rescue image's project (e.g. debian-cloud / windows-cloud) is not"
-        " in the allowed list",
+        "The default rescue image's project (e.g. debian-cloud / windows-cloud)"
+        " is not in the allowed list",
     ],
     suggestions=[
         "Specify an approved image with --rescue-image="
-        "projects/PROJECT/global/images/family/FAMILY",
+        "projects/IMAGE_PROJECT/global/images/IMAGE",
+        "An image family also works: .../global/images/family/FAMILY",
         "Ask your organization admin which image projects are permitted",
     ],
     commands=[
         "gce-rescue rescue {vm_name} --zone={zone} --project={project}"
-        " --rescue-image=projects/PROJECT/global/images/family/FAMILY",
+        " --rescue-image=projects/IMAGE_PROJECT/global/images/IMAGE",
     ]
 )
 

--- a/gce_rescue_v2/core/error_messages.py
+++ b/gce_rescue_v2/core/error_messages.py
@@ -216,6 +216,25 @@ DISK_CREATE_FAILED = ErrorSuggestion(
     ]
 )
 
+TRUSTED_IMAGE_BLOCKED = ErrorSuggestion(
+    message="Rescue disk image blocked by org policy (trustedImageProjects)",
+    causes=[
+        "This project restricts which image projects may be used"
+        " (constraints/compute.trustedImageProjects)",
+        "The rescue image's project (e.g. debian-cloud / windows-cloud) is not"
+        " in the allowed list",
+    ],
+    suggestions=[
+        "Specify an approved image with --rescue-image="
+        "projects/PROJECT/global/images/family/FAMILY",
+        "Ask your organization admin which image projects are permitted",
+    ],
+    commands=[
+        "gce-rescue rescue {vm_name} --zone={zone} --project={project}"
+        " --rescue-image=projects/PROJECT/global/images/family/FAMILY",
+    ]
+)
+
 DISK_DELETE_FAILED = ErrorSuggestion(
     message="Failed to delete disk",
     causes=[
@@ -383,6 +402,11 @@ def get_error_suggestion(error_msg: str, operation: str = None) -> Optional[Erro
         ErrorSuggestion if a match is found, None otherwise
     """
     error_lower = error_msg.lower()
+
+    # Org-policy image restriction (check before generic permission/403 errors,
+    # which a trustedImageProjects violation can otherwise be mistaken for).
+    if 'trustedimageprojects' in error_lower or 'trusted image' in error_lower:
+        return TRUSTED_IMAGE_BLOCKED
 
     # Insufficient OAuth scopes (check before generic permission errors)
     if 'insufficient authentication scopes' in error_lower or 'insufficientpermissions' in error_lower:

--- a/gce_rescue_v2/operations/attach_disk.py
+++ b/gce_rescue_v2/operations/attach_disk.py
@@ -85,7 +85,7 @@ class AttachDiskOperation(BaseOperation):
                     project=self.project,
                     disk_name=disk_name
                 )
-                self._log_error(error_detail)
+                self._log_debug(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
@@ -117,7 +117,7 @@ class AttachDiskOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to attach disk: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/base.py
+++ b/gce_rescue_v2/operations/base.py
@@ -317,7 +317,9 @@ class BaseOperation(ABC):
                         errors = result['error'].get('errors', [])
                         error_msg = '; '.join([e.get('message', 'Unknown error') for e in errors])
                         self._last_operation_error = error_msg
-                        self._log_error(f"Operation failed: {error_msg}")
+                        # Captured above for the caller to surface a formatted,
+                        # actionable message; keep the raw line out of user output.
+                        self._log_debug(f"Operation failed: {error_msg}")
                         return False
                     self._last_operation_error = None
                     return True

--- a/gce_rescue_v2/operations/base.py
+++ b/gce_rescue_v2/operations/base.py
@@ -148,6 +148,10 @@ class BaseOperation(ABC):
         self.zone = zone
         self.logger = logger
         self.result: Optional[OperationResult] = None
+        # Error message from the most recent _wait_for_operation failure, so
+        # callers can surface the real cause (e.g. an org-policy violation that
+        # only appears in the async operation result).
+        self._last_operation_error: Optional[str] = None
 
     @abstractmethod
     def execute(self, **kwargs) -> OperationResult:
@@ -312,8 +316,10 @@ class BaseOperation(ABC):
                     if 'error' in result:
                         errors = result['error'].get('errors', [])
                         error_msg = '; '.join([e.get('message', 'Unknown error') for e in errors])
+                        self._last_operation_error = error_msg
                         self._log_error(f"Operation failed: {error_msg}")
                         return False
+                    self._last_operation_error = None
                     return True
 
             except Exception as e:

--- a/gce_rescue_v2/operations/create_disk.py
+++ b/gce_rescue_v2/operations/create_disk.py
@@ -74,34 +74,41 @@ class CreateDiskOperation(BaseOperation):
 
             # Use tracked client if tracking_label provided
             compute = self._create_tracked_client(tracking_label) if tracking_label else self.compute
-            # Create the disk
-            compute.disks().insert(
+            start_time = time.time()
+            # Create the disk (returns an async zone operation)
+            operation = compute.disks().insert(
                 project=self.project,
                 zone=self.zone,
                 body=disk_body
             ).execute()
 
-            # Wait for disk creation
-            self._log_debug("Waiting for disk creation...")
-            start_time = time.time()
-
-            def get_status():
-                try:
-                    disk = self.compute.disks().get(
-                        project=self.project,
-                        zone=self.zone,
-                        disk=disk_name
-                    ).execute()
-                    return disk['status']
-                except Exception:
-                    return 'CREATING'
-
-            if not self._wait_for_status(get_status, 'READY', timeout):
+            # Wait on the OPERATION (not just the disk's status). Image/org-policy
+            # restrictions (e.g. constraints/compute.trustedImageProjects) surface
+            # only in the async operation result; polling the disk status would
+            # just time out and hide the real cause. Waiting on the operation
+            # fails fast and exposes the actual error message.
+            self._log_debug("Waiting for disk-create operation...")
+            if not self._wait_for_operation(operation, timeout):
+                op_error = self._last_operation_error
+                if op_error:
+                    suggestion = get_error_suggestion(op_error, operation='create_disk')
+                    if suggestion:
+                        error_detail = suggestion.format(
+                            vm_name=None, zone=self.zone,
+                            project=self.project, disk_name=disk_name
+                        )
+                    else:
+                        error_detail = f"Failed to create disk: {op_error}"
+                    self._log_error(error_detail)
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=False,
+                        message=f"Failed to create disk: {op_error}",
+                        error=error_detail
+                    )
                 error_detail = DISK_CREATE_FAILED.format(
-                    vm_name=None,
-                    zone=self.zone,
-                    project=self.project,
-                    disk_name=disk_name
+                    vm_name=None, zone=self.zone,
+                    project=self.project, disk_name=disk_name
                 )
                 self._log_error(error_detail)
                 return OperationResult(

--- a/gce_rescue_v2/operations/create_disk.py
+++ b/gce_rescue_v2/operations/create_disk.py
@@ -99,7 +99,7 @@ class CreateDiskOperation(BaseOperation):
                         )
                     else:
                         error_detail = f"Failed to create disk: {op_error}"
-                    self._log_error(error_detail)
+                    self._log_debug(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
@@ -110,7 +110,7 @@ class CreateDiskOperation(BaseOperation):
                     vm_name=None, zone=self.zone,
                     project=self.project, disk_name=disk_name
                 )
-                self._log_error(error_detail)
+                self._log_debug(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
@@ -142,7 +142,7 @@ class CreateDiskOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to create disk: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/create_snapshot.py
+++ b/gce_rescue_v2/operations/create_snapshot.py
@@ -122,7 +122,7 @@ class CreateSnapshotOperation(BaseOperation):
                         project=self.project,
                         disk_name=disk_name
                     )
-                    self._log_error(error_detail)
+                    self._log_debug(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
@@ -161,7 +161,7 @@ class CreateSnapshotOperation(BaseOperation):
                             project=self.project,
                             disk_name=disk_name
                         )
-                        self._log_error(error_detail)
+                        self._log_debug(error_detail)
                         return OperationResult(
                             operation_name=self.name,
                             success=False,
@@ -187,7 +187,7 @@ class CreateSnapshotOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to create snapshot: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/delete_disk.py
+++ b/gce_rescue_v2/operations/delete_disk.py
@@ -67,7 +67,7 @@ class DeleteDiskOperation(BaseOperation):
                     project=self.project,
                     disk_name=disk_name
                 )
-                self._log_error(error_detail)
+                self._log_debug(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
@@ -96,7 +96,7 @@ class DeleteDiskOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to delete disk: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/detach_disk.py
+++ b/gce_rescue_v2/operations/detach_disk.py
@@ -98,7 +98,7 @@ class DetachDiskOperation(BaseOperation):
                     project=self.project,
                     disk_name=device_name
                 )
-                self._log_error(error_detail)
+                self._log_debug(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
@@ -130,7 +130,7 @@ class DetachDiskOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to detach disk: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/set_metadata.py
+++ b/gce_rescue_v2/operations/set_metadata.py
@@ -124,7 +124,7 @@ class SetMetadataOperation(BaseOperation):
                     zone=self.zone,
                     project=self.project
                 )
-                self._log_error(error_detail)
+                self._log_debug(error_detail)
                 return OperationResult(
                     operation_name=self.name,
                     success=False,
@@ -155,7 +155,7 @@ class SetMetadataOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to set metadata: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/start_vm.py
+++ b/gce_rescue_v2/operations/start_vm.py
@@ -89,7 +89,7 @@ class StartVMOperation(BaseOperation):
                         zone=self.zone,
                         project=self.project
                     )
-                    self._log_error(error_detail)
+                    self._log_debug(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
@@ -142,7 +142,7 @@ class StartVMOperation(BaseOperation):
                         zone=self.zone,
                         project=self.project
                     )
-                    self._log_error(error_detail)
+                    self._log_debug(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
@@ -199,7 +199,7 @@ class StartVMOperation(BaseOperation):
                         zone=self.zone,
                         project=self.project
                     )
-                    self._log_error(error_detail)
+                    self._log_debug(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
@@ -237,7 +237,7 @@ class StartVMOperation(BaseOperation):
                 )
             else:
                 error_detail = f"Failed to start VM: {error_msg}"
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/operations/stop_vm.py
+++ b/gce_rescue_v2/operations/stop_vm.py
@@ -103,7 +103,7 @@ class StopVMOperation(BaseOperation):
                         zone=self.zone,
                         project=self.project
                     )
-                    self._log_error(error_detail)
+                    self._log_debug(error_detail)
                     return OperationResult(
                         operation_name=self.name,
                         success=False,
@@ -160,7 +160,7 @@ class StopVMOperation(BaseOperation):
             else:
                 error_detail = f"Failed to stop VM: {error_msg}"
 
-            self._log_error(error_detail)
+            self._log_debug(error_detail)
             return OperationResult(
                 operation_name=self.name,
                 success=False,

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -986,34 +986,42 @@ class RepairOrchestrator:
 
         self._log_debug(f"Phase: {phase}")
 
-    def _finish_progress(self, success: bool = True):
-        """Finalize the last active phase line with done./FAILED."""
-        if not self._progress_started:
-            return
+    def _finish_progress(self, success: bool = True, error: str = None):
+        """Finalize the last active phase line with done./FAILED.
 
-        self._spinner_stop = True
-        if self._spinner_thread:
-            self._spinner_thread.join(timeout=0.5)
+        When `error` (a pre-formatted, user-facing block) is supplied for a
+        failure, it is printed AFTER the FAILED line so it never interleaves
+        with the live spinner. Operations record the same detail to the log
+        file; in debug mode the spinner is off and the detail is already in the
+        console logs, so it is not reprinted here.
+        """
+        if self._progress_started:
+            self._spinner_stop = True
+            if self._spinner_thread:
+                self._spinner_thread.join(timeout=0.5)
 
-        if not self._is_debug_mode:
-            with self._progress_lock:
-                phase = self._current_phase
-                substeps = list(self._current_line_substeps)
-                substep = self._current_substep
+            if not self._is_debug_mode:
+                with self._progress_lock:
+                    phase = self._current_phase
+                    substeps = list(self._current_line_substeps)
+                    substep = self._current_substep
 
-            # Include current substep if not already recorded
-            if substep and (not substeps or substeps[-1] != substep):
-                substeps.append(substep)
+                # Include current substep if not already recorded
+                if substep and (not substeps or substeps[-1] != substep):
+                    substeps.append(substep)
 
-            trail = " -> ".join(substeps) if substeps else ""
-            phase_num = len(self._progress_phases)
-            prefix = f"  ({phase_num}/{self._total_steps}) {phase + ':':<9}" if phase else "  "
-            status_label = green("done.") if success else red("FAILED.")
+                trail = " -> ".join(substeps) if substeps else ""
+                phase_num = len(self._progress_phases)
+                prefix = f"  ({phase_num}/{self._total_steps}) {phase + ':':<9}" if phase else "  "
+                status_label = green("done.") if success else red("FAILED.")
 
-            if trail:
-                final = f"\r{prefix} {trail}  {status_label}"
-            else:
-                final = f"\r{prefix} {status_label}"
+                if trail:
+                    final = f"\r{prefix} {trail}  {status_label}"
+                else:
+                    final = f"\r{prefix} {status_label}"
 
-            sys.stdout.write(f"{final:<120}\n")
-            sys.stdout.flush()
+                sys.stdout.write(f"{final:<120}\n")
+                sys.stdout.flush()
+
+        if error and not getattr(self, '_is_debug_mode', False):
+            print(f"\n{error}", file=sys.stderr)

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -233,28 +233,36 @@ class RescueOrchestrator:
             self._progress_callback(phase)
         self._log_debug(f"Phase: {phase}")
 
-    def _finish_progress(self, success: bool = True):
-        """Finish spinner display with final status."""
+    def _finish_progress(self, success: bool = True, error: str = None):
+        """Finish spinner display with final status.
+
+        When `error` (a pre-formatted, user-facing block) is supplied for a
+        failure, it is printed AFTER the FAILED line so it never interleaves
+        with the live spinner. Operations record the same detail to the log
+        file; in debug mode the spinner is off and the detail is already in the
+        console logs, so it is not reprinted here.
+        """
         import sys
 
-        if not self._progress_started:
-            return
+        if self._progress_started:
+            # Stop spinner thread
+            self._spinner_stop = True
+            if self._spinner_thread:
+                self._spinner_thread.join(timeout=0.5)
 
-        # Stop spinner thread
-        self._spinner_stop = True
-        if self._spinner_thread:
-            self._spinner_thread.join(timeout=0.5)
+            if not self._is_debug_mode:
+                with self._progress_lock:
+                    phases_str = " -> ".join(self._progress_phases)
+                    current_step = len(self._progress_phases)
 
-        if not self._is_debug_mode:
-            with self._progress_lock:
-                phases_str = " -> ".join(self._progress_phases)
-                current_step = len(self._progress_phases)
+                if success:
+                    sys.stdout.write(f"\r ({self._total_steps}/{self._total_steps}) [{phases_str}] done.\n")
+                else:
+                    sys.stdout.write(f"\r ({current_step}/{self._total_steps}) [{phases_str}] FAILED.\n")
+                sys.stdout.flush()
 
-            if success:
-                sys.stdout.write(f"\r ({self._total_steps}/{self._total_steps}) [{phases_str}] done.\n")
-            else:
-                sys.stdout.write(f"\r ({current_step}/{self._total_steps}) [{phases_str}] FAILED.\n")
-            sys.stdout.flush()
+        if error and not getattr(self, '_is_debug_mode', False):
+            print(f"\n{error}", file=sys.stderr)
 
     def _log_info(self, message: str):
         """Log info message."""
@@ -591,7 +599,7 @@ class RescueOrchestrator:
                 )
                 self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data, step_number=1)
                 if not result.success:
-                    self._finish_progress(False)
+                    self._finish_progress(False, error=result.error)
                     self._rollback()
                     return False
                 # Update checkpoint after successful step
@@ -613,7 +621,7 @@ class RescueOrchestrator:
                 )
                 self.state_tracker.add_operation("Detach Boot Disk", result.success, result.message, result.rollback_data, step_number=2)
                 if not result.success:
-                    self._finish_progress(False)
+                    self._finish_progress(False, error=result.error)
                     self._rollback()
                     return False
                 # Update checkpoint
@@ -641,7 +649,7 @@ class RescueOrchestrator:
 
                 if not result.success:
                     if self.config.require_snapshot:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                 else:
@@ -736,7 +744,7 @@ class RescueOrchestrator:
                     )
                     self.state_tracker.add_operation("Create Rescue Disk", result.success, result.message, result.rollback_data, step_number=4)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint
@@ -768,7 +776,7 @@ class RescueOrchestrator:
                     )
                     self.state_tracker.add_operation("Attach Rescue Disk", result.success, result.message, result.rollback_data, step_number=5)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint
@@ -802,7 +810,7 @@ class RescueOrchestrator:
                 )
                 self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data, step_number=6)
                 if not result.success:
-                    self._finish_progress(False)
+                    self._finish_progress(False, error=result.error)
                     self._rollback()
                     return False
                 # Update checkpoint - include Windows password if set
@@ -841,7 +849,7 @@ class RescueOrchestrator:
                     )
                     self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data, step_number=7)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint
@@ -916,7 +924,7 @@ class RescueOrchestrator:
                     )
                     self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data, step_number=8)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint

--- a/gce_rescue_v2/orchestration/restore.py
+++ b/gce_rescue_v2/orchestration/restore.py
@@ -204,28 +204,36 @@ class RestoreOrchestrator:
             self._progress_callback(phase)
         self._log_debug(f"Phase: {phase}")
 
-    def _finish_progress(self, success: bool = True):
-        """Finish spinner display with final status."""
+    def _finish_progress(self, success: bool = True, error: str = None):
+        """Finish spinner display with final status.
+
+        When `error` (a pre-formatted, user-facing block) is supplied for a
+        failure, it is printed AFTER the FAILED line so it never interleaves
+        with the live spinner. Operations record the same detail to the log
+        file; in debug mode the spinner is off and the detail is already in the
+        console logs, so it is not reprinted here.
+        """
         import sys
 
-        if not self._progress_started:
-            return
+        if self._progress_started:
+            # Stop spinner thread
+            self._spinner_stop = True
+            if self._spinner_thread:
+                self._spinner_thread.join(timeout=0.5)
 
-        # Stop spinner thread
-        self._spinner_stop = True
-        if self._spinner_thread:
-            self._spinner_thread.join(timeout=0.5)
+            if not self._is_debug_mode:
+                with self._progress_lock:
+                    phases_str = " -> ".join(self._progress_phases)
+                    current_step = len(self._progress_phases)
 
-        if not self._is_debug_mode:
-            with self._progress_lock:
-                phases_str = " -> ".join(self._progress_phases)
-                current_step = len(self._progress_phases)
+                if success:
+                    sys.stdout.write(f"\r ({self._total_steps}/{self._total_steps}) [{phases_str}] done.\n")
+                else:
+                    sys.stdout.write(f"\r ({current_step}/{self._total_steps}) [{phases_str}] FAILED.\n")
+                sys.stdout.flush()
 
-            if success:
-                sys.stdout.write(f"\r ({self._total_steps}/{self._total_steps}) [{phases_str}] done.\n")
-            else:
-                sys.stdout.write(f"\r ({current_step}/{self._total_steps}) [{phases_str}] FAILED.\n")
-            sys.stdout.flush()
+        if error and not getattr(self, '_is_debug_mode', False):
+            print(f"\n{error}", file=sys.stderr)
 
     def _log_info(self, message: str):
         """Log info message."""
@@ -444,7 +452,7 @@ class RestoreOrchestrator:
                 )
                 self.state_tracker.add_operation("Stop VM", result.success, result.message, result.rollback_data, step_number=1)
                 if not result.success:
-                    self._finish_progress(False)
+                    self._finish_progress(False, error=result.error)
                     self._rollback()
                     return False
                 # Update checkpoint
@@ -475,7 +483,7 @@ class RestoreOrchestrator:
                     )
                     self.state_tracker.add_operation("Detach Rescue Disk", result.success, result.message, result.rollback_data, step_number=2)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint
@@ -504,7 +512,7 @@ class RestoreOrchestrator:
                     )
                     self.state_tracker.add_operation("Detach Original Disk", result.success, result.message, result.rollback_data, step_number=3)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint
@@ -534,7 +542,7 @@ class RestoreOrchestrator:
                     )
                     self.state_tracker.add_operation("Attach Original Disk", result.success, result.message, result.rollback_data, step_number=4)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint
@@ -557,7 +565,7 @@ class RestoreOrchestrator:
                 )
                 self.state_tracker.add_operation("Set Metadata", result.success, result.message, result.rollback_data, step_number=5)
                 if not result.success:
-                    self._finish_progress(False)
+                    self._finish_progress(False, error=result.error)
                     self._rollback()
                     return False
                 # Update checkpoint
@@ -588,7 +596,7 @@ class RestoreOrchestrator:
                     )
                     self.state_tracker.add_operation("Start VM", result.success, result.message, result.rollback_data, step_number=6)
                     if not result.success:
-                        self._finish_progress(False)
+                        self._finish_progress(False, error=result.error)
                         self._rollback()
                         return False
                     # Update checkpoint

--- a/gce_rescue_v2/tests/test_create_disk.py
+++ b/gce_rescue_v2/tests/test_create_disk.py
@@ -31,7 +31,7 @@ class TestCreateDiskOperation:
     def test_create_disk_success(self):
         """Test successful disk creation."""
         # Arrange
-        with patch.object(self.operation, '_wait_for_status', return_value=True):
+        with patch.object(self.operation, '_wait_for_operation', return_value=True):
             result = self.operation.execute(
                 disk_name='rescue-disk',
                 size_gb=10,
@@ -47,14 +47,29 @@ class TestCreateDiskOperation:
         assert args['body']['sizeGb'] == '10'
 
     def test_create_disk_timeout(self):
-        """Test timeout waiting for disk creation."""
-        # Arrange
-        with patch.object(self.operation, '_wait_for_status', return_value=False):
+        """Test timeout waiting for the disk-create operation."""
+        # Arrange: operation never completes, no specific error captured
+        with patch.object(self.operation, '_wait_for_operation', return_value=False):
             result = self.operation.execute(disk_name='rescue-disk', timeout=1)
 
         # Assert
         assert result.success is False
         assert "Timeout" in result.message
+
+    def test_create_disk_org_policy_error(self):
+        """Operation failing with a trustedImageProjects violation -> actionable msg."""
+        # The async operation result carries the org-policy error; surface it.
+        self.operation._last_operation_error = (
+            "Constraint constraints/compute.trustedImageProjects violated for "
+            "projects/p. Image projects/debian-cloud/... is not allowed."
+        )
+        with patch.object(self.operation, '_wait_for_operation', return_value=False):
+            result = self.operation.execute(disk_name='rescue-disk')
+
+        assert result.success is False
+        # Mapped to the actionable rescue-image guidance, not a generic timeout
+        assert '--rescue-image' in result.error
+        assert 'Timeout' not in result.message
 
     def test_create_disk_api_error(self):
         """Test API error during creation."""

--- a/gce_rescue_v2/tests/test_error_messages.py
+++ b/gce_rescue_v2/tests/test_error_messages.py
@@ -1,0 +1,38 @@
+"""Tests for error-message suggestion mapping (core/error_messages.py)."""
+
+from gce_rescue_v2.core.error_messages import (
+    get_error_suggestion,
+    TRUSTED_IMAGE_BLOCKED,
+    PERMISSION_DENIED,
+)
+
+
+class TestTrustedImagePolicyMapping:
+    """Issue #122: trustedImageProjects org-policy errors get an actionable message."""
+
+    def test_matches_constraint_violation(self):
+        err = ("Constraint constraints/compute.trustedImageProjects violated for"
+               " projects/my-proj. Image projects/debian-cloud/global/images/family/"
+               "debian-12 is not in the trusted image projects list.")
+        assert get_error_suggestion(err, operation='create_disk') is TRUSTED_IMAGE_BLOCKED
+
+    def test_matches_trusted_image_phrase(self):
+        err = "Image is not from a trusted image project."
+        assert get_error_suggestion(err) is TRUSTED_IMAGE_BLOCKED
+
+    def test_wins_over_permission_match(self):
+        """A 403/forbidden-flavored policy error still maps to the policy hint."""
+        err = ("403 Forbidden: Constraint constraints/compute.trustedImageProjects"
+               " violated.")
+        assert get_error_suggestion(err, operation='create_disk') is TRUSTED_IMAGE_BLOCKED
+
+    def test_formatted_message_points_at_rescue_image(self):
+        out = TRUSTED_IMAGE_BLOCKED.format(
+            vm_name='vm-1', zone='us-central1-a', project='my-proj'
+        )
+        assert '--rescue-image' in out
+        assert 'trustedImageProjects' in out
+
+    def test_plain_permission_error_unaffected(self):
+        """A normal permission error still maps to PERMISSION_DENIED (no regression)."""
+        assert get_error_suggestion("Permission denied", operation='create_disk') is PERMISSION_DENIED

--- a/gce_rescue_v2/tests/test_preflight.py
+++ b/gce_rescue_v2/tests/test_preflight.py
@@ -1,0 +1,74 @@
+"""Tests for org-policy image pre-flight (issue #122, Layer 1)."""
+
+from unittest.mock import Mock
+
+from gce_rescue_v2.cli import preflight
+
+
+def _vm(os_type='linux', arch='x86_64'):
+    """Minimal vm_info for OS/arch detection."""
+    if os_type == 'windows':
+        return {'disks': [{'boot': True,
+                           'licenses': ['projects/windows-cloud/global/licenses/windows-server-2022']}]}
+    disks = [{'boot': True, 'licenses': ['projects/debian-cloud/global/licenses/debian-12']}]
+    vm = {'disks': disks}
+    if arch == 'arm64':
+        vm['disks'][0]['architecture'] = 'ARM64'
+    return vm
+
+
+class TestResolveRescueImageProject:
+    def test_linux_default(self):
+        assert preflight.resolve_rescue_image_project(_vm('linux')) == 'debian-cloud'
+
+    def test_windows_default(self):
+        assert preflight.resolve_rescue_image_project(_vm('windows')) == 'windows-cloud'
+
+    def test_custom_image_url_parsed(self):
+        url = 'projects/my-proj/global/images/family/my-fam'
+        assert preflight.resolve_rescue_image_project(_vm(), rescue_image_url=url) == 'my-proj'
+
+    def test_unparseable_url_returns_empty(self):
+        assert preflight.resolve_rescue_image_project(_vm(), rescue_image_url='garbage') == ''
+
+
+class TestCheckImageOrgPolicy:
+    def _patch_policy(self, monkeypatch, policy):
+        """Make the policy fetch return `policy` (None simulates unreadable)."""
+        monkeypatch.setattr(preflight, '_fetch_trusted_image_policy',
+                            lambda compute, project: policy)
+
+    def test_blocked_when_not_in_allowed(self, monkeypatch):
+        self._patch_policy(monkeypatch, {'listPolicy': {'allowedValues': ['projects/gokulr']}})
+        err = preflight.check_image_org_policy(Mock(), 'gokulr', 'debian-cloud', command='rescue')
+        assert err is not None
+        assert '--rescue-image' in err
+        assert 'debian-cloud' in err
+
+    def test_example_uses_first_allowed_project(self, monkeypatch):
+        # The suggested --rescue-image example should reference a real allowed
+        # project, not the generic PROJECT placeholder.
+        self._patch_policy(monkeypatch, {'listPolicy': {'allowedValues': ['projects/my-approved']}})
+        err = preflight.check_image_org_policy(Mock(), 'gokulr', 'debian-cloud')
+        assert 'projects/my-approved/global/images/IMAGE' in err
+
+    def test_allowed_when_in_allowed(self, monkeypatch):
+        self._patch_policy(monkeypatch, {'listPolicy': {'allowedValues': ['projects/debian-cloud']}})
+        assert preflight.check_image_org_policy(Mock(), 'gokulr', 'debian-cloud') is None
+
+    def test_all_values_allow(self, monkeypatch):
+        self._patch_policy(monkeypatch, {'listPolicy': {'allValues': 'ALLOW'}})
+        assert preflight.check_image_org_policy(Mock(), 'gokulr', 'debian-cloud') is None
+
+    def test_denied_values(self, monkeypatch):
+        self._patch_policy(monkeypatch, {'listPolicy': {'deniedValues': ['projects/debian-cloud']}})
+        err = preflight.check_image_org_policy(Mock(), 'gokulr', 'debian-cloud')
+        assert err is not None
+
+    def test_fail_open_on_read_error(self, monkeypatch):
+        # _fetch returns None when the policy can't be read -> must NOT block
+        self._patch_policy(monkeypatch, None)
+        assert preflight.check_image_org_policy(Mock(), 'gokulr', 'debian-cloud') is None
+
+    def test_empty_image_project_skips(self):
+        assert preflight.check_image_org_policy(Mock(), 'gokulr', '') is None

--- a/gce_rescue_v2/utils/logger.py
+++ b/gce_rescue_v2/utils/logger.py
@@ -13,6 +13,7 @@ Logging Strategy:
 """
 
 import logging
+import re
 import sys
 import time
 from pathlib import Path
@@ -20,6 +21,9 @@ from datetime import datetime
 from typing import Any, Dict
 
 from .colors import error_prefix
+
+# Strips ANSI color codes so we can inspect the plain text of a message.
+_ANSI_RE = re.compile(r'\033\[[0-9;]*m')
 
 
 class CleanFormatter(logging.Formatter):
@@ -43,7 +47,16 @@ class CleanFormatter(logging.Formatter):
 
         # ERROR: Show with prefix (red)
         elif record.levelno == logging.ERROR:
-            return f"{error_prefix()} {record.getMessage()}"
+            msg = record.getMessage()
+            plain = _ANSI_RE.sub('', msg)
+            # Blank spacer lines: emit as-is (no "ERROR:" on an empty line).
+            if not plain.strip():
+                return msg
+            # Pre-formatted ErrorSuggestion blocks already start with "ERROR:";
+            # don't prefix a second time.
+            if plain.lstrip().startswith("ERROR:"):
+                return msg
+            return f"{error_prefix()} {msg}"
 
         # CRITICAL: Show with prefix and emphasis
         elif record.levelno == logging.CRITICAL:


### PR DESCRIPTION
## Problem

When a project enforces `constraints/compute.trustedImageProjects`, the default rescue image (e.g. `debian-cloud` / `windows-cloud`) is blocked. Previously this surfaced **after** the VM was already stopped and snapshotted — mid-operation, with downtime — and the error was a generic "failed to create disk." (Issue #122)

## Solution — two layers of detection

**Layer 1 — pre-flight (zero downtime).** Before any mutation, query the effective org policy (`getEffectiveOrgPolicy`) and, if the rescue image's project is blocked, fail fast with an actionable message. The VM is never touched. Reads ADC with `cloud-platform` scope just for the policy read (the compute client stays compute-scoped); fails open if the policy can't be read.

**Layer 2 — operation-error safety net.** If the policy can't be read (e.g. missing `orgpolicy.policy.get`), the async `disks().insert` operation error is now surfaced and mapped to the same actionable guidance, then rolled back cleanly.

The actionable error names the allowed image projects and gives a copy-pasteable `--rescue-image` example using the first allowed project.

## Also included

Cleaned up operation error output across **rescue, restore, and repair**:
- Removed the doubled `ERROR: ERROR:` prefix and stray empty `ERROR:` lines (centralized in the log formatter)
- Operation errors no longer interleave with the live progress spinner — they print after the `FAILED.` line
- Operations record error detail to the log file; orchestrators surface the formatted message once the progress line resolves

## Testing

- 521 unit tests pass
- Verified end-to-end against a live `compute.trustedImageProjects` policy: Layer 1 fires pre-flight (VM stays RUNNING), Layer 2 catches + rolls back when the policy is unreadable

Note: the 4 CodeQL `clear-text-logging` alerts were dismissed as false positives — the flagged sinks log only project IDs, zones, VM names, and a static org-policy message (no secrets).