### PR TITLE
feat: deterministic rescue completion via guest attribute (serial fallback)

### DIFF
--- a/gce_rescue_v2/operations/verify_startup.py
+++ b/gce_rescue_v2/operations/verify_startup.py
@@ -61,7 +61,23 @@ class VerifyStartupOperation(BaseOperation):
                         error=f"Startup script did not complete within {timeout}s"
                     )
 
-                # Poll serial console
+                # Reliable completion signal: a guest attribute set by the
+                # startup script. Checked before serial because the serial
+                # console can drop the script's final output burst before the
+                # process exits (the marker may never reach serial).
+                if self._completion_guest_attribute_set(compute, vm_name):
+                    duration = time.time() - start_time
+                    self._log_debug(
+                        f"Completion guest attribute set in {duration:.1f}s"
+                    )
+                    return OperationResult(
+                        operation_name=self.name,
+                        success=True,
+                        message=f"Startup script completed ({duration:.0f}s)",
+                        rollback_data=None
+                    )
+
+                # Poll serial console (fallback)
                 try:
                     result = compute.instances().getSerialPortOutput(
                         project=self.project,
@@ -114,6 +130,28 @@ class VerifyStartupOperation(BaseOperation):
                 message=f"Verification failed: {error_msg}",
                 error=error_msg
             )
+
+    def _completion_guest_attribute_set(self, compute, vm_name: str) -> bool:
+        """Check whether the guest set gce-rescue/status=COMPLETE.
+
+        Reliable, deterministic completion signal (unlike serial scraping).
+        Returns False on any error (attribute not set yet, guest attributes
+        disabled, 404) so the caller keeps polling / falls back to serial.
+        """
+        try:
+            resp = compute.instances().getGuestAttributes(
+                project=self.project, zone=self.zone, instance=vm_name,
+                queryPath='gce-rescue/status'
+            ).execute()
+            # Querying a specific key returns variableValue; a path returns items.
+            if str(resp.get('variableValue', '')).strip().upper() == 'COMPLETE':
+                return True
+            for item in resp.get('queryValue', {}).get('items', []):
+                if str(item.get('value', '')).strip().upper() == 'COMPLETE':
+                    return True
+        except Exception:
+            return False
+        return False
 
     def rollback(self, rollback_data: dict) -> bool:
         """

--- a/gce_rescue_v2/orchestration/compose.py
+++ b/gce_rescue_v2/orchestration/compose.py
@@ -42,10 +42,16 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
     Returns:
         The combined startup script.
     """
-    # Remove the completion marker line (re-added at the very end)
+    # Move the completion signal (serial marker + guest attribute) to the very
+    # end so verification only proceeds after all fixes finish. The base script
+    # calls signal_complete; relocate that call (the echo lives inside the
+    # function definition, which must stay intact).
+    # Match the bare call ("signal_complete\n") which only appears at the call
+    # site; the definition line is "signal_complete() {" so it is not matched.
     combined = base_script.replace(
-        f'echo "{RESCUE_COMPLETE_MARKER}" >&2',
-        f'# GCE-RESCUE-COMPLETE marker moved to end (repair mode)'
+        'signal_complete\n',
+        '# completion signal moved to end (repair mode)\n',
+        1,
     )
 
     combined += '\n'
@@ -66,7 +72,7 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
         combined += fix_script + '\n\n'
 
     combined += 'log "=== Repair fixes completed ==="\n'
-    combined += f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
+    combined += 'signal_complete\n'
     combined += 'log "=== Startup script completed successfully ==="\n'
 
     return combined

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -801,7 +801,12 @@ class RescueOrchestrator:
                     {'key': script_key, 'value': startup_script},
                     {'key': 'rescue-mode', 'value': str(int(time.time()))},
                     {'key': 'rescue-original-disk', 'value': self.original_disk_name},
-                    {'key': 'rescue-os-type', 'value': self.os_type}
+                    {'key': 'rescue-os-type', 'value': self.os_type},
+                    # Let the guest write a guest attribute on completion, which
+                    # the orchestrator polls as a reliable alternative to the
+                    # serial-console marker (serial can drop the script's final
+                    # output burst before the process exits).
+                    {'key': 'enable-guest-attributes', 'value': 'TRUE'},
                 ]
                 result = set_metadata.execute(
                     vm_name=self.vm_name,

--- a/gce_rescue_v2/startup_scripts/rescue_mount.sh
+++ b/gce_rescue_v2/startup_scripts/rescue_mount.sh
@@ -15,6 +15,16 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOGFILE"
 }
 
+# Signal rescue completion. Emits the serial marker (best-effort; serial can
+# drop the final output burst) AND sets a guest attribute the orchestrator
+# polls as the reliable, deterministic completion signal.
+signal_complete() {
+    echo "GCE-RESCUE-COMPLETE" >&2
+    curl -s -m 10 -X PUT --data "COMPLETE" -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/gce-rescue/status" \
+        >/dev/null 2>&1 || true
+}
+
 log "=== GCE Rescue Auto-Mount Started ==="
 
 # Change hostname to indicate rescue mode
@@ -131,8 +141,8 @@ if [ -n "$disk_p" ]; then
     log "=== GCE Rescue Auto-Mount Complete ==="
     echo "SUCCESS" > "$STATUS_FILE"
 
-    # Output completion marker to serial console (for orchestrator verification)
-    echo "GCE-RESCUE-COMPLETE" >&2
+    # Signal completion (serial marker + guest attribute)
+    signal_complete
     log "=== Startup script completed successfully ==="
 
 else

--- a/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
+++ b/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
@@ -179,6 +179,17 @@ foreach ($drive in $mountedDrives) {
 # This must happen before any operations that might fail (like desktop file creation)
 Write-Log ""
 Write-Log "GCE-RESCUE-COMPLETE"
+# Reliable completion signal: set a guest attribute the orchestrator polls.
+# The serial console can drop the script's final output burst before the
+# process exits, so the marker above is best-effort; this is deterministic.
+try {
+    Invoke-RestMethod -Method PUT -Headers @{'Metadata-Flavor' = 'Google'} `
+        -Uri 'http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/gce-rescue/status' `
+        -Body 'COMPLETE' -TimeoutSec 10 -ErrorAction SilentlyContinue | Out-Null
+    Write-Log "Set guest attribute gce-rescue/status=COMPLETE"
+} catch {
+    Write-Log "WARNING: could not set completion guest attribute: $_"
+}
 Write-Log "=== Startup script completed successfully ==="
 
 Write-Log ""

--- a/gce_rescue_v2/tests/test_compose.py
+++ b/gce_rescue_v2/tests/test_compose.py
@@ -8,11 +8,13 @@ from gce_rescue_v2.orchestration.compose import (
 )
 
 
-# Minimal stand-in for rescue_mount.sh: mount logic + completion marker
+# Minimal stand-in for rescue_mount.sh: mount logic + completion call.
+# The real script calls signal_complete (emits the serial marker AND sets the
+# completion guest attribute); compose relocates that call after the fixes.
 BASE_SCRIPT = (
     'log "mounting disk"\n'
     'mount /dev/sdb1 /mnt/sysroot\n'
-    f'echo "{RESCUE_COMPLETE_MARKER}" >&2\n'
+    'signal_complete\n'
     'log "startup done"\n'
 )
 
@@ -42,19 +44,19 @@ class TestComposeStartupScript:
     """compose_startup_script combines mount + fix with marker relocation."""
 
     def test_marker_relocated_after_fix(self):
-        """The active completion marker must come AFTER the fix body."""
+        """The active completion signal must come AFTER the fix body."""
         fix = 'sed -i "s/bad/good/" /mnt/sysroot/etc/fstab'
         script = compose_startup_script(BASE_SCRIPT, [fix], repair_targets=None)
-        marker_pos = script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"')
-        assert marker_pos > script.index(fix), \
-            "completion marker must fire only after the fix has run"
+        signal_pos = script.rindex('signal_complete')
+        assert signal_pos > script.index(fix), \
+            "completion signal must fire only after the fix has run"
 
     def test_original_marker_commented(self):
-        """The base script's marker line is replaced with a comment."""
+        """The base script's completion call is replaced with a comment."""
         script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=None)
-        assert 'marker moved to end' in script
-        # Exactly one ACTIVE echo of the marker remains (the relocated one)
-        assert script.count(f'echo "{RESCUE_COMPLETE_MARKER}"') == 1
+        assert 'moved to end' in script
+        # Exactly one ACTIVE completion call remains (the relocated one)
+        assert script.count('signal_complete') == 1
 
     def test_mount_logic_preserved(self):
         """Base mount logic is kept intact ahead of the fix."""
@@ -86,9 +88,8 @@ class TestComposeStartupScript:
             BASE_SCRIPT, ['first fix', 'second fix'], repair_targets=[]
         )
         assert script.index('first fix') < script.index('second fix')
-        # Marker still after the LAST fix
-        assert script.rindex(f'echo "{RESCUE_COMPLETE_MARKER}"') > \
-            script.index('second fix')
+        # Completion signal still after the LAST fix
+        assert script.rindex('signal_complete') > script.index('second fix')
 
 
 # Minimal stand-in for rescue_mount_windows.ps1: mount + marker + trailing

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -347,31 +347,30 @@ class TestRepairScript:
         assert 'fstab' in script.lower()
 
     def test_completion_marker_at_end(self):
-        """GCE-RESCUE-COMPLETE should be at the end, not in the middle."""
+        """The signal_complete call (serial marker + guest attr) should be at the end."""
         orch = self._make_orchestrator()
         diagnosis = {
             'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
         }
         script = orch._generate_repair_script(diagnosis)
 
-        # Find all occurrences of the marker
+        # The bare 'signal_complete' call (not the 'signal_complete() {' definition)
         lines = script.split('\n')
-        marker_lines = [
-            i for i, line in enumerate(lines)
-            if RESCUE_COMPLETE_MARKER in line and 'moved to end' not in line
+        call_lines = [
+            i for i, line in enumerate(lines) if line.strip() == 'signal_complete'
         ]
-        assert len(marker_lines) >= 1
-        # The active marker should be near the end (last 5 lines)
-        assert marker_lines[-1] > len(lines) - 6
+        assert len(call_lines) >= 1
+        # The active completion call should be near the end (last 5 lines)
+        assert call_lines[-1] > len(lines) - 6
 
     def test_original_marker_commented_out(self):
-        """Original completion marker in rescue_mount.sh should be commented."""
+        """Original completion call in rescue_mount.sh should be relocated/commented."""
         orch = self._make_orchestrator()
         diagnosis = {
             'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
         }
         script = orch._generate_repair_script(diagnosis)
-        assert 'marker moved to end' in script
+        assert 'moved to end' in script
 
     def test_missing_fix_script_raises_error(self):
         """Fix script for category without a .sh file should raise, not silently skip."""

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -673,12 +673,13 @@ class TestFixScriptComposition:
         return orch
 
     def test_linux_fix_script_composed(self):
-        """Linux + fix script: fix body embedded, marker relocated after it."""
+        """Linux + fix script: fix body embedded, completion signal after it."""
         fix = 'touch /mnt/sysroot/etc/fixed'
         orch = self._make_orchestrator(fix_script=fix)
         script = orch._generate_startup_script()
         assert fix in script
-        assert script.rindex('echo "GCE-RESCUE-COMPLETE"') > script.index(fix)
+        # signal_complete (serial marker + guest attribute) relocated after fix
+        assert script.rindex('signal_complete') > script.index(fix)
         assert 'REPAIR_TARGETS' not in script
 
     def test_disk_placeholder_resolved_before_composition(self):

--- a/gce_rescue_v2/tests/test_verify_startup.py
+++ b/gce_rescue_v2/tests/test_verify_startup.py
@@ -149,6 +149,46 @@ class TestVerifyStartupOperation:
             # Verify tracked client was used (called at least once)
             assert mock_tracked_client.instances().getSerialPortOutput.call_count >= 1
 
+    def test_guest_attr_complete_variable_value(self):
+        """Guest attribute variableValue=COMPLETE is detected."""
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'variableValue': 'COMPLETE'
+        }
+        assert self.operation._completion_guest_attribute_set(self.mock_compute, 'vm') is True
+
+    def test_guest_attr_complete_items(self):
+        """Guest attribute via queryValue.items is detected."""
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'queryValue': {'items': [
+                {'namespace': 'gce-rescue', 'key': 'status', 'value': 'COMPLETE'}
+            ]}
+        }
+        assert self.operation._completion_guest_attribute_set(self.mock_compute, 'vm') is True
+
+    def test_guest_attr_not_complete(self):
+        """A non-COMPLETE value is not treated as done."""
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'variableValue': 'RUNNING'
+        }
+        assert self.operation._completion_guest_attribute_set(self.mock_compute, 'vm') is False
+
+    def test_guest_attr_error_returns_false(self):
+        """A 404/disabled error (attribute not set) returns False, not a crash."""
+        self.mock_compute.instances().getGuestAttributes().execute.side_effect = Exception("404")
+        assert self.operation._completion_guest_attribute_set(self.mock_compute, 'vm') is False
+
+    def test_execute_succeeds_via_guest_attr_without_serial_marker(self):
+        """Completion via guest attribute succeeds even if serial lacks the marker."""
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'booting... no marker here'
+        }
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'variableValue': 'COMPLETE'
+        }
+        result = self.operation.execute(vm_name='test-vm', timeout=10)
+        assert result.success is True
+        assert "completed" in result.message.lower()
+
     def test_rollback_returns_true(self):
         """Test rollback always returns True (no-op for verification)."""
         # Act


### PR DESCRIPTION
## Problem (b/527991659)

Windows rescue verify timeouts were traced to the **serial console dropping the startup script's final output burst** before the process exits: the `GCE-RESCUE-COMPLETE` marker is written to the guest log but never reaches serial, so serial-only verification falsely times out even though the rescue actually succeeded.

## Fix — a deterministic completion signal

The startup script sets a **guest attribute** (`gce-rescue/status=COMPLETE`) via the metadata server; the orchestrator polls `getGuestAttributes` and treats that as completion. The serial marker is kept as a **fallback**.

- `rescue`: set `enable-guest-attributes=TRUE` in rescue metadata
- Windows mount script: PUT the guest attribute after the marker
- Linux mount script: `signal_complete()` emits the marker **and** PUTs the attribute; compose relocates the `signal_complete` call to after fixes
- `verify_startup`: poll the guest attribute (reliable) **before** serial (fallback)
- Tests updated for the new completion contract + guest-attribute coverage

## Testing
- 526 unit tests pass
- Linux rescue validated end-to-end on a live VM
- **Windows E2E to be validated on `develop`** (the point of landing this for testing)

Resolves the verify-timeout root cause behind the Windows P1. Targets `develop` so it can be tested on the dev branch before release.