### PR TITLE
feat: expand diagnose coverage to 21 boot-failure categories

### DIFF
--- a/gce_rescue_v2/core/diagnose_rules/cloud_init.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/cloud_init.yaml
@@ -1,0 +1,57 @@
+# cloud-init failure patterns (Stage 8 - late boot, mode 45).
+#
+# Like startup_script, these fire on a VM that reached multi-user.target
+# but whose provisioning failed - Ubuntu GCE images lean heavily on
+# cloud-init, so a broken user-data/config is a booted-but-unprovisioned
+# VM. Severity error (not warning): unlike a custom startup script,
+# cloud-init failures break SSH keys, users, and network config that the
+# platform itself relies on.
+category: cloud_init
+fix_guidance: "Check the full trace in /mnt/sysroot/var/log/cloud-init.log from rescue mode (or /var/log/cloud-init.log over SSH if the VM is reachable) and fix the user-data or /etc/cloud config it names"
+auto_repair: false
+# detect_only: the usual culprit is user-data (VM metadata) or distro
+# cloud config - not simple on-disk boot configuration a fix script could
+# safely edit. Follows the master-plan flag proposal for cloud_init.
+detect_only: true
+# The boot-success marker appears regardless of cloud-init's outcome
+# (multi-user.target is reached; cloud-final just fails alongside it), so
+# findings must survive boot-success suppression to ever be visible.
+survives_boot_success: true
+
+patterns:
+  - name: cloud_init_stage_failure
+    severity: error
+    description: "cloud-init failed while running a boot stage or module"
+    regex:
+      # All alternatives are bound to the cloud-init[PID]: journald prefix
+      # so a generic Python 'Traceback' from any other service can never
+      # match. Covers: module crashes (Traceback), the util.py 'Failed to
+      # run module ...' / 'failed to run' warnings, and the datasource
+      # failure 'Can not apply stage config'.
+      - 'cloud-init\[\d+\]:.*(?:Traceback|failed to run|Can not apply stage)'
+    fixes:
+      - "The failing module/stage is named on the matched line; the full trace is in /var/log/cloud-init.log on the disk"
+      - "Validate the instance's user-data before the next boot: sudo cloud-init schema --system (on the VM) or fix the metadata user-data key"
+      - "Re-run after fixing: sudo cloud-init clean --logs && sudo reboot"
+
+  # JUSTIFICATION vs the no-generic-'Failed to start' rule (see
+  # systemd_early.yaml): this regex is NOT generic - it is bound to the
+  # Cloud-init unit vocabulary. Every cloud-init unit's name or systemd
+  # description contains one of these tokens (cloud-init.service /
+  # cloud-init-local.service description 'Initial cloud-init job ...' or
+  # 'Cloud-init: ...' on newer images; cloud-config.service /
+  # cloud-final.service carry the cloud-config/cloud-final unit names),
+  # while no non-cloud-init unit does, so it cannot fire on the benign
+  # unit failures (apt-daily, fwupd, ...) that rule exists to exclude.
+  - name: cloud_init_unit_failed
+    severity: error
+    description: "A cloud-init boot unit failed to start"
+    regex:
+      - 'Failed to start .*cloud[- ]?init'
+      # cloud-config.service / cloud-final.service descriptions do not
+      # contain the string 'cloud-init' ('Apply the settings specified
+      # in cloud-config', 'Execute cloud user/final scripts').
+      - 'Failed to start .*cloud-(?:config|final)'
+    fixes:
+      - "Check why the unit failed: journalctl -u cloud-init.service on the disk (via rescue-mode chroot) or the cloud-init lines in this serial log"
+      - "Common causes: broken user-data (validate with sudo cloud-init schema --system), an unreachable datasource, or a broken Python environment on the disk"

--- a/gce_rescue_v2/core/diagnose_rules/cpu_lockup.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/cpu_lockup.yaml
@@ -15,6 +15,9 @@
 category: cpu_lockup
 fix_guidance: "Identify the offending process/workload from the serial log, then reset the VM; if lockups repeat, stop and start the VM to move it to a different host"
 auto_repair: false
+# detect_only: rescue mode does not help (nothing to edit on the rescued
+# disk), so the report must not steer users into a rescue/restore cycle.
+detect_only: true
 
 patterns:
   - name: cpu_lockup_soft_lockup
@@ -30,7 +33,12 @@ patterns:
     severity: critical
     description: "Hard CPU lockup detected by the NMI watchdog"
     regex:
-      - 'NMI watchdog: Watchdog detected hard LOCKUP'
+      # Prefix-agnostic: pre-6.5 kernels log "NMI watchdog: Watchdog detected
+      # hard LOCKUP"; 6.5+ (Ubuntu 24.04 = 6.8) moved the hardlockup path to
+      # kernel/watchdog.c which logs "watchdog: Watchdog detected hard LOCKUP".
+      # GCE guests have no PMU, so the buddy detector (6.5+ prefix) is the
+      # realistic reporter on modern images.
+      - 'Watchdog detected hard LOCKUP'
     fixes:
       - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
       - "If hard lockups repeat, stop and start the VM to move it to a different host"
@@ -51,8 +59,11 @@ patterns:
     severity: error
     description: "RCU stall detected (CPU unresponsive to the kernel RCU subsystem)"
     regex:
-      - 'rcu: INFO: rcu_sched detected stalls'
-      - 'rcu_sched self-detected stall on CPU'
+      # Covers all RCU flavors (rcu_sched, rcu_preempt — the Ubuntu 22.04/24.04
+      # default, rcu_bh), self-detected and expedited variants, with or without
+      # the "rcu: " prefix added in kernel 4.19. Does not match healthy boot
+      # banners like "rcu: Hierarchical RCU implementation."
+      - 'INFO: rcu_\w+ (?:self-)?detected (?:expedited )?stalls? on CPU'
     fixes:
       - "Check for runaway or real-time processes monopolizing the CPU"
       - "If the VM is unresponsive, reset it: gcloud compute instances reset VM_NAME --zone=ZONE"

--- a/gce_rescue_v2/core/diagnose_rules/cpu_lockup.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/cpu_lockup.yaml
@@ -1,0 +1,58 @@
+# CPU lockup and stall patterns (soft/hard lockups, bus locks, RCU stalls).
+#
+# Sources:
+#   - https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-cpu-soft-lockup
+#   - https://cloud.google.com/compute/docs/troubleshooting/troubleshoot-cpu-bus-locks
+#
+# Detect-only category: lockups are workload/host conditions, not on-disk boot
+# configuration, so there is nothing for the repair command to edit on the
+# rescued disk. auto_repair stays false.
+#
+# Scope note: unexpected reboots caused by host maintenance events
+# (hostError / guestTerminate) are recorded in Cloud operation logs, NOT in
+# the serial console output, so they cannot be detected by this serial-based
+# engine. Covering them needs an API extension (future work).
+category: cpu_lockup
+fix_guidance: "Identify the offending process/workload from the serial log, then reset the VM; if lockups repeat, stop and start the VM to move it to a different host"
+auto_repair: false
+
+patterns:
+  - name: cpu_lockup_soft_lockup
+    severity: error
+    description: "CPU soft lockup detected by the kernel watchdog (CPU stuck in kernel mode)"
+    regex:
+      - 'BUG: soft lockup - CPU#\d+ stuck for \d+s'
+    fixes:
+      - "Identify the process named in the lockup message and reduce its CPU load"
+      - "If the VM is unresponsive, reset it: gcloud compute instances reset VM_NAME --zone=ZONE"
+
+  - name: cpu_lockup_hard_lockup
+    severity: critical
+    description: "Hard CPU lockup detected by the NMI watchdog"
+    regex:
+      - 'NMI watchdog: Watchdog detected hard LOCKUP'
+    fixes:
+      - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
+      - "If hard lockups repeat, stop and start the VM to move it to a different host"
+
+  - name: cpu_lockup_bus_lock
+    severity: warning
+    description: "Bus lock or split lock detected (performance-degrading memory access)"
+    regex:
+      - 'took a bus_lock trap'
+      - 'took a split_lock trap'
+      - 'bus lock detected'
+      - 'split lock detected'
+    fixes:
+      - "Identify the application named in the message and fix its misaligned atomic memory access"
+      - "Bus/split locks slow down all vCPUs; update or isolate the offending workload"
+
+  - name: cpu_lockup_rcu_stall
+    severity: error
+    description: "RCU stall detected (CPU unresponsive to the kernel RCU subsystem)"
+    regex:
+      - 'rcu: INFO: rcu_sched detected stalls'
+      - 'rcu_sched self-detected stall on CPU'
+    fixes:
+      - "Check for runaway or real-time processes monopolizing the CPU"
+      - "If the VM is unresponsive, reset it: gcloud compute instances reset VM_NAME --zone=ZONE"

--- a/gce_rescue_v2/core/diagnose_rules/crypt.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/crypt.yaml
@@ -27,8 +27,19 @@ patterns:
     description: "systemd is stuck on a cryptsetup start job (encrypted device wait)"
     regex:
       # 'A start job is running for' alone is a benign transient on every
-      # boot - bound here to crypt/LUKS unit wording only.
-      - 'A start job is running for [^\n]*(?:crypt|luks)'
+      # boot - bound here to crypt/LUKS unit wording only. The negative
+      # lookahead requires that NO completion evidence for the cryptsetup
+      # job ('Started/Finished ... Cryptography Setup', or the device-unit
+      # form's 'Found device ... crypt/luks/mapper') follows anywhere later
+      # in the buffer: on a healthy boot the spinner always resolves into
+      # one of those lines (so every spinner occurrence is rejected), while
+      # a real hang repeats the spinner with no completion line ever - the
+      # last occurrence still matches. Unbounded (not a char window)
+      # because the engine keeps the LAST matching occurrence: a window
+      # would let an early spinner line far from the completion line keep
+      # firing on healthy-but-stopped VMs (TERMINATED skips boot-success
+      # suppression entirely).
+      - 'A start job is running for [^\n]*(?:crypt|luks)(?![\s\S]*?(?:(?:Started|Finished) [^\n]*Cryptography Setup|Found device [^\n]*(?:crypt|luks|mapper)))'
     fixes:
       - "The start job is waiting for an encrypted device to be unlocked - connect to the interactive serial console to supply the passphrase: gcloud compute connect-to-serial-port VM_NAME --zone=ZONE"
       - "If the underlying device is gone (deleted disk), remove its /etc/crypttab and /etc/fstab entries via rescue mode (the entries are readable even though the data is not)"

--- a/gce_rescue_v2/core/diagnose_rules/crypt.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/crypt.yaml
@@ -1,0 +1,46 @@
+# LUKS / dm-crypt encrypted-disk boot hangs.
+#
+# detect_only: a hung passphrase prompt cannot be fixed from the rescue
+# disk without the passphrase/keyfile - there is nothing to edit on disk
+# that would unlock it, so this is detect-and-advise territory.
+# Detection logic note (master-plan G): these are interactive hangs - the
+# prompt line itself IS the failure evidence; no error line ever follows.
+category: crypt
+detect_only: true
+fix_guidance: "The disk is LUKS-encrypted and boot is waiting for a passphrase that can never arrive over the GCE serial console; unlock it interactively via the serial console (gcloud compute connect-to-serial-port), supply a keyfile/crypttab fix from a system that has the key material, or restore from a snapshot"
+auto_repair: false
+
+patterns:
+  - name: crypt_passphrase_prompt
+    severity: critical
+    description: "Boot is waiting for a LUKS passphrase on the console"
+    regex:
+      - 'Please enter passphrase for disk'
+      - 'Please unlock disk'
+    fixes:
+      - "Connect to the interactive serial console and type the passphrase: gcloud compute connect-to-serial-port VM_NAME --zone=ZONE"
+      - "For unattended boot, add a keyfile to /etc/crypttab from a system that can unlock the disk (rescue mode cannot - the data is encrypted)"
+      - "If the passphrase is lost, the data is unrecoverable - restore from a snapshot taken before encryption or rebuild the VM"
+
+  - name: crypt_unlock_wait
+    severity: critical
+    description: "systemd is stuck on a cryptsetup start job (encrypted device wait)"
+    regex:
+      # 'A start job is running for' alone is a benign transient on every
+      # boot - bound here to crypt/LUKS unit wording only.
+      - 'A start job is running for [^\n]*(?:crypt|luks)'
+    fixes:
+      - "The start job is waiting for an encrypted device to be unlocked - connect to the interactive serial console to supply the passphrase: gcloud compute connect-to-serial-port VM_NAME --zone=ZONE"
+      - "If the underlying device is gone (deleted disk), remove its /etc/crypttab and /etc/fstab entries via rescue mode (the entries are readable even though the data is not)"
+
+  - name: crypt_setup_failed
+    severity: error
+    description: "systemd-cryptsetup failed to set up an encrypted device"
+    regex:
+      # Bound to failure wording: bare 'systemd-cryptsetup' appears on
+      # every healthy boot of a VM with encrypted disks.
+      - 'Failed to start [^\n]*(?:Cryptography Setup|systemd-cryptsetup)'
+      - 'systemd-cryptsetup\[\d+\]: [^\n]*[Ff]ailed'
+    fixes:
+      - "Check /etc/crypttab on the mounted disk for a device that no longer exists or a wrong key path (readable from rescue mode)"
+      - "Verify the backing device is attached: gcloud compute instances describe VM_NAME --zone=ZONE"

--- a/gce_rescue_v2/core/diagnose_rules/disk_full.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/disk_full.yaml
@@ -6,8 +6,13 @@ patterns:
   - name: disk_full_no_space
     severity: critical
     description: "Boot disk has no free space (writes are failing)"
+    # Match only lines ENDING with the ENOSPC phrase, and exclude sources
+    # that return ENOSPC without the disk being full:
+    #   - inotify watch/instance exhaustion (systemd "directory watch", tail)
+    #   - cgroup limits on container hosts (kubelet/docker mkdir /sys/fs/cgroup)
+    # Lines merely quoting the phrase mid-sentence no longer match either.
     regex:
-      - 'No space left on device'
+      - '^(?!.*(?:inotify|directory watch|/sys/fs/cgroup)).*No space left on device\s*$'
     fixes:
       - "Free space from rescue mode: clear journals (/mnt/sysroot/var/log/journal), /mnt/sysroot/tmp and old kernels/packages"
       - "Or resize the boot disk: gcloud compute disks resize DISK_NAME --zone=ZONE --size=NEW_SIZE_GB, then reboot to auto-expand"

--- a/gce_rescue_v2/core/diagnose_rules/disk_full.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/disk_full.yaml
@@ -1,4 +1,8 @@
 category: disk_full
+# A boot-success marker does not mean the disk is no longer full — a VM
+# can finish booting while writes keep failing. Findings must survive the
+# RUNNING + "Startup finished" suppression.
+survives_boot_success: true
 fix_guidance: "sudo du -xh /mnt/sysroot --max-depth=2 | sort -rh | head -20"
 auto_repair: false
 
@@ -12,7 +16,9 @@ patterns:
     #   - cgroup limits on container hosts (kubelet/docker mkdir /sys/fs/cgroup)
     # Lines merely quoting the phrase mid-sentence no longer match either.
     regex:
-      - '^(?!.*(?:inotify|directory watch|/sys/fs/cgroup)).*No space left on device\s*$'
+    # [ \t]*$ (not \s*$) so the match stops at end-of-line and the trailing
+    # newline never leaks into detected_pattern / JSON output.
+      - '^(?!.*(?:inotify|directory watch|/sys/fs/cgroup)).*No space left on device[ \t]*$'
     fixes:
       - "Free space from rescue mode: clear journals (/mnt/sysroot/var/log/journal), /mnt/sysroot/tmp and old kernels/packages"
       - "Or resize the boot disk: gcloud compute disks resize DISK_NAME --zone=ZONE --size=NEW_SIZE_GB, then reboot to auto-expand"

--- a/gce_rescue_v2/core/diagnose_rules/disk_full.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/disk_full.yaml
@@ -1,0 +1,22 @@
+category: disk_full
+fix_guidance: "sudo du -xh /mnt/sysroot --max-depth=2 | sort -rh | head -20"
+auto_repair: false
+
+patterns:
+  - name: disk_full_no_space
+    severity: critical
+    description: "Boot disk has no free space (writes are failing)"
+    regex:
+      - 'No space left on device'
+    fixes:
+      - "Free space from rescue mode: clear journals (/mnt/sysroot/var/log/journal), /mnt/sysroot/tmp and old kernels/packages"
+      - "Or resize the boot disk: gcloud compute disks resize DISK_NAME --zone=ZONE --size=NEW_SIZE_GB, then reboot to auto-expand"
+
+  - name: disk_full_guest_agent
+    severity: error
+    description: "Guest agent cannot write temporary files (disk likely full)"
+    regex:
+      - 'No usable temporary directory found'
+    fixes:
+      - "Free space in /mnt/sysroot/tmp and /mnt/sysroot/var so the guest agent and OS Config agent can write again"
+      - "Check usage from rescue mode: df -h /mnt/sysroot"

--- a/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
@@ -25,8 +25,13 @@ patterns:
       - 'The superblock could not be read or does not describe a valid'
       # Kernel mount error observed live on GCE serial console (Debian 12) when a
       # superblock is wiped: systemd-fsck detail stays in the journal, but the
-      # kernel prints "EXT4-fs (sdX): VFS: Can't find ext4 filesystem"
-      - "VFS: Can't find ext4 filesystem"
+      # kernel prints "EXT4-fs (sdX): VFS: Can't find ext4 filesystem".
+      # Anchored to a real mount failure in the same boot window: healthy VMs
+      # whose startup scripts do "try mount, else mkfs" on a blank disk emit the
+      # same VFS line right before mkfs output and must NOT be flagged. The
+      # lookahead keeps match.group(0) single-line so evidence extraction in
+      # _extract_context_lines still renders a clean context window.
+      - 'VFS: Can''t find ext4 filesystem(?=[\s\S]{0,600}?(?:\[FAILED\] Failed to mount|Dependency failed for))'
     fixes:
       - "From rescue mode, run fsck with a backup superblock on the unmounted disk: fsck -b 32768 -y /dev/sdX"
       - "If fsck cannot recover the filesystem, restore the disk from a snapshot"
@@ -37,7 +42,14 @@ patterns:
     regex:
       - 'Either the superblock or the partition table is likely to be corrupt'
       - 'Corruption of in-memory data detected'
-      - 'XFS \(\w+\): Metadata corruption detected'
+      # [\w-]+ (not \w+): device-mapper names contain hyphens (dm-0, LVM on
+      # RHEL/SAP images) and \w alone silently misses them.
+      - 'XFS \([\w-]+\): Metadata corruption detected'
+      # Modern kernels report checksum-verified corruption with different
+      # wording; also match the canonical companion line the kernel emits for
+      # both variants ("Unmount and run xfs_repair").
+      - 'XFS \([\w-]+\): Metadata CRC error detected'
+      - 'XFS \([\w-]+\): Unmount and run xfs_repair'
       - 'EXT4-fs error \(device'
     fixes:
       - "From rescue mode, check the unmounted disk: fsck -y /dev/sdX (ext) or xfs_repair /dev/sdX (XFS)"

--- a/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
@@ -53,6 +53,10 @@ patterns:
       # both variants ("Unmount and run xfs_repair").
       - 'XFS \([\w-]+\): Metadata CRC error detected'
       - 'XFS \([\w-]+\): Unmount and run xfs_repair'
+      # Combined-line form seen on modern kernels: "XFS (sda1): Corruption
+      # detected. Unmount and run xfs_repair" (no 'Metadata' prefix, and
+      # 'Unmount' is not at the message start).
+      - 'XFS \([\w-]+\): Corruption (?:detected|warning)\. Unmount'
       - 'EXT4-fs error \(device'
       # Severe corruption (superblock + partition table destroyed) makes the
       # device unopenable, so fsck/mount emit this instead of "Bad magic
@@ -61,3 +65,55 @@ patterns:
     fixes:
       - "From rescue mode, check the unmounted disk: fsck -y /dev/sdX (ext) or xfs_repair /dev/sdX (XFS)"
       - "If corruption persists, check disk health in GCP Console and restore from a snapshot"
+
+  - name: filesystem_btrfs_corruption
+    severity: critical
+    description: "Btrfs filesystem corruption detected (SLES/openSUSE root)"
+    regex:
+      # Bound to the kernel's '(device ...)' form so prose mentioning
+      # 'BTRFS error' can never match. 'BTRFS info'/'BTRFS warning' lines
+      # on healthy boots do not match any of these.
+      - 'BTRFS error \(device'
+      - 'BTRFS critical \(device'
+      - 'open_ctree failed'
+      - 'BTRFS: failed to read chunk tree'
+      - 'parent transid verify failed'
+    fixes:
+      - "From rescue mode, check the unmounted disk read-only first: sudo btrfs check /dev/sdX (do NOT use --repair without a snapshot)"
+      - "Try recovery mounts before repairing: sudo mount -o ro,rescue=usebackuproot /dev/sdX /mnt/recovery"
+      - "On SUSE root disks, a snapper snapshot rollback from the GRUB snapshot menu is often the safest fix"
+      - "If the chunk/root trees are unreadable, restore the disk from a snapshot"
+
+  - name: filesystem_xfs_log_failure
+    severity: critical
+    description: "XFS journal (log) mount or recovery failed"
+    regex:
+      - 'XFS \([\w-]+\): log mount/recovery failed'
+      - 'XFS \([\w-]+\): log mount failed'
+    fixes:
+      - "From rescue mode, replay/repair the log on the unmounted disk: sudo xfs_repair /dev/sdX"
+      - "If xfs_repair refuses because the log is dirty, retry with -L (zeroes the log; last transactions are lost): sudo xfs_repair -L /dev/sdX"
+      - "If corruption persists after repair, restore the disk from a snapshot"
+
+  - name: filesystem_ext4_feature_mismatch
+    severity: critical
+    description: "ext4 filesystem uses features unsupported by this kernel"
+    regex:
+      # Printed when a disk formatted by newer e2fsprogs (e.g.
+      # metadata_csum_seed, orphan_file) is mounted by an older kernel -
+      # typical after moving a disk to an older-distro rescue/host image.
+      - "couldn't mount (?:RDWR |read-only )?because of unsupported optional features"
+    fixes:
+      - "The disk was formatted with newer ext4 features than this kernel supports - mount it from a VM/rescue image at least as new as the OS that created it"
+      - "Check which features are set: sudo dumpe2fs -h /dev/sdX | grep features"
+      - "Some features can be disabled offline if you must mount on the older kernel, e.g.: sudo tune2fs -O ^orphan_file /dev/sdX (verify with e2fsck afterwards)"
+
+  - name: filesystem_xfs_duplicate_uuid
+    severity: error
+    description: "XFS refused to mount a filesystem whose UUID is already mounted (duplicate UUID)"
+    regex:
+      - "Filesystem has duplicate UUID [^\\n]{0,80}- can't mount"
+    fixes:
+      - "This is expected in rescue mode when the original XFS boot disk is attached as the secondary disk: the rescue image's root has the same UUID (same base image), so the kernel refuses the second mount"
+      - "Mount the original disk without UUID checking: sudo mount -o nouuid /dev/sdb1 /mnt/sysroot"
+      - "Or give the original filesystem a new UUID permanently: sudo xfs_admin -U generate /dev/sdb1 (then update fstab/grub references to the new UUID)"

--- a/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
@@ -3,6 +3,9 @@ fix_guidance: "sudo umount /mnt/sysroot && sudo fsck -y /dev/sdb1"
 # auto_repair stays false until startup_scripts/fixes/filesystem_fix.sh exists
 # and repair orchestration is wired for it. Detect-only with manual guidance.
 auto_repair: false
+# A corrupt secondary disk marked nofail lets the VM boot fine while the
+# disk stays broken — a successful boot never resolves these findings.
+survives_boot_success: true
 
 # Dedupe interplay with fstab.yaml:
 # fstab_fsck_failed matches generic boot-time fsck failure output (e.g.

--- a/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
@@ -61,7 +61,12 @@ patterns:
       # Severe corruption (superblock + partition table destroyed) makes the
       # device unopenable, so fsck/mount emit this instead of "Bad magic
       # number". Anchored to a real device path to avoid matching prose.
-      - "/dev/\\S+: Can't open blockdev"
+      # (?!root\b) carves out "/dev/root: Can't open blockdev" - /dev/root
+      # is the initramfs's ALIAS for the not-yet-resolved root device, and
+      # the line appears on every initramfs load failure with no corruption
+      # present (confirmed live: repair fsck reported NO_ISSUES). Those
+      # boots are owned by initramfs.yaml.
+      - "/dev/(?!root\\b)\\S+: Can't open blockdev"
     fixes:
       - "From rescue mode, check the unmounted disk: fsck -y /dev/sdX (ext) or xfs_repair /dev/sdX (XFS)"
       - "If corruption persists, check disk health in GCP Console and restore from a snapshot"

--- a/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
@@ -54,6 +54,10 @@ patterns:
       - 'XFS \([\w-]+\): Metadata CRC error detected'
       - 'XFS \([\w-]+\): Unmount and run xfs_repair'
       - 'EXT4-fs error \(device'
+      # Severe corruption (superblock + partition table destroyed) makes the
+      # device unopenable, so fsck/mount emit this instead of "Bad magic
+      # number". Anchored to a real device path to avoid matching prose.
+      - "/dev/\\S+: Can't open blockdev"
     fixes:
       - "From rescue mode, check the unmounted disk: fsck -y /dev/sdX (ext) or xfs_repair /dev/sdX (XFS)"
       - "If corruption persists, check disk health in GCP Console and restore from a snapshot"

--- a/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/filesystem.yaml
@@ -1,0 +1,44 @@
+category: filesystem
+fix_guidance: "sudo umount /mnt/sysroot && sudo fsck -y /dev/sdb1"
+# auto_repair stays false until startup_scripts/fixes/filesystem_fix.sh exists
+# and repair orchestration is wired for it. Detect-only with manual guidance.
+auto_repair: false
+
+# Dedupe interplay with fstab.yaml:
+# fstab_fsck_failed matches generic boot-time fsck failure output (e.g.
+# "UNEXPECTED INCONSISTENCY", "fsck exited with status code"). The patterns
+# below match filesystem-level corruption evidence (superblock damage, kernel
+# EXT4/XFS corruption reports) and intentionally do NOT match plain fstab
+# configuration errors (bad UUID, missing device, mount timeouts). When a
+# corrupted filesystem causes a boot-time fsck failure, BOTH categories firing
+# on the same buffer is expected and correct: they are different, both-true
+# findings, and none of these descriptions belong in the _CATCH_ALL or
+# _GENERIC_SYMPTOM dedupe tiers in core/diagnosis.py.
+
+patterns:
+  - name: filesystem_bad_superblock
+    severity: critical
+    description: "Filesystem superblock is corrupt or unreadable"
+    regex:
+      - 'Bad magic number in super-block'
+      - 'Superblock invalid, trying backup blocks'
+      - 'The superblock could not be read or does not describe a valid'
+      # Kernel mount error observed live on GCE serial console (Debian 12) when a
+      # superblock is wiped: systemd-fsck detail stays in the journal, but the
+      # kernel prints "EXT4-fs (sdX): VFS: Can't find ext4 filesystem"
+      - "VFS: Can't find ext4 filesystem"
+    fixes:
+      - "From rescue mode, run fsck with a backup superblock on the unmounted disk: fsck -b 32768 -y /dev/sdX"
+      - "If fsck cannot recover the filesystem, restore the disk from a snapshot"
+
+  - name: filesystem_corruption
+    severity: critical
+    description: "Filesystem corruption detected on a disk"
+    regex:
+      - 'Either the superblock or the partition table is likely to be corrupt'
+      - 'Corruption of in-memory data detected'
+      - 'XFS \(\w+\): Metadata corruption detected'
+      - 'EXT4-fs error \(device'
+    fixes:
+      - "From rescue mode, check the unmounted disk: fsck -y /dev/sdX (ext) or xfs_repair /dev/sdX (XFS)"
+      - "If corruption persists, check disk health in GCP Console and restore from a snapshot"

--- a/gce_rescue_v2/core/diagnose_rules/firmware.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/firmware.yaml
@@ -27,7 +27,12 @@ patterns:
       # Deliberately NOT matched: 'Booting from Hard Disk...' — SeaBIOS
       # prints that on EVERY healthy boot; only the explicit failure
       # strings below are reliable signals.
-      - 'No bootable device'
+      # Start-anchored so a startup-script echo merely MENTIONING the
+      # phrase mid-line cannot fire. The live SeaBIOS capture starts the
+      # line with the phrase ('No bootable device.SeaBIOS ...'), and when
+      # SeaBIOS glues it after 'Boot failed: could not read the boot
+      # disk', that line's own pattern below still reports the finding.
+      - '^\s*No bootable device'
       - '^\s*Boot failed: not a bootable disk'
       - '^\s*Boot failed: could not read the boot disk'
     fixes:
@@ -53,10 +58,12 @@ patterns:
     description: "Secure Boot rejected the bootloader or kernel (unsigned or wrongly signed)"
     regex:
       - 'Verification failed: \(0x1A\) Security Violation'
-      # shim/GRUB-emitted forms — line-start 'error:' bound like grub.yaml.
-      - '^\s*error: bad shim signature'
-      - '^\s*error: shim_lock protocol not found'
-      - '^\s*error: prohibited by secure boot policy'
+      # shim/GRUB-emitted forms — line-start 'error:' bound like grub.yaml,
+      # with the same optional RHEL/Fedora source-location prefix
+      # (error: ../../grub-core/...c:NNN:<message>).
+      - '^\s*error: (?:\S+\.c:\d+:)?bad shim signature'
+      - '^\s*error: (?:\S+\.c:\d+:)?shim_lock protocol not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?prohibited by secure boot policy'
     fixes:
       - "Advise-only: Secure Boot violations cannot be fixed by editing the disk from rescue mode - the Shielded VM firmware rejects the boot chain itself"
       - "If a custom/unsigned kernel or bootloader was installed, reinstall the distro-signed shim and GRUB packages from a chroot: apt-get install --reinstall shim-signed grub-efi-amd64-signed (Debian-family) or dnf reinstall shim-x64 grub2-efi-x64 (RHEL-family)"

--- a/gce_rescue_v2/core/diagnose_rules/firmware.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/firmware.yaml
@@ -1,0 +1,79 @@
+# Firmware-stage failure patterns (boot stage 1: SeaBIOS / UEFI-OVMF).
+#
+# These fire before GRUB or the kernel ever runs, so the lines carry no
+# timestamps and no unit prefixes. All strings below are firmware-unique
+# (SeaBIOS 'Boot failed'/'No bootable device', OVMF 'BdsDxe:') and cannot
+# appear in kernel or systemd output.
+category: firmware
+fix_guidance: "From rescue mode, verify the original disk's partition table (sgdisk --verify /dev/sdX or fdisk -l /dev/sdX) and reinstall the bootloader from a chroot; Secure Boot violations cannot be fixed by disk edits - they need correctly signed boot components"
+# auto_repair MUST stay false until startup_scripts/fixes/firmware_fix.sh
+# lands. RepairOrchestrator.validate() checks that every category with
+# auto_repair: true has a fix script, so flipping this early makes
+# `repair` fail preflight for ALL categories. Flip to true in the same
+# commit that adds the script.
+auto_repair: false
+# NOT detect_only: a wiped MBR/GPT or a missing/unformatted EFI system
+# partition IS repairable from rescue mode with partition and bootloader
+# surgery on the attached original disk. The exception is Secure Boot
+# rejection, which is advise-only — its per-pattern fixes say so.
+# No survives_boot_success: firmware failures block boot entirely, so a
+# later completed boot proves the stale finding is resolved.
+
+patterns:
+  - name: firmware_no_bootable_device
+    severity: critical
+    description: "Firmware found no bootable device (wiped or corrupt MBR / boot disk)"
+    regex:
+      # Deliberately NOT matched: 'Booting from Hard Disk...' — SeaBIOS
+      # prints that on EVERY healthy boot; only the explicit failure
+      # strings below are reliable signals.
+      - 'No bootable device'
+      - '^\s*Boot failed: not a bootable disk'
+      - '^\s*Boot failed: could not read the boot disk'
+    fixes:
+      - "Verify the boot disk is attached as the boot device: gcloud compute instances describe VM_NAME --zone=ZONE --format='value(disks[].boot)'"
+      - "From rescue mode, check the partition table of the original disk: sudo fdisk -l /dev/sdX - if it is empty, the MBR/GPT was wiped"
+      - "Reinstall the bootloader from a chroot: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "If the partition table is unrecoverable, restore the disk from a snapshot"
+
+  - name: firmware_uefi_boot_load_failed
+    severity: critical
+    description: "UEFI firmware could not load a boot option (missing or unformatted EFI system partition)"
+    regex:
+      # 'BdsDxe' is unique to OVMF/EDK2 firmware output.
+      - 'BdsDxe: failed to load Boot[0-9A-Fa-f]{4}'
+      - 'BdsDxe: No bootable option or device was found'
+    fixes:
+      - "From rescue mode, check the EFI system partition exists on the original disk: sudo sgdisk -p /dev/sdX (look for an EF00 partition)"
+      - "Mount the ESP and verify it contains the bootloader: sudo mount /dev/sdX15 /mnt/esp && ls /mnt/esp/EFI"
+      - "Reinstall the EFI bootloader from a chroot (with the ESP mounted at /boot/efi): grub-install --target=x86_64-efi /dev/sdX (Debian-family) or dnf reinstall grub2-efi-x64 shim-x64 (RHEL-family)"
+
+  - name: firmware_secure_boot_violation
+    severity: critical
+    description: "Secure Boot rejected the bootloader or kernel (unsigned or wrongly signed)"
+    regex:
+      - 'Verification failed: \(0x1A\) Security Violation'
+      # shim/GRUB-emitted forms — line-start 'error:' bound like grub.yaml.
+      - '^\s*error: bad shim signature'
+      - '^\s*error: shim_lock protocol not found'
+      - '^\s*error: prohibited by secure boot policy'
+    fixes:
+      - "Advise-only: Secure Boot violations cannot be fixed by editing the disk from rescue mode - the Shielded VM firmware rejects the boot chain itself"
+      - "If a custom/unsigned kernel or bootloader was installed, reinstall the distro-signed shim and GRUB packages from a chroot: apt-get install --reinstall shim-signed grub-efi-amd64-signed (Debian-family) or dnf reinstall shim-x64 grub2-efi-x64 (RHEL-family)"
+      - "Or disable Secure Boot on the stopped VM: gcloud compute instances update VM_NAME --zone=ZONE --no-shielded-secure-boot"
+
+  - name: firmware_gpt_corrupt
+    severity: critical
+    description: "Partition table on the boot disk is corrupt or invalid"
+    regex:
+      # Deliberately NOT matched: 'GPT: Primary header thinks Alt. header
+      # is not at the end of the disk' — the kernel prints that benign
+      # warning on every resized-but-not-yet-expanded persistent disk and
+      # the VM boots fine (it is also a kernel message, not firmware).
+      # Only unambiguous failure strings are matched here.
+      - '^\s*Invalid partition table'
+      - 'partition table (?:is )?corrupt'
+    fixes:
+      - "From rescue mode, inspect the original disk's partition table: sudo sgdisk --verify /dev/sdX or sudo fdisk -l /dev/sdX"
+      - "Recover the GPT from its backup header using gdisk's recovery menu: sudo gdisk /dev/sdX, then 'r' (recovery) and 'b' (use backup header)"
+      - "If the table is unrecoverable, restore the disk from a snapshot"

--- a/gce_rescue_v2/core/diagnose_rules/fstab.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/fstab.yaml
@@ -18,8 +18,16 @@ patterns:
     severity: critical
     description: "Device referenced in /etc/fstab timed out waiting"
     regex:
-      - 'Timed out waiting for device.*/dev/\S+'
-      - 'Timed out waiting for device dev-\w+'
+      # /dev/mapper/* timeouts are LVM activation failures and belong to
+      # lvm.yaml, hence the (?!mapper) carve-outs on both loose forms.
+      - 'Timed out waiting for device.*/dev/(?!mapper/)\S+'
+      # RHEL/SLES systemd escapes dashes in device unit names as \x2d
+      # (dev-disk-by\x2duuid-<uuid>.device). This explicit form is listed
+      # BEFORE the loose dev-\w+ fallback so the full unit name (with the
+      # UUID) lands in detected_pattern for identifier extraction, instead
+      # of the fallback's truncated 'device dev-disk' match.
+      - 'Timed out waiting for device dev-disk-by\\x2d\S+'
+      - 'Timed out waiting for device dev-(?!mapper)\w+'
     fixes:
       - "Comment out or fix the invalid device entry"
       - "Verify disk is attached: gcloud compute instances describe VM_NAME --zone=ZONE"
@@ -39,10 +47,13 @@ patterns:
     severity: critical
     description: "Failed to mount filesystem listed in /etc/fstab"
     regex:
+      # /sysroot failures happen inside the initrd (RHEL-family) and are
+      # owned by initramfs_sysroot_mount_failed - carved out here so one
+      # line never fires both categories.
       - 'Dependency failed for .*\.mount'
-      - 'Failed to mount .*\.mount'
+      - 'Failed to mount (?!/sysroot).*\.mount'
       - 'mount.*failed'
-      - 'systemd.*Failed to mount'
+      - 'systemd.*Failed to mount (?!/sysroot)'
     fixes:
       - "Comment out or fix the problematic entry"
       - "Verify filesystem type and mount options are correct"
@@ -51,7 +62,9 @@ patterns:
     severity: critical
     description: "Mount point dependency failed (device not available)"
     regex:
-      - 'Dependency failed for /[a-zA-Z]'
+      # (?!sysroot\b): /sysroot dependency failures are the initrd stage
+      # (initramfs_sysroot_mount_failed), not running-system fstab.
+      - 'Dependency failed for /(?!sysroot\b)[a-zA-Z]'
       - 'Dependency failed for File System Check'
     fixes:
       - "Comment out or fix the problematic entry"
@@ -64,6 +77,10 @@ patterns:
       - 'You are in emergency mode'
       - 'Welcome to emergency mode'
       - 'Entering emergency mode'
+      # sulogin maintenance prompt (RHEL/SLES/openSUSE wording; not
+      # SLES-only - RHEL emergency prints it too).
+      - 'Give root password for maintenance'
+      - 'press Control-D to continue'
     fixes:
       - "Review serial console for preceding error messages"
 

--- a/gce_rescue_v2/core/diagnose_rules/fstab.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/fstab.yaml
@@ -52,6 +52,11 @@ patterns:
       # line never fires both categories.
       - 'Dependency failed for .*\.mount'
       - 'Failed to mount (?!/sysroot).*\.mount'
+      # Plain console form (live openSUSE Leap 16 capture): systemd prints
+      # '[FAILED] Failed to mount /mnt/data.' with no .mount suffix and no
+      # systemd[1]: prefix. /sysroot stays carved out (initrd stage, owned
+      # by initramfs_sysroot_mount_failed).
+      - 'Failed to mount /(?!sysroot\b)\S+'
       - 'mount.*failed'
       - 'systemd.*Failed to mount (?!/sysroot)'
     fixes:

--- a/gce_rescue_v2/core/diagnose_rules/fstab.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/fstab.yaml
@@ -71,7 +71,12 @@ patterns:
     severity: critical
     description: "Filesystem check (fsck) failed on a mounted partition"
     regex:
-      - 'fsck.*failed'
+      # 'fsck' and 'failed' must be adjacent. A greedy 'fsck.*failed' spans
+      # garbled serial: on a full disk, journald interleaves 'systemd-fsckd
+      # ...service: Deactivated succe[...]Failed to open' onto one physical
+      # line, so 'fsck.*failed' fires on a healthy fsck daemon (false positive).
+      - 'fsck failed'
+      - 'fsck.{0,40}exited with (?:exit )?(?:status|code)'
       - 'fsck exited with status code'
       - 'FILE SYSTEM CHECK FAILED'
       - 'UNEXPECTED INCONSISTENCY'

--- a/gce_rescue_v2/core/diagnose_rules/fstab.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/fstab.yaml
@@ -7,7 +7,11 @@ patterns:
     severity: critical
     description: "UUID specified in /etc/fstab cannot be found"
     regex:
-      - 'UUID=[\w-]+ does not exist'
+      # (?!.*ALERT!): the BusyBox initramfs line 'ALERT!  UUID=... does not
+      # exist.  Dropping to a shell!' names the root= KERNEL PARAMETER, not
+      # an fstab entry - it is owned by initramfs_busybox_shell, and the
+      # fstab auto-repair guidance would point at the wrong file.
+      - '^(?!.*ALERT!)[^\n]*UUID=[\w-]+ does not exist'
       - "can't find UUID=[\\w-]+"
       - 'Timed out waiting for device.*UUID='
       - 'Expecting device.*/dev/disk/by-uuid/'

--- a/gce_rescue_v2/core/diagnose_rules/grub.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/grub.yaml
@@ -1,0 +1,167 @@
+# GRUB2 bootloader failure patterns (boot stage 2).
+#
+# Anchoring convention: GRUB output carries NO kernel timestamps and no
+# systemd/journald prefixes — its error messages start the serial line as
+# "error: <message>". Every error-message regex below is bound to that
+# line-start "error:" prefix (the engine compiles with re.MULTILINE), so
+# short phrases like "out of memory" or "unknown filesystem" can never
+# match kernel OOM reports or mount(8)/kernel messages, which always
+# arrive with a timestamp or unit prefix on the serial console.
+#
+# Interplay: no GRUB line contains "Kernel panic - not syncing", so the
+# kernel_panic_generic catch-all lookahead in kernel.yaml is unaffected.
+category: grub
+fix_guidance: "chroot into /mnt/sysroot, reinstall GRUB to the boot disk (grub-install /dev/sdX on Debian-family, grub2-install /dev/sdX on RHEL-family) and regenerate the config (update-grub or grub2-mkconfig -o /boot/grub2/grub.cfg)"
+# auto_repair MUST stay false until startup_scripts/fixes/grub_fix.sh
+# lands. RepairOrchestrator.validate() checks that every category with
+# auto_repair: true has a fix script, so flipping this early makes
+# `repair` fail preflight for ALL categories. Flip to true in the same
+# commit that adds the script.
+auto_repair: false
+# NOT detect_only: GRUB damage is genuinely fixable from rescue mode
+# (grub-install + update-grub/grub2-mkconfig on the mounted original disk).
+# No survives_boot_success: a stale GRUB error from an older boot IS
+# resolved once a later boot completes, so boot-success suppression must
+# clear these findings.
+
+patterns:
+  - name: grub_rescue_prompt
+    severity: critical
+    description: "GRUB dropped to the rescue prompt (core modules or boot partition unreadable)"
+    regex:
+      # Literal 'grub rescue>' cannot match ordinary prose mentioning GRUB.
+      - 'Entering rescue mode\.\.\.'
+      - '^\s*grub rescue>'
+    fixes:
+      - "Enter rescue mode and chroot into the original disk: sudo chroot /mnt/sysroot (bind-mount /dev, /proc and /sys first)"
+      - "Reinstall GRUB to the disk device: grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family), where /dev/sdX is the original boot disk"
+      - "Regenerate the GRUB config: update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
+  - name: grub_normal_shell
+    severity: critical
+    description: "Boot stopped at the GRUB shell (grub.cfg missing or unreadable)"
+    regex:
+      # Banner unique to the full grub> shell (rescue mode prints a shorter
+      # banner). It can also appear when a user presses 'c'/'e' at a healthy
+      # GRUB menu, but that only reaches the buffer during interactive
+      # serial sessions — accepted residual risk (plan FP note).
+      - 'Minimal BASH-like line editing is supported'
+    fixes:
+      - "The GRUB config is missing or unreadable - regenerate it from rescue mode: sudo chroot /mnt/sysroot, then update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+      - "Verify /boot/grub/grub.cfg (Debian-family) or /boot/grub2/grub.cfg (RHEL-family) exists on the mounted disk and is non-empty"
+
+  - name: grub_file_not_found
+    severity: critical
+    description: "GRUB configuration or module file not found"
+    regex:
+      # .? absorbs the opening quote/backtick GRUB prints around paths
+      # (serial rendering varies by version). grub2? covers Debian
+      # /boot/grub and RHEL/SLES /boot/grub2 layouts.
+      - '^\s*error: file .?/boot/grub2?/grub\.cfg.? not found'
+      - '^\s*error: file .?/boot/grub2?/\S* not found'
+      # UEFI layout: grub.cfg stub under /EFI/<distro>/ on the ESP.
+      - '^\s*error: file .?/efi/[\w.-]+/grub\.cfg.? not found'
+    fixes:
+      - "Regenerate the GRUB config from rescue mode: sudo chroot /mnt/sysroot, then update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+      - "If GRUB modules (*.mod) are missing or corrupt, reinstall GRUB: grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "Check that /boot (or the EFI system partition) is intact and not full: df -h /mnt/sysroot/boot"
+
+  - name: grub_kernel_not_found
+    severity: critical
+    description: "Kernel or initrd file referenced by the GRUB config not found"
+    regex:
+      # (?:/boot)? — on systems with a separate /boot partition, grub.cfg
+      # references /vmlinuz-* and /initrd.img-* without the /boot prefix.
+      - '^\s*error: file .?(?:/boot)?/vmlinuz\S* not found'
+      - '^\s*error: file .?(?:/boot)?/init(?:rd|ramfs)\S* not found'
+    fixes:
+      - "List installed kernels on the mounted disk: ls /mnt/sysroot/boot/vmlinuz-*"
+      - "Reinstall the kernel package from a chroot if the image is missing: sudo chroot /mnt/sysroot apt-get install --reinstall linux-image-amd64 (Debian-family) or dnf reinstall kernel-core (RHEL-family)"
+      - "Regenerate the GRUB config so entries match the installed kernels: update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
+  - name: grub_load_kernel_first
+    severity: critical
+    description: "GRUB tried to boot without a loaded kernel (broken boot entry)"
+    regex:
+      - '^\s*error: you need to load the kernel first'
+    fixes:
+      - "A boot entry failed to load its kernel/initrd - check the preceding 'error: file ... not found' line for the missing file"
+      - "Regenerate the GRUB config from rescue mode: sudo chroot /mnt/sysroot, then update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
+  - name: grub_no_such_partition
+    severity: critical
+    description: "GRUB cannot find the partition it was configured to boot from"
+    regex:
+      - '^\s*error: no such partition'
+    fixes:
+      - "The partition layout changed after GRUB was installed (deleted/renumbered partition) - verify the table from rescue mode: sudo fdisk -l /dev/sdX"
+      - "Reinstall GRUB against the current layout: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "Regenerate the config: update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
+  - name: grub_no_such_device
+    severity: critical
+    description: "GRUB cannot find the device (UUID or label) it was configured to boot from"
+    regex:
+      - '^\s*error: no such device'
+    fixes:
+      - "The filesystem UUID GRUB searches for no longer exists (reformatted /boot or cloned disk) - compare: sudo blkid vs the search line in grub.cfg on the mounted disk"
+      - "Reinstall GRUB and regenerate its config from rescue mode: sudo chroot /mnt/sysroot, then grub-install /dev/sdX + update-grub (Debian-family) or grub2-install /dev/sdX + grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
+  - name: grub_disk_not_found
+    severity: critical
+    description: "Disk referenced by GRUB does not exist"
+    regex:
+      # Canonical BIOS form: error: disk 'hd0,gpt2' not found.
+      - '^\s*error: disk .?hd\d+,\w+.? not found'
+      # Broader form (lvmid/..., UUID references) — still bound to the
+      # line-start 'error: disk' prefix.
+      - '^\s*error: disk [^\n]{1,80} not found'
+    fixes:
+      - "GRUB's device map no longer matches the attached disks - reinstall GRUB from rescue mode: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "If the entry references LVM, verify the volume group is intact: sudo vgscan; sudo lvs"
+
+  - name: grub_unknown_filesystem
+    severity: critical
+    description: "GRUB cannot read the filesystem holding /boot"
+    regex:
+      # 'error:' prefix keeps this from ever overlapping the kernel/mount
+      # message 'unknown filesystem type', which never starts a serial line.
+      - '^\s*error: unknown filesystem'
+    fixes:
+      - "The /boot filesystem is corrupt or an unsupported type - check it from rescue mode: sudo fsck -y /dev/sdX (run on the unmounted partition)"
+      - "Reinstall GRUB after repairing the filesystem: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "If the filesystem is unrecoverable, restore the disk from a snapshot"
+
+  - name: grub_symbol_not_found
+    severity: critical
+    description: "GRUB core image and modules are from different versions (symbol not found)"
+    regex:
+      # Bound to a grub_ symbol name (e.g. grub_calloc) so it cannot match
+      # linker/loader errors from other programs.
+      - '^\s*error: symbol .?grub_\w+.? not found'
+    fixes:
+      - "A GRUB package upgrade updated the modules without reinstalling the core image (version skew) - reinstall from rescue mode: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "Regenerate the config afterwards: update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
+  - name: grub_out_of_memory
+    severity: critical
+    description: "GRUB ran out of memory while loading the boot entry"
+    regex:
+      # The 'error:' line-start prefix is REQUIRED here: without it this
+      # would collide with kernel OOM output ('Out of memory: Killed
+      # process ...'), which is always timestamp-prefixed.
+      - '^\s*error: out of memory'
+    fixes:
+      - "Usually caused by an oversized initrd - rebuild it from rescue mode: sudo chroot /mnt/sysroot, then update-initramfs -u (Debian-family) or dracut -f (RHEL-family)"
+      - "Check the initrd size on the mounted disk: ls -lh /mnt/sysroot/boot/init*"
+
+  - name: grub_invalid_magic
+    severity: critical
+    description: "GRUB rejected a corrupt kernel or module image (invalid magic number)"
+    regex:
+      - '^\s*error: invalid magic number'
+      - '^\s*error: invalid arch-independent ELF magic'
+    fixes:
+      - "The kernel image or a GRUB module is corrupt (wrong-arch or truncated file) - reinstall the kernel from a chroot: sudo chroot /mnt/sysroot apt-get install --reinstall linux-image-amd64 (Debian-family) or dnf reinstall kernel-core (RHEL-family)"
+      - "Reinstall GRUB if modules are corrupt: grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
+      - "Verify /boot is not on a damaged filesystem: sudo fsck -y /dev/sdX (unmounted)"

--- a/gce_rescue_v2/core/diagnose_rules/grub.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/grub.yaml
@@ -8,6 +8,14 @@
 # match kernel OOM reports or mount(8)/kernel messages, which always
 # arrive with a timestamp or unit prefix on the serial console.
 #
+# RHEL/Fedora-family grub2 carries a downstream patch that inserts the
+# source location between "error: " and the message, e.g.
+#   error: ../../grub-core/fs/fshelp.c:258:file `/vmlinuz-...' not found.
+# Every message-bound regex therefore accepts an optional
+# (?:\S+\.c:\d+:)? prefix after "error: ". The prefix stays optional so
+# Debian-family output (no prefix) keeps matching, and it is tight
+# enough (*.c:<line>:) that it cannot absorb arbitrary prose.
+#
 # Interplay: no GRUB line contains "Kernel panic - not syncing", so the
 # kernel_panic_generic catch-all lookahead in kernel.yaml is unaffected.
 category: grub
@@ -57,10 +65,14 @@ patterns:
       # .? absorbs the opening quote/backtick GRUB prints around paths
       # (serial rendering varies by version). grub2? covers Debian
       # /boot/grub and RHEL/SLES /boot/grub2 layouts.
-      - '^\s*error: file .?/boot/grub2?/grub\.cfg.? not found'
-      - '^\s*error: file .?/boot/grub2?/\S* not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?file .?/boot/grub2?/grub\.cfg.? not found'
+      # (?!grubenv) excludes the well-known BENIGN RHEL-on-XFS line
+      # "error: ../../grub-core/fs/fshelp.c:257:file `/boot/grub2/grubenv'
+      # not found." — grubenv is unwritable on XFS but boot continues fine,
+      # so flagging it would be a critical FP on healthy stopped RHEL VMs.
+      - '^\s*error: (?:\S+\.c:\d+:)?file .?/boot/grub2?/(?!grubenv)\S* not found'
       # UEFI layout: grub.cfg stub under /EFI/<distro>/ on the ESP.
-      - '^\s*error: file .?/efi/[\w.-]+/grub\.cfg.? not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?file .?/efi/[\w.-]+/grub\.cfg.? not found'
     fixes:
       - "Regenerate the GRUB config from rescue mode: sudo chroot /mnt/sysroot, then update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
       - "If GRUB modules (*.mod) are missing or corrupt, reinstall GRUB: grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
@@ -72,8 +84,8 @@ patterns:
     regex:
       # (?:/boot)? — on systems with a separate /boot partition, grub.cfg
       # references /vmlinuz-* and /initrd.img-* without the /boot prefix.
-      - '^\s*error: file .?(?:/boot)?/vmlinuz\S* not found'
-      - '^\s*error: file .?(?:/boot)?/init(?:rd|ramfs)\S* not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?file .?(?:/boot)?/vmlinuz\S* not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?file .?(?:/boot)?/init(?:rd|ramfs)\S* not found'
     fixes:
       - "List installed kernels on the mounted disk: ls /mnt/sysroot/boot/vmlinuz-*"
       - "Reinstall the kernel package from a chroot if the image is missing: sudo chroot /mnt/sysroot apt-get install --reinstall linux-image-amd64 (Debian-family) or dnf reinstall kernel-core (RHEL-family)"
@@ -83,7 +95,7 @@ patterns:
     severity: critical
     description: "GRUB tried to boot without a loaded kernel (broken boot entry)"
     regex:
-      - '^\s*error: you need to load the kernel first'
+      - '^\s*error: (?:\S+\.c:\d+:)?you need to load the kernel first'
     fixes:
       - "A boot entry failed to load its kernel/initrd - check the preceding 'error: file ... not found' line for the missing file"
       - "Regenerate the GRUB config from rescue mode: sudo chroot /mnt/sysroot, then update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
@@ -92,7 +104,7 @@ patterns:
     severity: critical
     description: "GRUB cannot find the partition it was configured to boot from"
     regex:
-      - '^\s*error: no such partition'
+      - '^\s*error: (?:\S+\.c:\d+:)?no such partition'
     fixes:
       - "The partition layout changed after GRUB was installed (deleted/renumbered partition) - verify the table from rescue mode: sudo fdisk -l /dev/sdX"
       - "Reinstall GRUB against the current layout: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
@@ -102,7 +114,7 @@ patterns:
     severity: critical
     description: "GRUB cannot find the device (UUID or label) it was configured to boot from"
     regex:
-      - '^\s*error: no such device'
+      - '^\s*error: (?:\S+\.c:\d+:)?no such device'
     fixes:
       - "The filesystem UUID GRUB searches for no longer exists (reformatted /boot or cloned disk) - compare: sudo blkid vs the search line in grub.cfg on the mounted disk"
       - "Reinstall GRUB and regenerate its config from rescue mode: sudo chroot /mnt/sysroot, then grub-install /dev/sdX + update-grub (Debian-family) or grub2-install /dev/sdX + grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
@@ -112,10 +124,10 @@ patterns:
     description: "Disk referenced by GRUB does not exist"
     regex:
       # Canonical BIOS form: error: disk 'hd0,gpt2' not found.
-      - '^\s*error: disk .?hd\d+,\w+.? not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?disk .?hd\d+,\w+.? not found'
       # Broader form (lvmid/..., UUID references) — still bound to the
       # line-start 'error: disk' prefix.
-      - '^\s*error: disk [^\n]{1,80} not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?disk [^\n]{1,80} not found'
     fixes:
       - "GRUB's device map no longer matches the attached disks - reinstall GRUB from rescue mode: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
       - "If the entry references LVM, verify the volume group is intact: sudo vgscan; sudo lvs"
@@ -126,7 +138,7 @@ patterns:
     regex:
       # 'error:' prefix keeps this from ever overlapping the kernel/mount
       # message 'unknown filesystem type', which never starts a serial line.
-      - '^\s*error: unknown filesystem'
+      - '^\s*error: (?:\S+\.c:\d+:)?unknown filesystem'
     fixes:
       - "The /boot filesystem is corrupt or an unsupported type - check it from rescue mode: sudo fsck -y /dev/sdX (run on the unmounted partition)"
       - "Reinstall GRUB after repairing the filesystem: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
@@ -138,7 +150,7 @@ patterns:
     regex:
       # Bound to a grub_ symbol name (e.g. grub_calloc) so it cannot match
       # linker/loader errors from other programs.
-      - '^\s*error: symbol .?grub_\w+.? not found'
+      - '^\s*error: (?:\S+\.c:\d+:)?symbol .?grub_\w+.? not found'
     fixes:
       - "A GRUB package upgrade updated the modules without reinstalling the core image (version skew) - reinstall from rescue mode: sudo chroot /mnt/sysroot, then grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"
       - "Regenerate the config afterwards: update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
@@ -150,7 +162,7 @@ patterns:
       # The 'error:' line-start prefix is REQUIRED here: without it this
       # would collide with kernel OOM output ('Out of memory: Killed
       # process ...'), which is always timestamp-prefixed.
-      - '^\s*error: out of memory'
+      - '^\s*error: (?:\S+\.c:\d+:)?out of memory'
     fixes:
       - "Usually caused by an oversized initrd - rebuild it from rescue mode: sudo chroot /mnt/sysroot, then update-initramfs -u (Debian-family) or dracut -f (RHEL-family)"
       - "Check the initrd size on the mounted disk: ls -lh /mnt/sysroot/boot/init*"
@@ -159,8 +171,8 @@ patterns:
     severity: critical
     description: "GRUB rejected a corrupt kernel or module image (invalid magic number)"
     regex:
-      - '^\s*error: invalid magic number'
-      - '^\s*error: invalid arch-independent ELF magic'
+      - '^\s*error: (?:\S+\.c:\d+:)?invalid magic number'
+      - '^\s*error: (?:\S+\.c:\d+:)?invalid arch-independent ELF magic'
     fixes:
       - "The kernel image or a GRUB module is corrupt (wrong-arch or truncated file) - reinstall the kernel from a chroot: sudo chroot /mnt/sysroot apt-get install --reinstall linux-image-amd64 (Debian-family) or dnf reinstall kernel-core (RHEL-family)"
       - "Reinstall GRUB if modules are corrupt: grub-install /dev/sdX (Debian-family) or grub2-install /dev/sdX (RHEL-family)"

--- a/gce_rescue_v2/core/diagnose_rules/initramfs.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/initramfs.yaml
@@ -7,12 +7,34 @@ fix_guidance: "chroot into /mnt/sysroot and rebuild the initramfs: dracut -f (RH
 # (including fstab). Flip to true in the same commit that adds the script.
 auto_repair: false
 
+# Distro dialects covered here:
+#   dracut (RHEL/Rocky/Alma/CentOS/SLES): dracut-initqueue warnings,
+#     dracut: FATAL:, the rdsosreport/dracut:/# emergency shell.
+#   BusyBox initramfs-tools (Debian/Ubuntu): ALERT! ... Dropping to a
+#     shell!, 'Gave up waiting for root ...', the (initramfs) prompt.
+#
+# Overlap contract with fstab.yaml:
+#   fstab_emergency_mode owns the generic 'Entering emergency mode' /
+#   'You are in emergency mode' strings — dracut patterns below anchor
+#   ONLY on dracut-specific strings (rdsosreport.txt, dracut:/#,
+#   dracut-initqueue) so the same emergency line never matches twice.
+#   When both fire on a dracut buffer, Tier-1 dedupe in core/diagnosis.py
+#   demotes the fstab_emergency_mode catch-all in favor of the dracut
+#   root-cause finding. '/sysroot' mount/dependency failures belong HERE
+#   (initrd stage), and fstab.yaml carves them out with (?!sysroot).
+
 patterns:
   - name: initramfs_no_root_fs
     severity: critical
     description: "Kernel cannot mount the root filesystem (missing or corrupt initramfs)"
     regex:
       - 'VFS: Unable to mount root fs on unknown-block'
+      # Non-panic form printed just before the panic (or alone when the
+      # kernel keeps retrying). Does not interact with the
+      # kernel_panic_generic lookahead: that lookahead only guards the
+      # 'Kernel panic - not syncing' line itself, which is a separate
+      # serial line from this one.
+      - 'VFS: Cannot open root device'
     fixes:
       - "Enter the rescued VM and chroot into the original disk: sudo chroot /mnt/sysroot"
       - "Rebuild the initramfs: dracut -f (RHEL-family) or update-initramfs -u -k VERSION (Debian-family)"
@@ -29,9 +51,99 @@ patterns:
     description: "Initramfs image failed to load or unpack"
     regex:
       - 'Initramfs unpacking failed: junk \S+ compressed archive'
+      - 'Initramfs unpacking failed: invalid magic'
       - 'Failed to load initramfs'
+      # Bound to initr(d|amfs) on the same line so a generic 'Failed to
+      # decompress' from an unrelated subsystem can never match.
+      - 'Failed to decompress [^\n]*initr(?:d|amfs)'
     fixes:
       - "If the VM boots normally despite this message, it is likely benign (microcode cpio padding on some kernels) - no action needed"
       - "If boot fails: rebuild the initramfs from rescue mode: sudo chroot /mnt/sysroot, then dracut -f (RHEL-family) or update-initramfs -u -k VERSION (Debian-family)"
       - "Check free space on the boot partition before rebuilding: df -h /mnt/sysroot/boot"
       - "Regenerate the GRUB config after rebuilding: grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family) or update-grub (Debian-family)"
+
+  - name: initramfs_dracut_timeout
+    severity: critical
+    description: "dracut timed out waiting for the root device (RHEL-family initramfs)"
+    regex:
+      # Rocky/RHEL 9 live capture wording: 'dracut-initqueue[550]:
+      # Warning: dracut-initqueue timeout - starting timeout scripts'.
+      - 'dracut-initqueue\[\d+\]:.*timeout'
+      - 'dracut-initqueue\[\d+\]: Warning: Could not boot'
+      # Device-wait warning for by-uuid/by-label/by-path devices.
+      # /dev/mapper/* is carved out (owned by lvm.yaml) and /dev/sdX is
+      # carved out (owned by initramfs_nvme_device_rename below) so one
+      # warning line never produces two findings.
+      - 'dracut-initqueue\[\d+\]: Warning: /dev/(?!mapper/|sd[a-z])\S+ does not exist'
+    fixes:
+      - "The device named in the 'does not exist' warning is the one dracut cannot find - compare it against real devices from rescue mode: sudo blkid"
+      - "If the root UUID changed (disk restored/cloned), fix root= in the BLS entries: sudo chroot /mnt/sysroot, then grubby --update-kernel=ALL --args=root=UUID=NEW_UUID"
+      - "If a storage driver is missing from the initramfs, rebuild it: sudo chroot /mnt/sysroot, then dracut -f"
+
+  - name: initramfs_dracut_fatal
+    severity: critical
+    description: "dracut hit a fatal error inside the initramfs (RHEL-family)"
+    regex:
+      - 'dracut: FATAL:'
+      - 'dracut: Refusing to continue'
+    fixes:
+      - "Read the text after 'dracut: FATAL:' in the serial output - it names the exact failure (missing root, FIPS check, broken module)"
+      - "Rebuild the initramfs from rescue mode: sudo chroot /mnt/sysroot, then dracut -f"
+      - "Verify the root= kernel parameter matches a real device: sudo blkid vs the kernel command line in the serial output"
+
+  - name: initramfs_dracut_emergency
+    severity: critical
+    description: "Boot dropped into the dracut emergency shell (RHEL-family initramfs)"
+    regex:
+      # Anchored ONLY on dracut-specific strings: the generic 'Entering
+      # emergency mode' line on the same screen belongs to
+      # fstab_emergency_mode (see the overlap contract above).
+      - 'Generating "/run/initramfs/rdsosreport\.txt"'
+      - 'dracut:/#'
+      - 'Starting Dracut Emergency Shell'
+    fixes:
+      - "Review the dracut-initqueue warnings above this line in the serial output - they name the device dracut could not find"
+      - "Enter rescue mode and inspect the root filesystem and /mnt/sysroot/etc/fstab"
+      - "Rebuild the initramfs if drivers/config changed: sudo chroot /mnt/sysroot, then dracut -f"
+
+  - name: initramfs_busybox_shell
+    severity: critical
+    description: "Boot dropped into the BusyBox initramfs shell (Debian-family)"
+    regex:
+      - 'ALERT!.*does not exist.*Dropping to a shell'
+      - 'Gave up waiting for root (?:file system|device)'
+      # The bare BusyBox prompt line. [ \t]*$ (not \s*$) so the match can
+      # never swallow the trailing newline into detected_pattern.
+      - '^\(initramfs\)[ \t]*$'
+    fixes:
+      - "The ALERT! line names the root device the initramfs cannot find - compare it against real devices from rescue mode: sudo blkid"
+      - "If the root UUID changed, fix the root= parameter: sudo chroot /mnt/sysroot, then edit /etc/default/grub and run update-grub"
+      - "If a storage driver is missing from the initramfs, rebuild it: sudo chroot /mnt/sysroot, then update-initramfs -u"
+
+  - name: initramfs_sysroot_mount_failed
+    severity: critical
+    description: "initrd could not mount the real root filesystem at /sysroot (RHEL-family)"
+    regex:
+      # The single most common RHEL boot-failure form: systemd inside the
+      # initrd fails sysroot.mount. Distinct wording from the running
+      # system's fstab failures (fstab.yaml excludes /sysroot).
+      - 'Failed to mount /sysroot'
+      - 'Dependency failed for /sysroot'
+      - 'Dependency failed for Initrd Root File System'
+    fixes:
+      - "Check the kernel/mount error just above this line in the serial output (bad UUID, corrupt filesystem, unknown filesystem type)"
+      - "Verify the root filesystem from rescue mode: sudo blkid, then fsck -y /dev/sdX (ext4) or xfs_repair /dev/sdX (XFS) on the unmounted disk"
+      - "If root= points at the wrong UUID, fix the BLS entries: sudo chroot /mnt/sysroot, then grubby --update-kernel=ALL --args=root=UUID=NEW_UUID"
+
+  - name: initramfs_nvme_device_rename
+    severity: critical
+    description: "Root disk referenced by legacy /dev/sdX name that no longer exists (NVMe machine family)"
+    regex:
+      # GCE NVMe machine families (C3, C3D, H3, M3, ...) expose Persistent
+      # Disks as /dev/nvme0n1, so an image carrying root=/dev/sdaN or bare
+      # /dev/sdX fstab entries stops booting after a machine-type change.
+      - 'dracut-initqueue\[\d+\]: Warning: /dev/sd[a-z]\d* does not exist'
+    fixes:
+      - "This VM's machine family (C3/C3D/H3/M3 and newer) exposes disks as NVMe (/dev/nvme0n1) - the /dev/sdX name in the boot config no longer exists"
+      - "Switch root= and /etc/fstab to UUID references from rescue mode: sudo blkid to get the UUID, then sudo chroot /mnt/sysroot and grubby --update-kernel=ALL --args=root=UUID=REAL_UUID (RHEL-family) or edit /etc/default/grub + update-grub (Debian-family)"
+      - "Alternatively, move the VM back to a SCSI machine family (e.g. e2/n2) to boot, then convert the config to UUIDs"

--- a/gce_rescue_v2/core/diagnose_rules/initramfs.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/initramfs.yaml
@@ -1,0 +1,37 @@
+category: initramfs
+fix_guidance: "chroot into /mnt/sysroot and rebuild the initramfs: dracut -f (RHEL-family) or update-initramfs -u -k VERSION (Debian-family), then regenerate the GRUB config"
+# auto_repair MUST stay false until startup_scripts/fixes/initramfs_fix.sh
+# lands. RepairOrchestrator.validate() checks that every category in
+# SUPPORTED_FIX_CATEGORIES has a fix script, so flipping this to true
+# without the script makes `repair` fail preflight for ALL categories
+# (including fstab). Flip to true in the same commit that adds the script.
+auto_repair: false
+
+patterns:
+  - name: initramfs_no_root_fs
+    severity: critical
+    description: "Kernel cannot mount the root filesystem (missing or corrupt initramfs)"
+    regex:
+      - 'VFS: Unable to mount root fs on unknown-block'
+    fixes:
+      - "Enter the rescued VM and chroot into the original disk: sudo chroot /mnt/sysroot"
+      - "Rebuild the initramfs: dracut -f (RHEL-family) or update-initramfs -u -k VERSION (Debian-family)"
+      - "Regenerate the GRUB config: grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family) or update-grub (Debian-family)"
+      - "Verify the root= kernel parameter points to an existing device or UUID"
+
+  # severity: error (not critical) — "junk in/within compressed archive"
+  # is benign on some kernels (~5.4-5.15) when the initrd is a microcode
+  # cpio concatenated with the main archive (boot proceeds normally).
+  # The unambiguous failure is initramfs_no_root_fs above; this pattern
+  # alone, without a following VFS panic, may be noise.
+  - name: initramfs_load_failure
+    severity: error
+    description: "Initramfs image failed to load or unpack"
+    regex:
+      - 'Initramfs unpacking failed: junk \S+ compressed archive'
+      - 'Failed to load initramfs'
+    fixes:
+      - "If the VM boots normally despite this message, it is likely benign (microcode cpio padding on some kernels) - no action needed"
+      - "If boot fails: rebuild the initramfs from rescue mode: sudo chroot /mnt/sysroot, then dracut -f (RHEL-family) or update-initramfs -u -k VERSION (Debian-family)"
+      - "Check free space on the boot partition before rebuilding: df -h /mnt/sysroot/boot"
+      - "Regenerate the GRUB config after rebuilding: grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family) or update-grub (Debian-family)"

--- a/gce_rescue_v2/core/diagnose_rules/kernel.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/kernel.yaml
@@ -26,6 +26,12 @@ patterns:
       #                  / "compulsory panic_on_oom is enabled" (sysctl=2)
       - 'Kernel panic - not syncing: [Oo]ut of memory'
       - 'panic_on_oom is (?:selected|enabled)'
+      # mm/oom_kill.c panics with this wording when no killable process
+      # remains (red-team C4) - it is an OOM panic, and classifying it
+      # as generic gave reset/previous-kernel fixes instead of
+      # resize/panic_on_oom guidance. Mirrored in the
+      # kernel_panic_generic lookahead exclusions below.
+      - 'Kernel panic - not syncing: System is deadlocked on memory'
     fixes:
       - "Identify the memory-hungry process in the serial output (Out of memory: Killed process ...)"
       - "Resize the VM to a larger machine type: gcloud compute instances set-machine-type VM_NAME --zone=ZONE --machine-type=NEW_TYPE (VM must be stopped)"
@@ -150,7 +156,7 @@ patterns:
     severity: critical
     description: "Kernel panic detected (unspecified cause)"
     regex:
-      - 'Kernel panic - not syncing(?!.*(?:hung_task: blocked tasks|[Oo]ut of memory|panic_on_oom is (?:selected|enabled)|Fatal Machine check|NMI: Not continuing|VFS: Unable to mount root fs on unknown-block|Attempted to kill init|No working init found|No init found\.\s*Try passing init=))'
+      - 'Kernel panic - not syncing(?!.*(?:hung_task: blocked tasks|[Oo]ut of memory|panic_on_oom is (?:selected|enabled)|System is deadlocked on memory|Fatal Machine check|NMI: Not continuing|VFS: Unable to mount root fs on unknown-block|Attempted to kill init|No working init found|No init found\.\s*Try passing init=))'
     fixes:
       - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
       - "Boot a previous kernel from the GRUB menu via the interactive serial console"

--- a/gce_rescue_v2/core/diagnose_rules/kernel.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/kernel.yaml
@@ -1,0 +1,73 @@
+category: kernel
+# Detect-only category: kernel panics require manual investigation
+# (reset the VM, pick a previous kernel from GRUB, read the backtrace).
+# fix_guidance is intentionally guidance text, not a single command.
+fix_guidance: "Reset the VM and select a previous kernel from the GRUB menu via the serial console; investigate the panic backtrace in the serial output"
+auto_repair: false
+
+patterns:
+  - name: kernel_panic_hung_task
+    severity: critical
+    description: "Kernel panic caused by hung (blocked) tasks"
+    regex:
+      - 'Kernel panic - not syncing: hung_task: blocked tasks'
+    fixes:
+      - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
+      - "If panics persist, boot a previous kernel from the GRUB menu via the interactive serial console"
+      - "Review the serial output for blocked task backtraces (INFO: task ... blocked) to identify stuck I/O or workload"
+
+  - name: kernel_panic_oom
+    severity: critical
+    description: "Kernel panic due to out of memory (panic_on_oom)"
+    regex:
+      # Pre-4.x kernels: "out of memory. panic_on_oom is selected"
+      # Modern kernels:  "Out of memory: system-wide panic_on_oom is enabled"
+      #                  / "compulsory panic_on_oom is enabled" (sysctl=2)
+      - 'Kernel panic - not syncing: [Oo]ut of memory'
+      - 'panic_on_oom is (?:selected|enabled)'
+    fixes:
+      - "Identify the memory-hungry process in the serial output (Out of memory: Killed process ...)"
+      - "Resize the VM to a larger machine type: gcloud compute instances set-machine-type VM_NAME --zone=ZONE --machine-type=NEW_TYPE (VM must be stopped)"
+      - "If panic-on-OOM is not intended, set vm.panic_on_oom=0 in /etc/sysctl.conf"
+
+  - name: kernel_panic_machine_check
+    severity: critical
+    description: "Kernel panic due to a fatal machine check (hardware error)"
+    regex:
+      - 'Kernel panic - not syncing: Fatal Machine check'
+    fixes:
+      - "This usually indicates a host hardware error - stop and start the VM to move it to a different host"
+      - "Stop: gcloud compute instances stop VM_NAME --zone=ZONE, then start: gcloud compute instances start VM_NAME --zone=ZONE"
+      - "If the panic repeats, contact Google Cloud Support with the serial console output"
+
+  - name: kernel_panic_nmi
+    severity: critical
+    description: "Kernel panic triggered by a non-maskable interrupt (NMI)"
+    regex:
+      - 'Kernel panic - not syncing: NMI: Not continuing'
+    fixes:
+      - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
+      - "If NMI panics repeat, stop and start the VM to move it to a different host"
+      - "Check for unknown_nmi_panic or panic-on-NMI settings in kernel parameters"
+
+  # Catch-all for panics not matched by the specific patterns above.
+  # The negative lookahead prevents double-reporting the same panic line:
+  # the engine only dedupes identical (category, description) pairs, so
+  # without the lookahead both a specific pattern and this generic one
+  # would be reported. Also excludes 'VFS: Unable to mount root fs on
+  # unknown-block' panics, which belong to the initramfs category.
+  #
+  # INVARIANT: every exclusion term below must mirror the positive regex
+  # of the pattern it defers to (here or in initramfs.yaml). An exclusion
+  # broader than its positive creates a silent hole where a real panic
+  # matches nothing and the VM reports healthy. Guarded by
+  # test_diagnose.py::TestKernelPanicDetection exclusion-drift tests.
+  - name: kernel_panic_generic
+    severity: critical
+    description: "Kernel panic detected (unspecified cause)"
+    regex:
+      - 'Kernel panic - not syncing(?!.*(?:hung_task: blocked tasks|[Oo]ut of memory|panic_on_oom is (?:selected|enabled)|Fatal Machine check|NMI: Not continuing|VFS: Unable to mount root fs on unknown-block))'
+    fixes:
+      - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
+      - "Boot a previous kernel from the GRUB menu via the interactive serial console"
+      - "Review the full panic backtrace in the serial output to identify the failing module or driver"

--- a/gce_rescue_v2/core/diagnose_rules/kernel.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/kernel.yaml
@@ -51,23 +51,89 @@ patterns:
       - "If NMI panics repeat, stop and start the VM to move it to a different host"
       - "Check for unknown_nmi_panic or panic-on-NMI settings in kernel parameters"
 
+  - name: kernel_attempted_kill_init
+    severity: critical
+    description: "Kernel panic: init (PID 1) died (Attempted to kill init)"
+    regex:
+      # "Kernel panic - not syncing: Attempted to kill init! exitcode=0x..."
+      # PID 1 crashed or exited - broken init/systemd binary, missing
+      # libraries, or a run-init exec failure inside the initramfs (the
+      # switchroot category catches the companion run-init line).
+      # Mirrored in the kernel_panic_generic lookahead exclusions below.
+      - 'Kernel panic - not syncing: Attempted to kill init'
+    fixes:
+      - "PID 1 (init/systemd) crashed or exited - check the lines just above the panic for the init error (run-init: can't execute, error while loading shared libraries, segfault)"
+      - "Verify init on the mounted disk from rescue mode: ls -l /mnt/sysroot/sbin/init and sudo chroot /mnt/sysroot ldd /sbin/init"
+      - "Reinstall systemd via chroot if broken: sudo chroot /mnt/sysroot apt-get install --reinstall systemd systemd-sysv (Debian-family) or dnf reinstall systemd (RHEL-family)"
+
+  # severity: error, not critical — a BUG/Oops is fatal only for the
+  # faulting task; the machine often keeps running (panic follows only
+  # with panic_on_oops or when the fault is in a critical path, and that
+  # panic line is reported separately by the panic patterns).
+  - name: kernel_bug_oops
+    severity: error
+    description: "Kernel BUG or Oops (crash in kernel code)"
+    regex:
+      - 'BUG: unable to handle kernel'
+      # Real form is always "kernel BUG at <file>:<line>!" (e.g. fs/ext4/
+      # inode.c:1234). The engine is IGNORECASE, so require the :<line>
+      # suffix - prose like "a kernel bug at startup" can never match.
+      - 'kernel BUG at [\w/.-]+:\d+'
+      # Oops header: "Oops: 0002 [#1] SMP PTI". Bound tightly - the line
+      # must start with an optional kernel timestamp then 'Oops: ' and a
+      # 4-digit error code, because bare 'Oops' appears in ordinary log
+      # prose and application output.
+      - '^(?:\[[\d\. ]+\] ?)?Oops: \d{4}'
+    fixes:
+      - "Read the Oops/BUG block in the serial output - RIP: names the failing kernel function and the module list shows what was loaded"
+      - "If the fault repeats, boot a previous kernel from the GRUB menu via the interactive serial console"
+      - "Report the backtrace to the distro/kernel vendor if it reproduces on current kernels"
+
+  - name: kernel_decompress_fail
+    severity: critical
+    description: "Kernel image failed to decompress (corrupt vmlinuz)"
+    regex:
+      # Same-line binding: the healthy boot line 'Decompressing Linux...
+      # Parsing ELF... done.' contains neither 'failed' nor 'error', so
+      # only an actual decompressor failure on that line can match.
+      - 'Decompressing Linux\.\.\.[^\n]*(?:failed|error)'
+      # Decompressor self-reports: "XZ-compressed data is corrupt".
+      - '(?:XZ|LZ4|ZSTD|gzip)[- ]compressed data is corrupt'
+      # The decompression stub halts with the literal line '-- System
+      # halted'. It cannot be bound to a decompression context: the stub
+      # prints the corruption message and this line with nothing usable
+      # in between, and on some failures '-- System halted' is the ONLY
+      # output. Anchoring is instead structural - the line-start '-- '
+      # prefix is unique to the boot stub; the kernel's ordinary shutdown
+      # message is 'System halted.' with no dashes, which cannot match.
+      # Severity stays critical: when this line appears the VM is
+      # unbootable by definition (the stub halted the CPU).
+      - '^\s*-- System halted'
+    fixes:
+      - "The kernel image (vmlinuz) is corrupt or truncated - reinstall it from rescue mode via chroot: sudo chroot /mnt/sysroot apt-get install --reinstall linux-image-amd64 (Debian-family) or dnf reinstall kernel-core (RHEL-family)"
+      - "Check /boot for disk-full or filesystem damage before reinstalling: df -h /mnt/sysroot/boot and fsck -y on the unmounted /boot partition"
+      - "Regenerate the GRUB config after reinstalling: update-grub (Debian-family) or grub2-mkconfig -o /boot/grub2/grub.cfg (RHEL-family)"
+
   # Catch-all for panics not matched by the specific patterns above.
   # The negative lookahead prevents double-reporting the same panic line:
   # the engine only dedupes identical (category, description) pairs, so
   # without the lookahead both a specific pattern and this generic one
   # would be reported. Also excludes 'VFS: Unable to mount root fs on
-  # unknown-block' panics, which belong to the initramfs category.
+  # unknown-block' panics, which belong to the initramfs category, and
+  # the no-init panics ('No working init found', 'No init found. Try
+  # passing init='), which belong to switchroot_no_init in switchroot.yaml.
   #
   # INVARIANT: every exclusion term below must mirror the positive regex
-  # of the pattern it defers to (here or in initramfs.yaml). An exclusion
-  # broader than its positive creates a silent hole where a real panic
-  # matches nothing and the VM reports healthy. Guarded by
-  # test_diagnose.py::TestKernelPanicDetection exclusion-drift tests.
+  # of the pattern it defers to (here, in initramfs.yaml or in
+  # switchroot.yaml). An exclusion broader than its positive creates a
+  # silent hole where a real panic matches nothing and the VM reports
+  # healthy. Guarded by test_diagnose.py::TestKernelPanicDetection
+  # exclusion-drift tests.
   - name: kernel_panic_generic
     severity: critical
     description: "Kernel panic detected (unspecified cause)"
     regex:
-      - 'Kernel panic - not syncing(?!.*(?:hung_task: blocked tasks|[Oo]ut of memory|panic_on_oom is (?:selected|enabled)|Fatal Machine check|NMI: Not continuing|VFS: Unable to mount root fs on unknown-block))'
+      - 'Kernel panic - not syncing(?!.*(?:hung_task: blocked tasks|[Oo]ut of memory|panic_on_oom is (?:selected|enabled)|Fatal Machine check|NMI: Not continuing|VFS: Unable to mount root fs on unknown-block|Attempted to kill init|No working init found|No init found\.\s*Try passing init=))'
     fixes:
       - "Reset the VM: gcloud compute instances reset VM_NAME --zone=ZONE"
       - "Boot a previous kernel from the GRUB menu via the interactive serial console"

--- a/gce_rescue_v2/core/diagnose_rules/kernel.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/kernel.yaml
@@ -99,6 +99,11 @@ patterns:
       - 'Decompressing Linux\.\.\.[^\n]*(?:failed|error)'
       # Decompressor self-reports: "XZ-compressed data is corrupt".
       - '(?:XZ|LZ4|ZSTD|gzip)[- ]compressed data is corrupt'
+      # Live-validated on GCE (2026-07, Debian 12 UEFI, zstd kernel with
+      # corrupted payload): the EFI stub prints only 'Decoding failed'
+      # followed by ' -- System halted' - no 'Decompressing Linux...'
+      # line and no '*-compressed data is corrupt' message appear on the
+      # UEFI boot path, so this anchor is the pattern that fires there.
       # The decompression stub halts with the literal line '-- System
       # halted'. It cannot be bound to a decompression context: the stub
       # prints the corruption message and this line with nothing usable

--- a/gce_rescue_v2/core/diagnose_rules/kernel.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/kernel.yaml
@@ -84,6 +84,18 @@ patterns:
       # 4-digit error code, because bare 'Oops' appears in ordinary log
       # prose and application output.
       - '^(?:\[[\d\. ]+\] ?)?Oops: \d{4}'
+      # arm64 (T2A) Oops header: 'Internal error: Oops: 96000004 [#1]
+      # PREEMPT SMP' - the arm64 fault path prefixes 'Internal error: ',
+      # so the line-anchored x86 regex above never matches it.
+      - 'Internal error: Oops'
+      # Modern x86 (>= 5.1) page-fault header dropped the 'kernel' word:
+      # 'BUG: unable to handle page fault for address: ...'
+      - 'BUG: unable to handle page fault for address'
+      # arm64 fault header has no 'BUG:' prefix at all: 'Unable to handle
+      # kernel NULL pointer dereference at virtual address ...' /
+      # 'Unable to handle kernel paging request at ...'. Kernel-only
+      # wording - no prose collision (WARN_ON traces match none of these).
+      - 'Unable to handle kernel (?:NULL pointer dereference|paging request)'
     fixes:
       - "Read the Oops/BUG block in the serial output - RIP: names the failing kernel function and the module list shows what was loaded"
       - "If the fault repeats, boot a previous kernel from the GRUB menu via the interactive serial console"

--- a/gce_rescue_v2/core/diagnose_rules/kernel.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/kernel.yaml
@@ -2,6 +2,7 @@ category: kernel
 # Detect-only category: kernel panics require manual investigation
 # (reset the VM, pick a previous kernel from GRUB, read the backtrace).
 # fix_guidance is intentionally guidance text, not a single command.
+detect_only: true
 fix_guidance: "Reset the VM and select a previous kernel from the GRUB menu via the serial console; investigate the panic backtrace in the serial output"
 auto_repair: false
 

--- a/gce_rescue_v2/core/diagnose_rules/lvm.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/lvm.yaml
@@ -1,0 +1,46 @@
+# LVM activation failures (RHEL/enterprise images with LVM root).
+#
+# Ownership contract: device-mapper (/dev/mapper/*, dev-mapper-*) wait
+# failures live HERE, not in fstab.yaml (which carves them out with
+# (?!mapper)) and not in initramfs.yaml (whose dracut does-not-exist
+# regex excludes /dev/mapper/).
+category: lvm
+fix_guidance: "from the rescue VM scan and activate the volume group (sudo vgscan; sudo vgchange -ay), mount the logical volume at /mnt/sysroot, then rebuild the initramfs (dracut -f) if LVM config changed"
+# auto_repair stays false until startup_scripts/fixes/lvm_fix.sh exists.
+auto_repair: false
+
+patterns:
+  - name: lvm_vg_not_found
+    severity: critical
+    description: "LVM volume group not found during boot"
+    regex:
+      - 'Volume group "\S+" not found'
+      - 'Cannot process volume group'
+    fixes:
+      - "From rescue mode, scan for volume groups: sudo vgscan --mknodes, then sudo vgchange -ay"
+      - "If the VG metadata is damaged, list backups on the mounted disk (/mnt/sysroot/etc/lvm/backup) and restore: sudo vgcfgrestore VG_NAME"
+      - "Verify the physical volume is present: sudo pvs; if the PV disk is missing, reattach it or restore from a snapshot"
+
+  - name: lvm_device_timeout
+    severity: critical
+    description: "Timed out waiting for an LVM (device-mapper) device"
+    regex:
+      # Escaped systemd unit form: dev-mapper-vg\x2droot.device
+      - 'Timed out waiting for device [^\n]*dev-mapper'
+      - 'Timed out waiting for device /dev/mapper/\S+'
+    fixes:
+      - "The logical volume never appeared - activate it from rescue mode: sudo vgscan; sudo vgchange -ay, then inspect /mnt/sysroot/etc/fstab"
+      - "If the LV was removed or renamed, fix or comment out its /etc/fstab entry"
+
+  - name: lvm_dracut_device_missing
+    severity: critical
+    description: "dracut cannot find the LVM root device (volume group not activated)"
+    regex:
+      # /dev/mapper/* only: the VG-path form (/dev/<vg>/<lv>) cannot be
+      # distinguished from arbitrary device paths without knowing VG
+      # names, and the initramfs dracut pattern already reports those.
+      - 'Warning: /dev/mapper/\S+ does not exist'
+    fixes:
+      - "The LVM root was not activated inside the initramfs - from rescue mode run: sudo vgscan; sudo vgchange -ay and verify the LV exists (sudo lvs)"
+      - "Rebuild the initramfs so it includes the LVM tools/config: sudo chroot /mnt/sysroot, then dracut -f"
+      - "Check rd.lvm.lv= kernel arguments match the real VG/LV names: compare the kernel command line in the serial output with sudo lvs"

--- a/gce_rescue_v2/core/diagnose_rules/machine_id.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/machine_id.yaml
@@ -1,0 +1,18 @@
+# Missing/unreadable /etc/machine-id (badly cloned images) - cascades
+# into dbus/systemd unit failures. Boot usually continues with a
+# transient ID, so on a healthy completed boot these findings are
+# cleared by boot-success suppression (no survives_boot_success).
+category: machine_id
+fix_guidance: "chroot into /mnt/sysroot and regenerate the machine ID: rm -f /etc/machine-id && systemd-machine-id-setup (also remove /var/lib/dbus/machine-id if it is a stale copy)"
+auto_repair: false
+
+patterns:
+  - name: machine_id_missing
+    severity: error
+    description: "/etc/machine-id is missing or unreadable"
+    regex:
+      - 'Failed to (?:read|open) [^\n]{0,60}machine.id'
+      - 'Could not get machine ID'
+    fixes:
+      - "Regenerate from rescue mode: sudo chroot /mnt/sysroot, then rm -f /etc/machine-id && systemd-machine-id-setup"
+      - "If /var/lib/dbus/machine-id exists as a stale copy, remove it too and let dbus recreate the symlink"

--- a/gce_rescue_v2/core/diagnose_rules/network.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/network.yaml
@@ -1,0 +1,57 @@
+# Network bring-up failure patterns (Stage 8, mode 46) - the noisiest FP
+# space in the taxonomy, so every regex is bound to a network unit name or
+# a DHCP-client-unique phrase; there is deliberately NO generic
+# 'Failed to bring up'/'link down' matching.
+#
+# survives_boot_success: false (DELIBERATE - reasoned, not defaulted):
+#   - Errors BEFORE the last boot-success marker are transient bring-up
+#     flaps that recovered (DHCP retried and got a lease, or the unit was
+#     restarted) - exactly the noise that suppression exists to clear.
+#   - The real support case - a NIC that died POST-boot - is still always
+#     reported: its error lines sit AFTER the last success marker, so the
+#     engine's ordering check (last_success_pos > last_error_pos) fails
+#     and nothing is suppressed. The flag is only reachable by pre-marker
+#     errors, and those are the recovered ones.
+category: network
+fix_guidance: "From rescue mode, inspect the network config on the mounted disk (/mnt/sysroot/etc/netplan/, /mnt/sysroot/etc/network/interfaces, /mnt/sysroot/etc/sysconfig/network-scripts/ or NetworkManager system-connections) and revert the most recent change"
+auto_repair: false
+
+patterns:
+  # JUSTIFICATION vs the no-generic-'Failed to start' rule (see
+  # systemd_early.yaml): each alternative is bound to a specific network
+  # manager unit name or description - none of the benign healthy-boot
+  # unit failures (apt-daily, fwupd, motd-news...) can match.
+  - name: network_unit_failed
+    severity: error
+    description: "A core network service failed to start"
+    regex:
+      - 'Failed to start .*systemd-networkd'
+      # Unit description 'Network Manager' (with space) and unit name
+      # 'NetworkManager.service'.
+      - 'Failed to start .*Network ?Manager'
+      # Debian ifupdown: networking.service - 'Raise network interfaces'.
+      - 'Failed to start .*networking\.service'
+      - 'Failed to start .*Raise network interfaces'
+      # systemd-networkd-wait-online / cloud-init's network wait.
+      - 'Failed to start .*Wait for Network to be Configured'
+    fixes:
+      - "Read the unit's error lines just above this one in the serial log - they name the bad config file/stanza"
+      - "From rescue mode, validate the config on the mounted disk: netplan (sudo chroot /mnt/sysroot netplan generate), ifupdown (/etc/network/interfaces), or NetworkManager connection files"
+      - "Revert the most recently changed network config file and restore the VM"
+
+  - name: network_dhcp_failure
+    severity: error
+    description: "DHCP failed - the interface did not obtain a lease"
+    regex:
+      # dhclient's give-up line; wording unique to ISC dhclient.
+      - 'No DHCPOFFERS received'
+      # ifupdown/dhclient companion: 'ifup: failed to bring up eth0'.
+      # Bound to real GCE interface name prefixes so prose about
+      # "bringing up" services can't match.
+      - '[Ff]ailed to bring up (?:eth|ens|enp)\d'
+      # google-guest-agent / netplan wording.
+      - 'Could not bring up interface'
+    fixes:
+      - "On GCE the metadata server always answers DHCP - a missing lease means the guest's network stack is broken (bad MTU/MAC config, wrong interface name, or a firewall in the guest), not the VPC"
+      - "Check for renamed interfaces: a config pinned to eth0 breaks if the image switched to predictable names (ens4) - update the config or add net.ifnames=0 to the kernel command line"
+      - "From rescue mode, revert recent changes under /mnt/sysroot/etc/netplan/ or /mnt/sysroot/etc/network/"

--- a/gce_rescue_v2/core/diagnose_rules/network.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/network.yaml
@@ -25,19 +25,40 @@ patterns:
     severity: error
     description: "A core network service failed to start"
     regex:
-      - 'Failed to start .*systemd-networkd'
+      # (?!-wait-online): the wait-online unit's NAME contains
+      # 'systemd-networkd', but its failure is a benign timeout, not a
+      # networkd failure - it gets its own warning pattern below
+      # (red-team C2).
+      - 'Failed to start .*systemd-networkd(?!-wait-online)'
       # Unit description 'Network Manager' (with space) and unit name
       # 'NetworkManager.service'.
       - 'Failed to start .*Network ?Manager'
       # Debian ifupdown: networking.service - 'Raise network interfaces'.
       - 'Failed to start .*networking\.service'
       - 'Failed to start .*Raise network interfaces'
-      # systemd-networkd-wait-online / cloud-init's network wait.
-      - 'Failed to start .*Wait for Network to be Configured'
     fixes:
       - "Read the unit's error lines just above this one in the serial log - they name the bad config file/stanza"
       - "From rescue mode, validate the config on the mounted disk: netplan (sudo chroot /mnt/sysroot netplan generate), ifupdown (/etc/network/interfaces), or NetworkManager connection files"
       - "Revert the most recently changed network config file and restore the VM"
+
+  # WARNING, not error (red-team C2): wait-online timing out is a
+  # well-known benign event - boot continues and SSH works; the usual
+  # cause is an unmanaged/secondary NIC that never reaches 'configured',
+  # not a network outage. Reporting it as a failed core network service
+  # sent support engineers chasing a non-issue on healthy stopped VMs.
+  - name: network_wait_online_timeout
+    severity: warning
+    description: "Waiting for network-online timed out (boot continued)"
+    regex:
+      # Unit name form ('systemd-networkd-wait-online.service') and the
+      # unit's description ('Wait for Network to be Configured') - the
+      # [FAILED] console line can print either or both.
+      - 'Failed to start .*systemd-networkd-wait-online'
+      - 'Failed to start .*Wait for Network to be Configured'
+    fixes:
+      - "The network-online wait timed out but boot continued - this is usually an unmanaged or secondary NIC that never reports 'configured', not a network outage"
+      - "If units that depend on network-online.target misbehaved, check which interface held up the wait: networkctl list on the running VM"
+      - "To silence it for an intentionally unmanaged interface, mark it Unmanaged in networkd/netplan or drop the wait-online dependency"
 
   - name: network_dhcp_failure
     severity: error

--- a/gce_rescue_v2/core/diagnose_rules/oom.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/oom.yaml
@@ -43,8 +43,15 @@ patterns:
       # cgroup-scoped kills ("Memory cgroup out of memory: Killed process
       # ...") already match the first regex; the oom-kill summary line
       # (4.19+) is a distinct wording:
+      # DECISION (red-team C5): memcg/container kills DELIBERATELY still
+      # match - a regex-level exclusion is impossible (the 'invoked
+      # oom-killer: gfp_mask=' header is byte-identical for global and
+      # memcg kills) and a memcg kill can still be the customer's real
+      # problem. The container-vs-VM distinction is handled in the fixes
+      # text instead; WARNING + detect_only keeps this safe.
       - 'oom-kill:constraint='
     fixes:
       - "Find the OOM report block in the serial output - it names the killed process and the per-process memory table"
+      - "If the line says 'Memory cgroup out of memory' or constraint=CONSTRAINT_MEMCG, a container/cgroup hit its OWN memory limit - raise the container/pod limit instead of resizing the VM"
       - "Resize the VM to a larger machine type: gcloud compute instances set-machine-type VM_NAME --zone=ZONE --machine-type=NEW_TYPE (VM must be stopped)"
       - "Or reduce the workload's memory usage / add swap; if a critical service was killed, restart it or reboot the VM"

--- a/gce_rescue_v2/core/diagnose_rules/oom.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/oom.yaml
@@ -1,0 +1,50 @@
+# Out-of-memory killer patterns (mode 55 - live OOM without a panic).
+#
+# CONTRACT CHANGE (Wave 4, deliberate): before this file existed, OOM-killer
+# lines ('Out of memory: Killed process', 'invoked oom-killer') matched
+# NOTHING - they appeared only as context in kernel_panic_oom fixtures and
+# as proof that grub/disk_full anchors don't cross-fire. They now produce a
+# WARNING-severity oom finding. On a panic_on_oom buffer BOTH findings are
+# reported: oom (warning, the kill) and kernel_panic_oom (critical, the
+# panic). That is safe post-Wave-3: tier-1 dedupe suppressors require
+# CRITICAL severity and _is_boot_root_cause() excludes warnings and
+# detect-only categories, so this finding can never suppress or demote
+# anything.
+category: oom
+fix_guidance: "Identify the killed process in the serial output, then reduce its memory usage, add swap, or resize the VM: gcloud compute instances set-machine-type VM_NAME --zone=ZONE --machine-type=NEW_TYPE (VM must be stopped)"
+auto_repair: false
+# detect_only: there is nothing on the rescued disk to edit - OOM is a
+# workload/sizing condition; the remedy is a bigger machine type, swap, or
+# fixing the memory-hungry process. Rescue mode does not apply.
+detect_only: true
+# Runtime kills persist past boot: a long-running VM that OOM-killed a
+# process last week still has the evidence in its serial buffer, and a
+# "Startup finished" marker does not mean memory pressure is resolved.
+# Severity WARNING keeps this non-alarmist: a single historical kill on an
+# otherwise healthy VM is worth surfacing, not paging over.
+survives_boot_success: true
+
+patterns:
+  # One pattern (not one per line): the 'invoked oom-killer' and
+  # 'Out of memory: Killed process' lines are two halves of the SAME kill
+  # event, so they must produce a single finding, not two.
+  - name: oom_killed_process
+    severity: warning
+    description: "The kernel out-of-memory killer terminated a process (VM ran out of memory)"
+    regex:
+      # Modern kernels: "Out of memory: Killed process 1234 (java) ...";
+      # pre-4.6: "Out of memory: Kill process 1234 (java) score 500 or
+      # sacrifice child". Bound to the PID so prose can't match.
+      - 'Out of memory: Kill(?:ed)? process \d+'
+      # The invocation header: "java invoked oom-killer: gfp_mask=0x...".
+      # Bound to the gfp_mask= tail (always present) - 'invoked
+      # oom-killer' alone could be quoted in application logs.
+      - 'invoked oom-killer: gfp_mask='
+      # cgroup-scoped kills ("Memory cgroup out of memory: Killed process
+      # ...") already match the first regex; the oom-kill summary line
+      # (4.19+) is a distinct wording:
+      - 'oom-kill:constraint='
+    fixes:
+      - "Find the OOM report block in the serial output - it names the killed process and the per-process memory table"
+      - "Resize the VM to a larger machine type: gcloud compute instances set-machine-type VM_NAME --zone=ZONE --machine-type=NEW_TYPE (VM must be stopped)"
+      - "Or reduce the workload's memory usage / add swap; if a critical service was killed, restart it or reboot the VM"

--- a/gce_rescue_v2/core/diagnose_rules/raid.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/raid.yaml
@@ -25,6 +25,13 @@ patterns:
     regex:
       - 'mdadm: Unable to start array'
       - 'mdadm: failed to (?:start|run) array'
+      # Actual mdadm source wordings (verified against Assemble.c /
+      # Incremental.c): 'failed to RUN_ARRAY /dev/md0: ...' and the two
+      # degraded-assembly refusals '... - not enough to start the array.'
+      # (mdadm --assemble) / '... attached to /dev/md/0, not enough to
+      # start (1).' (udev incremental path used by modern boots).
+      - 'mdadm: failed to RUN_ARRAY'
+      - 'mdadm:[^\n]*not enough to start'
     fixes:
       - "From rescue mode, examine the members: sudo mdadm --examine /dev/sd[a-z]* and reassemble: sudo mdadm --assemble --scan --force"
       - "Update /mnt/sysroot/etc/mdadm.conf to match the real array UUIDs (sudo mdadm --detail --scan) and rebuild the initramfs"

--- a/gce_rescue_v2/core/diagnose_rules/raid.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/raid.yaml
@@ -1,0 +1,30 @@
+# mdadm / software-RAID assembly failures (custom images; low GCE volume
+# but zero coverage otherwise).
+category: raid
+fix_guidance: "from the rescue VM inspect the array (cat /proc/mdstat; sudo mdadm --detail /dev/mdX), force-run a degraded array if its data is acceptable (sudo mdadm --run /dev/mdX) or reassemble (sudo mdadm --assemble --force), then fix /mnt/sysroot/etc/mdadm.conf and rebuild the initramfs"
+# auto_repair stays false until startup_scripts/fixes/raid_fix.sh exists.
+auto_repair: false
+
+patterns:
+  - name: raid_dirty_degraded
+    severity: critical
+    description: "RAID array is dirty and degraded - kernel refused to start it"
+    regex:
+      - 'Cannot start dirty degraded array'
+      # Covers both 'not enough operational devices' (raid5/6) and
+      # 'not enough operational mirrors' (raid1) kernel wording.
+      - 'md/raid[^\n]{0,40}not enough operational'
+    fixes:
+      - "From rescue mode, check array state: cat /proc/mdstat and sudo mdadm --detail /dev/mdX"
+      - "If the remaining members are acceptable, force-start: sudo mdadm --run /dev/mdX (or sudo mdadm --assemble --force /dev/mdX member-devices...)"
+      - "Replace the failed member and re-add it: sudo mdadm --manage /dev/mdX --add /dev/sdY"
+
+  - name: raid_start_failed
+    severity: critical
+    description: "mdadm was unable to start a RAID array during boot"
+    regex:
+      - 'mdadm: Unable to start array'
+      - 'mdadm: failed to (?:start|run) array'
+    fixes:
+      - "From rescue mode, examine the members: sudo mdadm --examine /dev/sd[a-z]* and reassemble: sudo mdadm --assemble --scan --force"
+      - "Update /mnt/sysroot/etc/mdadm.conf to match the real array UUIDs (sudo mdadm --detail --scan) and rebuild the initramfs"

--- a/gce_rescue_v2/core/diagnose_rules/readonly.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/readonly.yaml
@@ -1,0 +1,65 @@
+# Runtime read-only remount and disk I/O error patterns (modes 29/43).
+#
+# CATEGORY CHOICE: this is a separate category, not extra patterns in
+# filesystem.yaml, because the finding class is different: filesystem.yaml
+# patterns are evidence of on-disk damage found while MOUNTING (superblock,
+# metadata, journal), while these patterns are the kernel's RUNTIME response
+# to a disk that started failing under a mounted filesystem
+# (errors=remount-ro kicking in, block-layer I/O errors). Both categories
+# firing on the same incident is expected and correct (the EXT4-fs error
+# line belongs to filesystem_corruption, the remount-ro line to
+# readonly_remount) - the engine dedupes per (category, description), so
+# a separate category is what lets both findings surface.
+category: readonly
+fix_guidance: "From rescue mode, run fsck on the unmounted disk: sudo umount /mnt/sysroot && sudo fsck -y /dev/sdb1; then check the disk's status in the GCP Console before restoring"
+# auto_repair stays false until startup_scripts/fixes/readonly_fix.sh lands
+# (RepairOrchestrator.validate() requires the script for every auto_repair
+# category). Future fix: offline fsck via the rescue mount.
+auto_repair: false
+# This is a RUNNING-VM condition: the whole point of the errors=remount-ro
+# response is that the VM keeps "running" (and often finished booting long
+# ago) while every write fails. A "Startup finished" marker never resolves
+# it, so findings must survive boot-success suppression.
+survives_boot_success: true
+
+patterns:
+  - name: readonly_remount
+    severity: critical
+    description: "Filesystem was remounted read-only after disk errors (errors=remount-ro)"
+    regex:
+      # ext4's errors=remount-ro response; list the device-bound form first
+      # so the evidence line names the device when present. [\w-]+ (not
+      # \w+): device-mapper names contain hyphens (dm-0, LVM volumes).
+      - 'EXT4-fs \([\w-]+\): Remounting filesystem read-only'
+      # Bare kernel form (ext2/jbd2 print it without the EXT4-fs prefix).
+      # Kernel-unique wording - prose does not say "Remounting filesystem
+      # read-only".
+      - 'Remounting filesystem read-only'
+    fixes:
+      - "The kernel switched the filesystem to read-only to prevent further damage - writes are failing on this VM right now"
+      - "From rescue mode, repair the unmounted disk: sudo fsck -y /dev/sdb1 (ext) or sudo xfs_repair /dev/sdb1 (XFS)"
+      - "Check the serial output for the I/O errors that triggered the remount; if the device itself is failing, restore from a snapshot"
+
+  # severity: error, not critical - I/O errors degrade the VM and usually
+  # precede a read-only remount, but a burst of them does not by itself
+  # prove the filesystem is dead (the remount-ro pattern above is the
+  # critical signal).
+  - name: readonly_io_error
+    severity: error
+    description: "Disk I/O errors reported by the block layer"
+    regex:
+      # Kernels ~4.x-5.17: "blk_update_request: I/O error, dev sda, sector 2048"
+      - 'blk_update_request: I/O error'
+      # 5.18+ dropped the function-name prefix: "I/O error, dev sda,
+      # sector 2048 op 0x1:(WRITE) ...". Bound to the ", dev X, sector N"
+      # tail so prose mentioning "I/O error" can never match.
+      - 'I/O error, dev [\w-]+, sector \d+'
+      # Page-cache level companion line, bound to a device name.
+      - 'Buffer I/O error on dev [\w-]+'
+      # Pre-3.x kernels only (removed upstream years ago); kept for old
+      # custom images - the string is specific enough that it cannot FP.
+      - 'end_request: I/O error'
+    fixes:
+      - "The block layer is reporting failed reads/writes - check the disk in the GCP Console and the device named in the error"
+      - "If the errors target the boot disk, snapshot it immediately (gcloud compute disks snapshot DISK_NAME --zone=ZONE) before any repair attempt"
+      - "From rescue mode, check the filesystem on the unmounted disk: sudo fsck -y /dev/sdb1"

--- a/gce_rescue_v2/core/diagnose_rules/readonly.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/readonly.yaml
@@ -47,18 +47,25 @@ patterns:
   - name: readonly_io_error
     severity: error
     description: "Disk I/O errors reported by the block layer"
+    # ALL four regexes are device-bound with a shared negative lookahead
+    # excluding loop/sr/fd/ram/zram devices (red-team C1): loop-device
+    # I/O errors are routine snapd refresh/remove noise on every Ubuntu
+    # GCE image, sr0/fd0 errors are phantom CD-ROM/floppy probes (the
+    # fd0 'end_request' line is the most famous benign I/O-error line in
+    # VM history), and none of them can be a boot/root disk on GCE.
+    # Real disks (sda, nvme0n1, dm-0, vd*) pass the lookahead.
     regex:
       # Kernels ~4.x-5.17: "blk_update_request: I/O error, dev sda, sector 2048"
-      - 'blk_update_request: I/O error'
+      - 'blk_update_request: I/O error, dev (?!loop|sr\d|fd\d|ram\d|zram)[\w-]+'
       # 5.18+ dropped the function-name prefix: "I/O error, dev sda,
       # sector 2048 op 0x1:(WRITE) ...". Bound to the ", dev X, sector N"
       # tail so prose mentioning "I/O error" can never match.
-      - 'I/O error, dev [\w-]+, sector \d+'
+      - 'I/O error, dev (?!loop|sr\d|fd\d|ram\d|zram)[\w-]+, sector \d+'
       # Page-cache level companion line, bound to a device name.
-      - 'Buffer I/O error on dev [\w-]+'
+      - 'Buffer I/O error on dev (?!loop|sr\d|fd\d|ram\d|zram)[\w-]+'
       # Pre-3.x kernels only (removed upstream years ago); kept for old
-      # custom images - the string is specific enough that it cannot FP.
-      - 'end_request: I/O error'
+      # custom images.
+      - 'end_request: I/O error, dev (?!loop|sr\d|fd\d|ram\d|zram)[\w-]+'
     fixes:
       - "The block layer is reporting failed reads/writes - check the disk in the GCP Console and the device named in the error"
       - "If the errors target the boot disk, snapshot it immediately (gcloud compute disks snapshot DISK_NAME --zone=ZONE) before any repair attempt"

--- a/gce_rescue_v2/core/diagnose_rules/selinux.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/selinux.yaml
@@ -1,0 +1,55 @@
+# SELinux boot failure patterns (mode 51 - RHEL/Rocky/Alma/CentOS family).
+#
+# NOT detect_only: unlike kernel panics or OOM, these ARE fixable from
+# rescue mode - touch /.autorelabel on the mounted root, fix the policy
+# store via chroot, or boot with selinux=0/enforcing=0 on the kernel
+# command line. auto_repair stays false until startup_scripts/fixes/
+# selinux_fix.sh lands (RepairOrchestrator.validate() requires it).
+#
+# No survives_boot_success (deviation from the master-plan draft, which
+# suggested true): a policy-load failure freezes boot, so it can never
+# coexist with a LATER success marker from the same boot - and if a later
+# boot did complete, the policy demonstrably loaded (someone fixed it or
+# booted permissive), making the old finding stale noise that boot-success
+# suppression must clear. Same reasoning as grub/systemd_early.
+category: selinux
+fix_guidance: "From rescue mode, force a full relabel on next boot (sudo touch /mnt/sysroot/.autorelabel), or boot once with SELinux disabled by adding selinux=0 to the kernel command line via the GRUB menu"
+auto_repair: false
+
+patterns:
+  - name: selinux_policy_load_failure
+    severity: critical
+    description: "SELinux policy failed to load - init froze the boot"
+    regex:
+      # systemd/init wording; covers both the classic one-line RHEL form
+      # 'Failed to load SELinux policy, freezing.' and the modern
+      # 'Failed to load SELinux policy.' followed by a separate freeze
+      # line (which systemd_early's 'Freezing execution' also reports -
+      # both firing on that two-line form is correct, they are the cause
+      # and the terminal action).
+      - 'Failed to load SELinux policy'
+      # Older upstart/init wording (RHEL 6 era).
+      - 'Unable to load SELinux policy'
+      # Kernel-side read failure; \s+ tolerates the kernel's double-space
+      # after 'SELinux:'.
+      - 'SELinux:\s+policy read failure'
+    fixes:
+      - "The policy store on the disk is missing or corrupt - from rescue mode reinstall it via chroot: sudo chroot /mnt/sysroot dnf reinstall selinux-policy-targeted"
+      - "To boot immediately, add selinux=0 to the kernel command line from the GRUB menu (interactive serial console), then repair the policy from inside the VM"
+      - "If /etc/selinux/config names a policy type that is not installed (e.g. SELINUXTYPE=mls without the mls policy), fix it to match the installed policy"
+
+  # severity: warning - this banner is printed at the START of a normal,
+  # self-resolving autorelabel run (the system relabels and reboots
+  # itself). It becomes a problem only when the relabel loops forever,
+  # which the user can judge from the report; a single occurrence on an
+  # otherwise healthy VM must not be alarmist.
+  - name: selinux_relabel_required
+    severity: warning
+    description: "SELinux is performing (or requires) a full filesystem relabel"
+    regex:
+      # Console banner: '*** Warning -- SELinux targeted policy relabel is
+      # required. ***'. \S+ covers targeted/mls/minimum policy types.
+      - 'Warning -- SELinux \S+ policy relabel is required'
+    fixes:
+      - "A full relabel runs automatically and reboots the VM when done - large disks can take many minutes; wait before intervening"
+      - "If the VM loops on relabeling (this banner repeats across reboots), boot with selinux=0 from the GRUB menu and inspect /etc/selinux/config and /.autorelabel"

--- a/gce_rescue_v2/core/diagnose_rules/ssh.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/ssh.yaml
@@ -12,10 +12,14 @@ patterns:
     severity: critical
     description: "SSH daemon failed to start due to invalid sshd_config"
     regex:
-      - 'sshd_config: line \d+: Bad configuration option'
-      - 'sshd_config: terminating, \d+ bad configuration options'
+      # OpenSSH prints "sshd_config: line N" or "sshd_config line N"
+      # depending on version, so the colon is optional.
+      - 'sshd_config:? line \d+: Bad configuration option'
+      - 'sshd_config:? terminating, \d+ bad configuration options'
       - 'Failed to start .*OpenBSD Secure Shell server'
       - 'Failed to start .*OpenSSH server daemon'
+      # SLES unit description; older systemd omits the unit name.
+      - 'Failed to start .*OpenSSH Daemon'
       - 'Failed to start sshd?\.service'
     fixes:
       - "Fix or remove the invalid directive in /mnt/sysroot/etc/ssh/sshd_config"
@@ -25,11 +29,13 @@ patterns:
     severity: error
     description: "Google Compute Engine guest agent failed (SSH key provisioning may not work)"
     regex:
+      # "Failed with result" alone is dropped: it also fires on shutdown
+      # transients; the "Failed to start" line covers real boot failures.
       - 'Failed to start .*Google Compute Engine Guest Agent'
-      - 'google-guest-agent\.service.*Failed with result'
-      - 'google[-_]guest[-_]agent.*(?:fatal|panic)'
+      # Lookbehind excludes benign "non-fatal" agent log lines.
+      - 'google[-_]guest[-_]agent.*(?:panic|(?<!non-)fatal)'
     fixes:
-      - "Reinstall the guest agent from rescue mode: sudo chroot /mnt/sysroot apt-get install --reinstall google-guest-agent"
+      - "Reinstall the guest agent from rescue mode: sudo chroot /mnt/sysroot apt-get install --reinstall google-guest-agent (Debian/Ubuntu) or sudo chroot /mnt/sysroot dnf reinstall google-guest-agent (RHEL/Rocky)"
       - "Check agent logs under /mnt/sysroot/var/log for the failure reason"
 
   - name: ssh_auth_permissions

--- a/gce_rescue_v2/core/diagnose_rules/ssh.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/ssh.yaml
@@ -50,3 +50,26 @@ patterns:
     fixes:
       - "Fix permissions from rescue mode: sudo chmod 700 /mnt/sysroot/home/USER/.ssh and sudo chmod 600 /mnt/sysroot/home/USER/.ssh/authorized_keys"
       - "Fix ownership: sudo chown -R USER:USER /mnt/sysroot/home/USER/.ssh (run inside chroot or use numeric UID)"
+
+  # PLACEMENT: serial-getty lives here, not in systemd_early, because
+  # (a) this category is "operator access paths" - SSH and the serial
+  # console are the two ways into a VM, and a dead getty is the same
+  # class of boot-completing access failure as a dead sshd (which is
+  # exactly why survives_boot_success fits it), and (b) systemd_early's
+  # scoping contract forbids 'Failed to start' anchors entirely (it is
+  # PID1-fatal conditions only, enforced by a loader test).
+  - name: ssh_serial_getty_failed
+    severity: error
+    description: "Serial console login (serial-getty on ttyS0) failed to start"
+    regex:
+      # Bound to the serial-getty unit name; healthy boots only log
+      # 'Started serial-getty@ttyS0.service ...', which contains neither
+      # 'failed' nor the restart-loop wording.
+      - 'serial-getty@ttyS\d+\.service.*(?:failed|start request repeated too quickly)'
+      # Console status line form: '[FAILED] Failed to start Serial Getty
+      # on ttyS0.' - bound to the unit description.
+      - 'Failed to start .*Serial Getty on ttyS\d+'
+    fixes:
+      - "The interactive serial console has no login prompt - use SSH or rescue mode instead to reach the VM"
+      - "Check why getty failed from rescue mode: look for a missing agetty binary, a broken /etc/nsswitch.conf/PAM stack, or an overridden serial-getty@.service drop-in under /mnt/sysroot/etc/systemd/system/"
+      - "Verify the console kernel arg is present so the getty has a device: console=ttyS0,115200 on the kernel command line"

--- a/gce_rescue_v2/core/diagnose_rules/ssh.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/ssh.yaml
@@ -1,6 +1,10 @@
 category: ssh
 fix_guidance: "sudo nano /mnt/sysroot/etc/ssh/sshd_config"
 auto_repair: false
+# ssh failures are boot-completing by nature (sshd or the guest agent fails
+# while the rest of the boot reaches multi-user.target), so a "Startup
+# finished" marker does not mean they are resolved.
+survives_boot_success: true
 
 # Scope: only SSH failures that are visible in the VM serial console are
 # patterned here. Client-side errors such as "Permission denied (publickey)"

--- a/gce_rescue_v2/core/diagnose_rules/ssh.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/ssh.yaml
@@ -1,0 +1,42 @@
+category: ssh
+fix_guidance: "sudo nano /mnt/sysroot/etc/ssh/sshd_config"
+auto_repair: false
+
+# Scope: only SSH failures that are visible in the VM serial console are
+# patterned here. Client-side errors such as "Permission denied (publickey)"
+# are printed by the SSH client on the user's machine and never reach the
+# serial console, so they are intentionally not covered.
+
+patterns:
+  - name: ssh_sshd_config_error
+    severity: critical
+    description: "SSH daemon failed to start due to invalid sshd_config"
+    regex:
+      - 'sshd_config: line \d+: Bad configuration option'
+      - 'sshd_config: terminating, \d+ bad configuration options'
+      - 'Failed to start .*OpenBSD Secure Shell server'
+      - 'Failed to start .*OpenSSH server daemon'
+      - 'Failed to start sshd?\.service'
+    fixes:
+      - "Fix or remove the invalid directive in /mnt/sysroot/etc/ssh/sshd_config"
+      - "Validate the config from rescue mode: sudo sshd -t -f /mnt/sysroot/etc/ssh/sshd_config"
+
+  - name: ssh_guest_agent_failed
+    severity: error
+    description: "Google Compute Engine guest agent failed (SSH key provisioning may not work)"
+    regex:
+      - 'Failed to start .*Google Compute Engine Guest Agent'
+      - 'google-guest-agent\.service.*Failed with result'
+      - 'google[-_]guest[-_]agent.*(?:fatal|panic)'
+    fixes:
+      - "Reinstall the guest agent from rescue mode: sudo chroot /mnt/sysroot apt-get install --reinstall google-guest-agent"
+      - "Check agent logs under /mnt/sysroot/var/log for the failure reason"
+
+  - name: ssh_auth_permissions
+    severity: error
+    description: "SSH authentication refused due to bad ownership or permissions on .ssh files"
+    regex:
+      - 'Authentication refused: bad ownership or modes'
+    fixes:
+      - "Fix permissions from rescue mode: sudo chmod 700 /mnt/sysroot/home/USER/.ssh and sudo chmod 600 /mnt/sysroot/home/USER/.ssh/authorized_keys"
+      - "Fix ownership: sudo chown -R USER:USER /mnt/sysroot/home/USER/.ssh (run inside chroot or use numeric UID)"

--- a/gce_rescue_v2/core/diagnose_rules/startup_script.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/startup_script.yaml
@@ -1,0 +1,37 @@
+# GCE startup-script failure patterns (Stage 8 - late boot, mode 45 family).
+#
+# These fire AFTER multi-user.target: the VM booted fine, but the user's
+# provisioning code failed. Severity warning - it is the user's script,
+# not the platform, and the VM is up.
+category: startup_script
+fix_guidance: "Read the startup-script output lines above the exit-status line in the serial log, then fix the script in metadata: gcloud compute instances describe VM_NAME --zone=ZONE --format=\"value(metadata.items.extract(startup-script))\""
+auto_repair: false
+# detect_only: the failing code is the USER's startup script (VM metadata,
+# not on-disk boot configuration) - there is nothing on the rescued disk
+# for the repair command to edit, and disk swap would not change the
+# metadata the script runs from.
+detect_only: true
+# A booted VM whose provisioning failed is exactly the case this category
+# exists for - the boot-success marker always appears around these lines,
+# so without this flag every finding would be suppressed instantly.
+survives_boot_success: true
+
+patterns:
+  - name: startup_script_failed
+    severity: warning
+    description: "GCE startup script exited with a non-zero status"
+    regex:
+      # google_metadata_script_runner: "startup-script exit status 1".
+      # [1-9] makes zero UNMATCHABLE by construction: the healthy line
+      # 'startup-script exit status 0' on every successful boot must
+      # never fire this pattern. Multi-digit codes (e.g. 127) still
+      # match on their first digit. (?:-url)? covers startup-script-url.
+      - 'startup-script(?:-url)? exit status [1-9]'
+      # Guest-agent wording: Script "startup-script" failed with error:
+      # ... - .? tolerates the quote character (serial output sometimes
+      # mangles or drops it).
+      - 'Script .?startup-script.? failed'
+    fixes:
+      - "The script's own output (stdout/stderr) is in the serial log directly above the exit-status line - fix the failing command there"
+      - "View the current script: gcloud compute instances describe VM_NAME --zone=ZONE --format=\"value(metadata.items.extract(startup-script))\""
+      - "After fixing the metadata, re-run without a reboot: sudo google_metadata_script_runner startup (or reboot the VM)"

--- a/gce_rescue_v2/core/diagnose_rules/startup_script.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/startup_script.yaml
@@ -25,12 +25,15 @@ patterns:
       # [1-9] makes zero UNMATCHABLE by construction: the healthy line
       # 'startup-script exit status 0' on every successful boot must
       # never fire this pattern. Multi-digit codes (e.g. 127) still
-      # match on their first digit. (?:-url)? covers startup-script-url.
-      - 'startup-script(?:-url)? exit status [1-9]'
+      # match on their first digit. Windows variants (red-team C3):
+      # GCEMetadataScripts prints 'windows-startup-script-ps1 exit
+      # status 1' (also -cmd/-bat/-url) and sysprep-specialize scripts
+      # fail the same way - all on COM1, previously undetected.
+      - '(?:windows-)?(?:startup|sysprep-specialize)-script(?:-(?:url|ps1|cmd|bat))? exit status [1-9]'
       # Guest-agent wording: Script "startup-script" failed with error:
       # ... - .? tolerates the quote character (serial output sometimes
-      # mangles or drops it).
-      - 'Script .?startup-script.? failed'
+      # mangles or drops it). Same Windows/sysprep suffixes as above.
+      - 'Script .?(?:windows-)?(?:startup|sysprep-specialize)-script(?:-(?:ps1|cmd|bat))?.? failed'
     fixes:
       - "The script's own output (stdout/stderr) is in the serial log directly above the exit-status line - fix the failing command there"
       - "View the current script: gcloud compute instances describe VM_NAME --zone=ZONE --format=\"value(metadata.items.extract(startup-script))\""

--- a/gce_rescue_v2/core/diagnose_rules/switchroot.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/switchroot.yaml
@@ -51,6 +51,12 @@ patterns:
       # klibc run-init: "run-init: can't execute '/sbin/init': No such
       # file or directory"
       - 'run-init: can.t execute'
+      # klibc run-init path-first form, observed live on Debian 12
+      # (2026-07 GCE validation): "run-init: /sbin/init: No such file or
+      # directory" (repeated for /etc/init and /bin/init fallbacks). The
+      # 'run-init: ' prefix is unique to the initramfs helper, so this
+      # cannot match userspace output.
+      - 'run-init: [^\n]*: No such file or directory'
       # Kernel (init/main.c): "Failed to execute /sbin/init (error -2)"
       - 'Failed to execute /sbin/init'
       # Modern kernels panic with "Kernel panic - not syncing: No working

--- a/gce_rescue_v2/core/diagnose_rules/switchroot.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/switchroot.yaml
@@ -1,0 +1,86 @@
+# switch_root / pivot_root failure patterns (boot stage 6).
+#
+# The initramfs found and mounted the real root filesystem but could not
+# hand control to it: switch_root itself failed, /sbin/init is missing or
+# not executable, or init exists but its shared libraries are broken.
+# All of these are on-disk damage that rescue mode can inspect and fix
+# (restore the /sbin/init symlink, reinstall systemd/libc via chroot),
+# so the category is NOT detect_only.
+#
+# Kernel-panic interplay: two positives here match text that also appears
+# on 'Kernel panic - not syncing:' lines ('No working init found' on
+# modern kernels, 'No init found. Try passing init=' on old kernels).
+# The kernel_panic_generic lookahead in kernel.yaml mirrors BOTH terms —
+# see the INVARIANT comment there before editing either regex.
+#
+# No survives_boot_success: if a later boot completes, init executed and
+# the failure is resolved, so boot-success suppression must clear these.
+category: switchroot
+fix_guidance: "In rescue mode, verify /mnt/sysroot/sbin/init exists and its symlink target resolves (ls -l /mnt/sysroot/sbin/init), check its libraries (chroot /mnt/sysroot ldd /sbin/init), and reinstall systemd from a chroot if broken"
+# auto_repair MUST stay false until startup_scripts/fixes/switchroot_fix.sh
+# lands. RepairOrchestrator.validate() checks that every category with
+# auto_repair: true has a fix script, so flipping this early makes
+# `repair` fail preflight for ALL categories. Flip to true in the same
+# commit that adds the script.
+auto_repair: false
+
+patterns:
+  - name: switchroot_failed
+    severity: critical
+    description: "switch_root failed to hand over to the real root filesystem"
+    regex:
+      # systemd form: 'Failed to switch root: Specified switch root path
+      # /sysroot does not seem to be an OS tree. os-release file is missing.'
+      - 'Failed to switch root'
+      # util-linux switch_root(8) form: 'switch_root: failed to mount
+      # moving /dev to /sysroot/dev: Invalid argument'
+      - 'switch_root: failed to mount moving'
+    fixes:
+      - "The mounted root filesystem is not a usable OS tree - inspect it from rescue mode: ls /mnt/sysroot (expect /sbin, /etc, /usr and /etc/os-release)"
+      - "If /mnt/sysroot/etc/os-release is missing, the wrong partition is being mounted as root - compare root= on the kernel command line against sudo blkid"
+      - "If the tree is damaged, restore the disk from a snapshot or reinstall the core packages via chroot"
+
+  - name: switchroot_no_init
+    severity: critical
+    description: "No usable init on the root filesystem (/sbin/init missing or not executable)"
+    regex:
+      # initramfs-tools (Debian/Ubuntu): "Target filesystem doesn't have
+      # requested /sbin/init." — .? absorbs the apostrophe, which serial
+      # rendering can mangle.
+      - 'Target filesystem doesn.t have requested /sbin/init'
+      # klibc run-init: "run-init: can't execute '/sbin/init': No such
+      # file or directory"
+      - 'run-init: can.t execute'
+      # Kernel (init/main.c): "Failed to execute /sbin/init (error -2)"
+      - 'Failed to execute /sbin/init'
+      # Modern kernels panic with "Kernel panic - not syncing: No working
+      # init found. Try passing init= option to kernel." — mirrored in the
+      # kernel_panic_generic lookahead exclusions.
+      - 'No working init found'
+      # Old kernels: "No init found. Try passing init= option to kernel."
+      # (also mirrored in the kernel_panic_generic lookahead).
+      - 'No init found\.\s*Try passing init='
+    fixes:
+      - "Check init on the mounted disk from rescue mode: ls -l /mnt/sysroot/sbin/init (it is normally a symlink to /lib/systemd/systemd)"
+      - "If the symlink or its target is missing, reinstall systemd via chroot: sudo chroot /mnt/sysroot apt-get install --reinstall systemd systemd-sysv (Debian-family) or dnf reinstall systemd (RHEL-family)"
+      - "If a custom init= parameter was set, remove or correct it in /etc/default/grub (Debian-family) or via grubby --update-kernel=ALL --remove-args=init (RHEL-family), then regenerate the GRUB config"
+
+  - name: switchroot_init_libs
+    severity: critical
+    description: "init found but its shared libraries are missing or broken"
+    regex:
+      # 'error while loading shared libraries' on its own appears in
+      # ORDINARY userspace failures on healthy running VMs (any daemon
+      # with a broken dependency prints it), so unbound it is a
+      # guaranteed false positive. It is only a boot failure when the
+      # failing BINARY is init itself, and the loader prints the binary
+      # name immediately before the message ("/sbin/init: error while
+      # loading shared libraries: libc.so.6: ..."), so the regex requires
+      # an init-context binary directly before the colon. 'systemd'
+      # must be followed by ':' so systemd-resolved / systemd-networkd
+      # and other systemd-* units failing at runtime can never match.
+      - '(?:/sbin/init|/init|run-init|systemd): error while loading shared libraries'
+    fixes:
+      - "Identify the missing library from the serial line, then check it from rescue mode: sudo chroot /mnt/sysroot ldd /sbin/init"
+      - "Reinstall the broken packages via chroot: sudo chroot /mnt/sysroot apt-get install --reinstall systemd libc6 (Debian-family) or dnf reinstall systemd glibc (RHEL-family)"
+      - "If the C library itself is damaged, chroot may fail - restore the disk from a snapshot instead"

--- a/gce_rescue_v2/core/diagnose_rules/switchroot.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/switchroot.yaml
@@ -35,6 +35,15 @@ patterns:
       # util-linux switch_root(8) form: 'switch_root: failed to mount
       # moving /dev to /sysroot/dev: Invalid argument'
       - 'switch_root: failed to mount moving'
+      # systemd unit-status form - the only guaranteed console output when
+      # journal-to-console forwarding is off (the journal 'Failed to switch
+      # root:' line above never reaches the serial console then):
+      #   RHEL9: '[FAILED] Failed to start initrd-switch-root.service -
+      #          Switch Root.'
+      #   RHEL8: '[FAILED] Failed to start Switch Root.'
+      # 'Switch Root' as a unit description is unique to
+      # initrd-switch-root.service, so FP risk is negligible.
+      - 'Failed to start (?:[\w-]+\.service - )?Switch Root'
     fixes:
       - "The mounted root filesystem is not a usable OS tree - inspect it from rescue mode: ls /mnt/sysroot (expect /sbin, /etc, /usr and /etc/os-release)"
       - "If /mnt/sysroot/etc/os-release is missing, the wrong partition is being mounted as root - compare root= on the kernel command line against sudo blkid"

--- a/gce_rescue_v2/core/diagnose_rules/systemd_early.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/systemd_early.yaml
@@ -1,0 +1,72 @@
+# Early systemd / PID 1 failure patterns (boot stage 7).
+#
+# SCOPING DECISION: this file deliberately does NOT ship a generic
+# 'Failed to start <unit>' pattern. That string fires on every non-fatal
+# unit failure (apt-daily, fwupd, motd-news, ...) on perfectly healthy
+# boots, so a bare match would be a constant false positive. Only
+# PID1-fatal or dead-end conditions are matched here; revisit generic
+# unit failures only with a healthy/failed serial corpus to tune against.
+#
+# Overlap contract: fstab.yaml owns the emergency-mode entry strings
+# ('You are in emergency mode', 'Give root password for maintenance').
+# Patterns here anchor only on wording those patterns never match.
+#
+# No survives_boot_success: a completed later boot means PID1 recovered
+# (ordering cycles are logged and broken, the console lockout only
+# matters while stuck in emergency mode), so boot-success suppression
+# must clear stale findings from an older boot.
+category: systemd_early
+fix_guidance: "In rescue mode, inspect the unit files named in the serial output under /mnt/sysroot/etc/systemd/system/ and fix the broken dependency or drop-in; for the locked-root emergency dead end, set a root password or add a systemd debug-shell via chroot"
+# auto_repair MUST stay false until startup_scripts/fixes/
+# systemd_early_fix.sh lands. RepairOrchestrator.validate() checks that
+# every category with auto_repair: true has a fix script, so flipping
+# this early makes `repair` fail preflight for ALL categories. Flip to
+# true in the same commit that adds the script.
+auto_repair: false
+
+patterns:
+  # severity: error, not critical — systemd resolves a cycle by deleting
+  # one job and boot usually continues (minus the deleted unit). It is a
+  # real on-disk misconfiguration worth reporting, but on its own it is
+  # not a boot-blocker; if it did block boot, the emergency-mode or
+  # dependency-failure patterns fire alongside it.
+  - name: systemd_ordering_cycle
+    severity: error
+    description: "systemd found an ordering cycle and deleted a job to break it"
+    regex:
+      - 'Found ordering cycle on'
+      - 'Breaking ordering cycle by deleting job'
+    fixes:
+      - "The serial lines after 'Found ordering cycle on' list the units in the cycle and which job was deleted - that unit did not start"
+      - "Fix the After=/Before=/Requires= loop in the listed unit files under /mnt/sysroot/etc/systemd/system/ from rescue mode"
+      - "Check recently added drop-ins for the looping units: ls /mnt/sysroot/etc/systemd/system/*.d/"
+
+  - name: systemd_freeze
+    severity: critical
+    description: "systemd (PID 1) froze execution - boot cannot continue"
+    regex:
+      # Printed by PID 1 as its terminal action after a crash or a fatal
+      # startup error ('systemd[1]: Freezing execution.'). The wording is
+      # unique to systemd's freeze() path, so no unit-prefix binding is
+      # needed.
+      - 'Freezing execution'
+    fixes:
+      - "Read the systemd[1] lines immediately before 'Freezing execution' in the serial output - they name the fatal error (segfault, failed to allocate manager, bad system.conf)"
+      - "If a recent systemd upgrade or /etc/systemd/system.conf change preceded this, revert it from rescue mode via chroot"
+      - "Reinstall systemd if its binaries are damaged: sudo chroot /mnt/sysroot apt-get install --reinstall systemd (Debian-family) or dnf reinstall systemd (RHEL-family)"
+
+  # severity: error — this is the sulogin lockout: the VM reached
+  # emergency/rescue mode but root has no password (the default on cloud
+  # images), so the maintenance shell is unreachable and emergency mode
+  # becomes a dead end. The underlying boot failure is reported by the
+  # pattern that put the VM in emergency mode (fstab/filesystem/...);
+  # this finding explains why the console prompt cannot be used.
+  - name: systemd_no_console
+    severity: error
+    description: "Emergency shell unreachable - root account is locked (no root password)"
+    regex:
+      - 'Cannot open access to console, the root account is locked'
+    fixes:
+      - "The emergency shell cannot be entered because root has no password (normal on GCP images) - use rescue mode instead of the serial console to repair the disk"
+      - "Fix the underlying boot failure reported above; this finding only explains why the emergency prompt is unusable"
+      - "To make future emergency shells usable, set a root password from a chroot (sudo chroot /mnt/sysroot passwd root) or enable the systemd debug-shell"

--- a/gce_rescue_v2/core/diagnose_rules/systemd_early.yaml
+++ b/gce_rescue_v2/core/diagnose_rules/systemd_early.yaml
@@ -35,7 +35,18 @@ patterns:
     description: "systemd found an ordering cycle and deleted a job to break it"
     regex:
       - 'Found ordering cycle on'
+      # Pre-v250 systemd wording.
       - 'Breaking ordering cycle by deleting job'
+      # systemd >= 250 journal wording, observed live on Debian 12
+      # (systemd 252, 2026-07 GCE validation): "cyclea.service: Job
+      # cycleb.service/start deleted to break ordering cycle starting
+      # with cyclea.service/start".
+      - 'deleted to break ordering cycle'
+      # Console status line printed alongside the journal lines
+      # (observed live): "[ SKIP ] Ordering cycle found, skipping
+      # cycleb.service" - present even when journal-to-console
+      # forwarding is off.
+      - 'Ordering cycle found, skipping'
     fixes:
       - "The serial lines after 'Found ordering cycle on' list the units in the cycle and which job was deleted - that unit did not start"
       - "Fix the After=/Before=/Requires= loop in the listed unit files under /mnt/sysroot/etc/systemd/system/ from rescue mode"

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -303,9 +303,17 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         "Failed to mount filesystem listed in /etc/fstab",
         "Mount point dependency failed (device not available)",
     }
+    # A finding only counts as a suppressing "root cause" if it can actually
+    # explain a boot failure: cpu_lockup findings describe runtime CPU
+    # conditions (not on-disk boot config) and warnings are informational,
+    # so neither may hide critical boot-failure findings like emergency mode.
+    def _is_boot_root_cause(err: DetectedError) -> bool:
+        return err.category != 'cpu_lockup' and err.severity != 'warning'
+
     if len(detected_errors) > 1:
         has_non_catchall = any(
-            e.description not in _CATCH_ALL for e in detected_errors
+            _is_boot_root_cause(e) and e.description not in _CATCH_ALL
+            for e in detected_errors
         )
         if has_non_catchall:
             detected_errors = [
@@ -314,7 +322,8 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
             ]
     if len(detected_errors) > 1:
         has_root_cause = any(
-            e.description not in _GENERIC_SYMPTOM for e in detected_errors
+            _is_boot_root_cause(e) and e.description not in _GENERIC_SYMPTOM
+            for e in detected_errors
         )
         if has_root_cause:
             detected_errors = [

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -303,6 +303,10 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         "Failed to mount filesystem listed in /etc/fstab",
         "Mount point dependency failed (device not available)",
     }
+    # Snapshot the full evidence set before dedupe: the boot-success
+    # suppression below must reason over everything that matched (positions,
+    # emergency-mode presence), not just the deduped survivors.
+    all_detected = list(detected_errors)
     if len(detected_errors) > 1:
         has_non_catchall = any(
             e.description not in _CATCH_ALL for e in detected_errors
@@ -313,14 +317,19 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                 if e.description not in _CATCH_ALL
             ]
     if len(detected_errors) > 1:
-        has_root_cause = any(
-            e.description not in _GENERIC_SYMPTOM for e in detected_errors
-        )
-        if has_root_cause:
-            detected_errors = [
-                e for e in detected_errors
-                if e.description not in _GENERIC_SYMPTOM
-            ]
+        # Tier 2 is category-scoped: a generic symptom is only demoted when
+        # a specific root-cause finding of the SAME category exists.
+        # A finding from an unrelated category (e.g. a stale ssh auth error
+        # in the serial buffer) must never erase fstab boot-blockers.
+        root_cause_categories = {
+            e.category for e in detected_errors
+            if e.description not in _GENERIC_SYMPTOM
+        }
+        detected_errors = [
+            e for e in detected_errors
+            if e.description not in _GENERIC_SYMPTOM
+            or e.category not in root_cause_categories
+        ]
 
     # Boot success detection: if VM is RUNNING and the LATEST boot completed
     # successfully, clear non-emergency errors entirely.
@@ -336,16 +345,27 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         r'Started .*OpenBSD Secure Shell server',
         r'Started .*Google Compute Engine Startup Scripts',
     ]
-    if vm_status == 'RUNNING' and detected_errors:
+    # ssh failures are boot-completing by nature (sshd or the guest agent
+    # fails while the rest of the boot reaches multi-user.target), so a
+    # "Startup finished" marker does not mean they are resolved. They are
+    # therefore exempt from boot-success suppression.
+    _SUPPRESSION_EXEMPT_CATEGORIES = {'ssh'}
+    suppressible = [
+        e for e in detected_errors
+        if e.category not in _SUPPRESSION_EXEMPT_CATEGORIES
+    ]
+    if vm_status == 'RUNNING' and suppressible:
         # Find the position of the last boot success marker
         last_success_pos = -1
         for marker in _BOOT_SUCCESS_MARKERS:
             for match in re.finditer(marker, serial_output, re.IGNORECASE):
                 last_success_pos = max(last_success_pos, match.end())
 
-        # Find the position of the last detected error
+        # Find the position of the last detected error. Use the full
+        # pre-dedupe evidence set: a finding removed by dedupe (e.g.
+        # emergency mode) still proves the latest boot failed.
         last_error_pos = -1
-        for err in detected_errors:
+        for err in all_detected:
             for match in re.finditer(
                 re.escape(err.detected_pattern), serial_output, re.IGNORECASE
             ):
@@ -359,15 +379,18 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         if boot_completed:
             has_emergency = any(
                 'emergency mode' in e.description.lower()
-                for e in detected_errors
+                for e in all_detected
             )
             if not has_emergency:
                 logger.debug(
                     f"VM booted successfully (success at pos {last_success_pos}, "
                     f"last error at pos {last_error_pos}) — clearing "
-                    f"{len(detected_errors)} non-blocking error(s)"
+                    f"{len(suppressible)} non-blocking error(s)"
                 )
-                detected_errors = []
+                detected_errors = [
+                    e for e in detected_errors
+                    if e.category in _SUPPRESSION_EXEMPT_CATEGORIES
+                ]
 
     # Determine diagnosis status and recommendations
     if detected_errors:

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -351,11 +351,14 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
 
     # A finding only counts as a suppressing "root cause" if it can actually
     # explain a boot failure: detect-only categories (YAML flag
-    # 'detect_only') describe runtime conditions, not on-disk boot config,
-    # and warnings are informational — neither may hide critical
+    # 'detect_only') describe runtime conditions, not on-disk boot config;
+    # survives-boot-success categories (e.g. ssh) describe failures that by
+    # definition do NOT block boot and so can never explain emergency mode;
+    # and warnings are informational. None of these may hide critical
     # boot-failure findings like emergency mode.
     def _is_boot_root_cause(err: DetectedError) -> bool:
         return (err.category not in DETECT_ONLY_CATEGORIES
+                and err.category not in SURVIVES_BOOT_SUCCESS_CATEGORIES
                 and err.severity != 'warning')
 
     if len(detected_errors) > 1:
@@ -418,8 +421,13 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         # Find the position of the last detected error. Use the full
         # pre-dedupe evidence set: a finding removed by dedupe (e.g.
         # emergency mode) still proves the latest boot failed.
+        # Skip survives-boot-success categories: they are exempt from
+        # suppression anyway, so a post-marker ssh/filesystem line must not
+        # veto the clearing of stale boot-blocker noise from an older boot.
         last_error_pos = -1
         for err in all_detected:
+            if err.category in SURVIVES_BOOT_SUCCESS_CATEGORIES:
+                continue
             for match in re.finditer(
                 re.escape(err.detected_pattern), serial_output, re.IGNORECASE
             ):

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -362,12 +362,20 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                 for e in detected_errors
             )
             if not has_emergency:
+                # Filesystem corruption is never self-resolving noise the way
+                # fstab nofail/timeout errors are: a corrupt secondary disk
+                # marked nofail lets the VM boot fine while the disk stays
+                # broken. Keep filesystem findings even after a successful
+                # boot so "my data disk won't mount" doesn't report healthy.
+                kept = [
+                    e for e in detected_errors if e.category == 'filesystem'
+                ]
                 logger.debug(
                     f"VM booted successfully (success at pos {last_success_pos}, "
                     f"last error at pos {last_error_pos}) — clearing "
-                    f"{len(detected_errors)} non-blocking error(s)"
+                    f"{len(detected_errors) - len(kept)} non-blocking error(s)"
                 )
-                detected_errors = []
+                detected_errors = kept
 
     # Determine diagnosis status and recommendations
     if detected_errors:

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -161,7 +161,8 @@ BOOT_ERROR_PATTERNS = _load_patterns_from_yaml()
 
 
 def _extract_context_lines(
-    serial_output: str, match_text: str, context_lines: int = 3
+    serial_output: str, match_text: str, context_lines: int = 3,
+    match_pos: int = None
 ) -> Tuple[List[str], int]:
     """Extract lines around a matched pattern for context.
 
@@ -169,6 +170,14 @@ def _extract_context_lines(
         serial_output: Full serial console output
         match_text: The matched text to find context for
         context_lines: Number of lines before and after to include
+        match_pos: Character offset of the actual regex match. When given,
+            the matched line is derived from this offset directly — never
+            by re-searching for match_text. This matters when the matched
+            text also appears on earlier lines (e.g. a generic
+            'Kernel panic - not syncing' whose lookahead rejected an older
+            panic line): re-searching would anchor the evidence on the
+            wrong (first) occurrence, while the matcher deliberately uses
+            the last one.
 
     Returns:
         Tuple of (context lines cleaned of ANSI codes, index of matched line)
@@ -176,12 +185,18 @@ def _extract_context_lines(
     # Split output into lines
     lines = serial_output.split('\n')
 
-    # Find the line containing the match
-    match_line_idx = -1
-    for i, line in enumerate(lines):
-        if match_text in line:
-            match_line_idx = i
-            break
+    if match_pos is not None:
+        # Line index = number of newlines before the match offset
+        match_line_idx = serial_output.count('\n', 0, match_pos)
+        if match_line_idx >= len(lines):
+            match_line_idx = -1
+    else:
+        # Fallback: find the first line containing the match text
+        match_line_idx = -1
+        for i, line in enumerate(lines):
+            if match_text in line:
+                match_line_idx = i
+                break
 
     if match_line_idx == -1:
         return [match_text], 0  # Fallback: single line, index 0
@@ -268,10 +283,12 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                     # Avoid duplicate errors for the same category
                     if not any(err.category == pattern_def.category and err.description == pattern_def.description
                               for err in detected_errors):
-                        # Extract context around the error
+                        # Extract context around the error, anchored on the
+                        # actual match offset (not a re-search of the text)
                         context, match_idx = _extract_context_lines(
                             serial_output, match.group(0),
-                            context_lines=1
+                            context_lines=1,
+                            match_pos=match.start()
                         )
 
                         # Use inline fixes from the pattern definition

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -27,6 +27,13 @@ class BootErrorPattern:
     severity: str  # critical, error, warning
     description: str
     fixes: List[str] = field(default_factory=list)  # Suggested fixes
+    # Category-level flags, copied onto each pattern of the category:
+    # survives_boot_success: findings are NOT cleared by the RUNNING +
+    #   boot-success-marker suppression (failures that don't block boot).
+    # detect_only: runtime condition, not on-disk boot config — never a
+    #   suppressing "root cause" in dedupe.
+    survives_boot_success: bool = False
+    detect_only: bool = False
 
 
 @dataclass
@@ -83,6 +90,12 @@ def _validate_pattern_file(data: dict, filename: str) -> None:
 
     if not isinstance(data['patterns'], list) or len(data['patterns']) == 0:
         raise ValueError(f"{filename}: 'patterns' must be a non-empty list")
+
+    for flag in ('survives_boot_success', 'detect_only'):
+        if flag in data and not isinstance(data[flag], bool):
+            raise ValueError(
+                f"{filename}: '{flag}' must be a boolean"
+            )
 
     required_pattern_fields = ['name', 'severity', 'description', 'regex']
     for i, pattern in enumerate(data['patterns']):
@@ -142,6 +155,8 @@ def _load_patterns_from_yaml(
         _validate_pattern_file(data, yaml_file.name)
 
         category = data['category']
+        survives = bool(data.get('survives_boot_success', False))
+        detect_only = bool(data.get('detect_only', False))
 
         for p in data['patterns']:
             all_patterns.append(BootErrorPattern(
@@ -151,6 +166,8 @@ def _load_patterns_from_yaml(
                 severity=p['severity'],
                 description=p['description'],
                 fixes=list(p.get('fixes', [])),
+                survives_boot_success=survives,
+                detect_only=detect_only,
             ))
 
     return all_patterns
@@ -158,6 +175,13 @@ def _load_patterns_from_yaml(
 
 # Load patterns at module level (fail fast if patterns are broken)
 BOOT_ERROR_PATTERNS = _load_patterns_from_yaml()
+
+# Category behavior sets derived from the YAML flags — the analysis engine
+# never hardcodes category names.
+SURVIVES_BOOT_SUCCESS_CATEGORIES = frozenset(
+    p.category for p in BOOT_ERROR_PATTERNS if p.survives_boot_success)
+DETECT_ONLY_CATEGORIES = frozenset(
+    p.category for p in BOOT_ERROR_PATTERNS if p.detect_only)
 
 
 def _extract_context_lines(
@@ -326,11 +350,13 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
     all_detected = list(detected_errors)
 
     # A finding only counts as a suppressing "root cause" if it can actually
-    # explain a boot failure: cpu_lockup findings describe runtime CPU
-    # conditions (not on-disk boot config) and warnings are informational,
-    # so neither may hide critical boot-failure findings like emergency mode.
+    # explain a boot failure: detect-only categories (YAML flag
+    # 'detect_only') describe runtime conditions, not on-disk boot config,
+    # and warnings are informational — neither may hide critical
+    # boot-failure findings like emergency mode.
     def _is_boot_root_cause(err: DetectedError) -> bool:
-        return err.category != 'cpu_lockup' and err.severity != 'warning'
+        return (err.category not in DETECT_ONLY_CATEGORIES
+                and err.severity != 'warning')
 
     if len(detected_errors) > 1:
         has_non_catchall = any(
@@ -373,16 +399,14 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         r'Started .*OpenBSD Secure Shell server',
         r'Started .*Google Compute Engine Startup Scripts',
     ]
-    # ssh failures are boot-completing by nature (sshd or the guest agent
-    # fails while the rest of the boot reaches multi-user.target), so a
-    # "Startup finished" marker does not mean they are resolved. Filesystem
-    # corruption is never self-resolving noise either: a corrupt secondary
-    # disk marked nofail lets the VM boot fine while the disk stays broken.
-    # Both are therefore exempt from boot-success suppression.
-    _SUPPRESSION_EXEMPT_CATEGORIES = {'ssh', 'filesystem'}
+    # Categories flagged 'survives_boot_success' in their YAML (e.g. ssh,
+    # filesystem) describe failures that do not block boot — sshd dies but
+    # boot completes, or a corrupt nofail secondary disk lets the VM boot
+    # while the disk stays broken. A "Startup finished" marker does not mean
+    # they are resolved, so they are exempt from boot-success suppression.
     suppressible = [
         e for e in detected_errors
-        if e.category not in _SUPPRESSION_EXEMPT_CATEGORIES
+        if e.category not in SURVIVES_BOOT_SUCCESS_CATEGORIES
     ]
     if vm_status == 'RUNNING' and suppressible:
         # Find the position of the last boot success marker
@@ -419,7 +443,7 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                 )
                 detected_errors = [
                     e for e in detected_errors
-                    if e.category in _SUPPRESSION_EXEMPT_CATEGORIES
+                    if e.category in SURVIVES_BOOT_SUCCESS_CATEGORIES
                 ]
 
     # Determine diagnosis status and recommendations

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -362,8 +362,17 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
                 and err.severity != 'warning')
 
     if len(detected_errors) > 1:
+        # Tier 1 is additionally gated on CRITICAL severity: emergency mode
+        # is itself a critical boot-blocker, so only a finding that names a
+        # critical root cause may replace it. Error-level companions (e.g.
+        # systemd_no_console, which fires on EVERY emergency entry because
+        # root is locked on GCP images, or an ordering-cycle report) are
+        # symptoms/context — letting them suppress the catch-all demotes a
+        # real emergency incident to a lone ERROR whose fix text points at
+        # a "failure reported above" that no longer exists.
         has_non_catchall = any(
-            _is_boot_root_cause(e) and e.description not in _CATCH_ALL
+            _is_boot_root_cause(e) and e.severity == 'critical'
+            and e.description not in _CATCH_ALL
             for e in detected_errors
         )
         if has_non_catchall:

--- a/gce_rescue_v2/core/diagnosis.py
+++ b/gce_rescue_v2/core/diagnosis.py
@@ -439,20 +439,24 @@ def analyze_serial_output(serial_output: str, vm_name: str, zone: str, vm_status
         )
 
         if boot_completed:
-            has_emergency = any(
-                'emergency mode' in e.description.lower()
-                for e in all_detected
+            # No emergency-mode veto here: boot_completed already requires
+            # the last success marker to sit AFTER the last occurrence of
+            # every non-surviving finding in all_detected — including the
+            # emergency-mode line itself (fstab/initramfs, neither of which
+            # survives boot success). Any emergency evidence at this point
+            # is therefore provably from an older, resolved boot in the
+            # accumulating serial buffer; keeping a presence-based veto
+            # made every resolved emergency incident report CRITICAL
+            # forever until the buffer rotated.
+            logger.debug(
+                f"VM booted successfully (success at pos {last_success_pos}, "
+                f"last error at pos {last_error_pos}) — clearing "
+                f"{len(suppressible)} non-blocking error(s)"
             )
-            if not has_emergency:
-                logger.debug(
-                    f"VM booted successfully (success at pos {last_success_pos}, "
-                    f"last error at pos {last_error_pos}) — clearing "
-                    f"{len(suppressible)} non-blocking error(s)"
-                )
-                detected_errors = [
-                    e for e in detected_errors
-                    if e.category in SURVIVES_BOOT_SUCCESS_CATEGORIES
-                ]
+            detected_errors = [
+                e for e in detected_errors
+                if e.category in SURVIVES_BOOT_SUCCESS_CATEGORIES
+            ]
 
     # Determine diagnosis status and recommendations
     if detected_errors:

--- a/gce_rescue_v2/core/fix_catalog.py
+++ b/gce_rescue_v2/core/fix_catalog.py
@@ -6,6 +6,8 @@ Each YAML file contains both detection patterns and fix info in one place.
 Exports:
     CATEGORY_FIX_GUIDANCE: Dict mapping category -> manual fix command
     SUPPORTED_FIX_CATEGORIES: Set of categories with auto_repair: true
+    DETECT_ONLY_CATEGORIES: Set of categories with detect_only: true
+        (runtime conditions — rescue mode does not apply)
     get_fixes_for_pattern(): Look up suggested fixes by category + pattern name
 """
 
@@ -87,10 +89,12 @@ def _build_exports(
     """Build module-level exports from loaded fix data.
 
     Returns:
-        Tuple of (category_fix_guidance, supported_fix_categories, pattern_fixes_map)
+        Tuple of (category_fix_guidance, supported_fix_categories,
+        detect_only_categories, pattern_fixes_map)
     """
     guidance: Dict[str, str] = {}
     supported: Set[str] = set()
+    detect_only: Set[str] = set()
     pattern_fixes: Dict[str, Dict[str, List[str]]] = {}
 
     for category, data in fix_data.items():
@@ -99,6 +103,9 @@ def _build_exports(
         if data.get('auto_repair', False):
             supported.add(category)
 
+        if data.get('detect_only', False):
+            detect_only.add(category)
+
         pattern_fixes[category] = {}
         for pattern in data.get('patterns', []):
             pattern_name = pattern.get('name', '')
@@ -106,12 +113,13 @@ def _build_exports(
             if pattern_name and fixes:
                 pattern_fixes[category][pattern_name] = list(fixes)
 
-    return guidance, supported, pattern_fixes
+    return guidance, supported, detect_only, pattern_fixes
 
 
 # Load at module level (fail fast if fix files are broken)
 _FIX_DATA = _load_fix_files()
-CATEGORY_FIX_GUIDANCE, SUPPORTED_FIX_CATEGORIES, _PATTERN_FIXES = _build_exports(_FIX_DATA)
+(CATEGORY_FIX_GUIDANCE, SUPPORTED_FIX_CATEGORIES, DETECT_ONLY_CATEGORIES,
+ _PATTERN_FIXES) = _build_exports(_FIX_DATA)
 
 
 def get_fixes_for_pattern(category: str, pattern_name: str) -> List[str]:

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -1707,6 +1707,64 @@ class TestDiagnoseUnifiedEngineRedTeamRegressions:
     failing serial buffer from the red-team report. The _diagnose helper
     runs with vm_status RUNNING."""
 
+    def test_full_disk_garbled_fsckd_line_not_flagged_as_fsck_failed(self):
+        """LIVE (t-diskfull): on a full disk, journald interleaves two writes
+        onto one physical serial line, e.g. a healthy 'systemd-fsckd.service:
+        Deactivated succe...' fragment concatenated with journald's 'Failed
+        to open ...: No space left on device'. The old greedy 'fsck.*failed'
+        matched 'fsckd...Failed' across the garble -> false CRITICAL
+        fstab_fsck_failed. disk_full must be the only fstab-family finding
+        here (no fsck_failed)."""
+        serial = (
+            "systemd-journald[206]: Failed to open system journal: "
+            "No space left on device\n"
+            "syst[   33.575608] systemd-fsckd.service: Deactivated succe"
+            "[   33.581290] systemd-journald[206]: Failed to open: "
+            "No space left on device\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'disk_full_no_space' in names
+        assert 'fstab_fsck_failed' not in names
+
+    def test_healthy_fsckd_daemon_lines_not_flagged(self):
+        """LIVE (t-diskfull): the fsck-to-fsckd socket/daemon startup lines are
+        normal on every boot and must never match fstab_fsck_failed."""
+        serial = (
+            "[    3.302480] systemd[1]: Listening on systemd-fsckd.socket - "
+            "fsck to fsckd communication Socket.\n"
+            "systemd[1]: Started systemd-fsckd.service - File System Check "
+            "Daemon to report status.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_fsck_failed' not in names
+
+    def test_real_fsck_failure_still_detected(self):
+        """Guard: tightening the regex must not lose true fsck failures."""
+        for line in (
+            "systemd-fsck[512]: fsck failed with exit status 4\n",
+            "systemd-fsck[512]: fsck exited with status code 8\n",
+            "[   12.3] EXT4-fs (sdb1): FILE SYSTEM CHECK FAILED\n",
+        ):
+            data = _diagnose("Linux version 6.1\n" + line)
+            names = [e['name'] for e in data['boot_errors']]
+            assert 'fstab_fsck_failed' in names, line
+
+    def test_device_cannot_open_blockdev_detected_as_filesystem(self):
+        """LIVE (t-fs): severe superblock+partition corruption makes the
+        device unopenable, so serial shows '/dev/sda: Can't open blockdev'
+        rather than 'Bad magic number'. That must surface as a filesystem
+        finding (alongside the fstab mount failure)."""
+        serial = (
+            "[    4.129800] /dev/sda: Can't open blockdev\n"
+            "[FAILED] Failed to mount mnt-data.mount - /mnt/data.\n"
+        )
+        data = _diagnose(serial)
+        cats = {e['category'] for e in data['boot_errors']}
+        assert 'filesystem' in cats
+        assert 'fstab' in cats  # mount failure still reported too
+
     def test_lone_ssh_error_does_not_erase_emergency_mode(self):
         """C1: a single ssh auth error (survives-boot category, can never
         explain emergency mode) must not qualify as a Tier-1 root cause and

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -59,6 +59,14 @@ def _make_http_error(status_code, message="error"):
     return HttpError(resp, f'{{"error": {{"message": "{message}"}}}}'.encode())
 
 
+def _diagnose(serial: str):
+    """Run DiagnoseOperation against a serial excerpt, return rollback_data."""
+    compute = _make_compute(serial_output=serial)
+    op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+    result = op.execute('test-vm')
+    return result.rollback_data
+
+
 # ---------------------------------------------------------------------------
 # TestDiagnoseBasic
 # ---------------------------------------------------------------------------
@@ -478,3 +486,125 @@ class TestDiagnoseStabilization:
             result = op.execute('test-vm', stabilize=False)
             mock_stab.assert_not_called()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseSshPatterns
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseSshPatterns:
+    """Detection tests for the ssh diagnose category."""
+
+    def test_sshd_config_bad_option_detected(self):
+        """Invalid sshd_config directive should match ssh_sshd_config_error."""
+        serial = (
+            "[   10.312478] cloud-init[498]: Cloud-init v. 22.4.2 running 'modules:final'\n"
+            "[   10.812345] sshd[512]: /etc/ssh/sshd_config: line 122: "
+            "Bad configuration option: ThisIsNotAValidDirective\n"
+            "[   10.812999] systemd[1]: ssh.service: Control process exited, "
+            "code=exited, status=255/EXCEPTION\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_sshd_config_terminating_detected(self):
+        """sshd 'terminating, N bad configuration options' should match."""
+        serial = (
+            "[   11.102938] sshd[512]: /etc/ssh/sshd_config: terminating, "
+            "1 bad configuration options\n"
+            "[   11.104001] systemd[1]: ssh.service: Main process exited, "
+            "code=exited, status=255/EXCEPTION\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_sshd_service_failed_debian_detected(self):
+        """Debian-style ssh.service failure line should match."""
+        serial = (
+            "[   12.001234] systemd[1]: ssh.service: Start request repeated too quickly.\n"
+            "[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.\n"
+            "See 'systemctl status ssh.service' for details.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_sshd_service_failed_rhel_detected(self):
+        """RHEL-style sshd.service failure line should match."""
+        serial = (
+            "[   13.442210] systemd[1]: sshd.service: Start request repeated too quickly.\n"
+            "[FAILED] Failed to start sshd.service - OpenSSH server daemon.\n"
+            "See 'systemctl status sshd.service' for details.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_guest_agent_failed_to_start_detected(self):
+        """systemd failure of google-guest-agent should match ssh_guest_agent_failed."""
+        serial = (
+            "[   12.481000] systemd[1]: google-guest-agent.service: "
+            "Start request repeated too quickly.\n"
+            "[FAILED] Failed to start google-guest-agent.service - "
+            "Google Compute Engine Guest Agent.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_guest_agent_failed' in names
+
+    def test_guest_agent_fatal_log_detected(self):
+        """Guest agent fatal log line should match ssh_guest_agent_failed."""
+        serial = (
+            "[   13.001111] systemd[1]: Starting google-guest-agent.service...\n"
+            "[   13.123456] google_guest_agent[655]: FATAL main.go:118 "
+            "error creating instance config: invalid config\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_guest_agent_failed' in names
+
+    def test_guest_agent_benign_log_not_matched(self):
+        """Normal guest agent startup logs should not trigger any ssh pattern."""
+        serial = (
+            "[    9.881234] google_guest_agent[652]: GCE Agent Started (version 20230601.00)\n"
+            "[    9.991234] google_guest_agent[652]: Adding existing user gokull to google-sudoers group.\n"
+        )
+        data = _diagnose(serial)
+        assert 'ssh' not in {e['category'] for e in data['boot_errors']}
+
+    def test_auth_permissions_detected(self):
+        """sshd 'bad ownership or modes' should match ssh_auth_permissions."""
+        serial = (
+            "[  241.601000] sshd[1042]: Connection from 192.168.1.7 port 51522\n"
+            "[  241.693421] sshd[1042]: Authentication refused: "
+            "bad ownership or modes for directory /home/gokull/.ssh\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_auth_permissions' in names
+
+    def test_fstab_errors_do_not_trigger_ssh_patterns(self):
+        """fstab root-cause lines must not produce ssh findings."""
+        serial = (
+            "[    5.102938] systemd[1]: Timed out waiting for device "
+            "/dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "[    5.104001] systemd[1]: Dependency failed for /mnt/data\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        assert 'ssh' not in {e['category'] for e in data['boot_errors']}
+
+    def test_healthy_boot_matches_no_ssh_patterns(self):
+        """A clean boot with normal ssh/guest-agent lines should stay healthy."""
+        serial = (
+            "[    8.812345] systemd[1]: Started ssh.service - OpenBSD Secure Shell server.\n"
+            "[    9.881234] google_guest_agent[652]: GCE Agent Started (version 20230601.00)\n"
+            "[   10.101234] systemd[1]: Startup finished in 4.102s (kernel) + 6.204s (userspace) = 10.306s.\n"
+            "login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -614,6 +614,23 @@ class TestKernelPanicDetection:
         assert 'kernel_panic_oom' in names
         assert 'kernel_panic_generic' not in names
 
+    def test_deadlocked_on_memory_panic_classified_as_oom(self):
+        """Red-team C4: mm/oom_kill.c panics 'System is deadlocked on
+        memory' when no killable process remains - it must classify as
+        kernel_panic_oom (resize/panic_on_oom fixes), not generic
+        (reset/previous-kernel fixes), and the generic lookahead must
+        mirror the new exclusion."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  712.103311] Kernel panic - not syncing: System is "
+            "deadlocked on memory\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_oom' in names
+        assert 'kernel_panic_generic' not in names
+
     def test_evidence_anchors_on_actual_match_not_first_occurrence(self):
         """Evidence must quote the line the regex matched, not an earlier
         line containing the same text.
@@ -4161,6 +4178,60 @@ class TestReadonlyDetection:
         names = [e['name'] for e in data['boot_errors']]
         assert 'readonly_remount' in names
 
+    def test_loop_device_io_errors_not_flagged(self):
+        """Red-team C1: loop-device I/O errors are routine snapd
+        refresh/remove noise on every Ubuntu GCE image - with
+        survives_boot_success they stuck an ERROR to healthy VMs until
+        the buffer rotated. The device lookahead must exclude them."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "ubuntu login: \n"
+            "[ 8123.101234] blk_update_request: I/O error, dev loop3, "
+            "sector 0\n"
+            "[ 8123.202345] Buffer I/O error on dev loop3, logical "
+            "block 0, async page read\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_removable_and_ram_device_io_errors_not_flagged(self):
+        """Red-team C1: phantom CD-ROM (sr0), floppy (fd0 - the most
+        famous benign I/O-error line in VM history) and ram-disk probes
+        must not fire readonly_io_error."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "[ 1201.101234] I/O error, dev sr0, sector 0 op 0x0:(READ) "
+            "flags 0x80700 phys_seg 1 prio class 0\n"
+            "[ 1202.202345] end_request: I/O error, dev fd0, sector 0\n"
+            "[ 1203.303456] Buffer I/O error on dev ram0, logical block 0\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_real_disk_io_errors_still_flagged_after_device_binding(self):
+        """The lookahead must not eat real disks: sda (end_request form)
+        and dm-0 (device-mapper/LVM) still fire readonly_io_error."""
+        serial_endreq = (
+            "[    0.000000] Linux version 3.10.0-1160.el7.x86_64\n"
+            "[ 7211.101234] end_request: I/O error, dev sda, sector "
+            "409600\n"
+        )
+        serial_dm = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[ 7211.101234] I/O error, dev dm-0, sector 2048 op "
+            "0x1:(WRITE) flags 0x800 phys_seg 8 prio class 2\n"
+        )
+        for serial in (serial_endreq, serial_dm):
+            data = _diagnose(serial)
+            names = [e['name'] for e in data['boot_errors']]
+            assert 'readonly_io_error' in names
+
     def test_healthy_mount_lines_not_flagged(self):
         """Healthy 'mounted filesystem' / 're-mounted' kernel lines must
         not fire any readonly pattern."""
@@ -4275,6 +4346,29 @@ class TestOomDetection:
         names = [e.name for e in result.boot_errors]
         assert 'oom_killed_process' in names
         assert 'fstab_emergency_mode' in names
+
+    def test_memcg_kill_matches_with_container_guidance(self):
+        """Red-team C5 (decision lock): cgroup/container kills
+        DELIBERATELY still match (the 'invoked oom-killer' header is
+        byte-identical for global and memcg kills, and a memcg kill can
+        be the real problem) - but the fixes must carry the
+        container-vs-VM distinction so 'resize the VM' is not the only
+        advice a GKE/Docker host gets."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[ 8123.101234] oom-kill:constraint=CONSTRAINT_MEMCG,"
+            "nodemask=(null),cpuset=cri-containerd-abc,mems_allowed=0\n"
+            "[ 8123.202345] Memory cgroup out of memory: Killed process "
+            "2201 (stress) total-vm:1048576kB\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        findings = [e for e in result.boot_errors
+                    if e.name == 'oom_killed_process']
+        assert len(findings) == 1
+        assert findings[0].severity == 'warning'
+        assert any('cgroup' in f.lower() for f in
+                   findings[0].suggested_fixes)
 
     def test_prose_oom_mentions_not_flagged(self):
         """Prose quoting 'Out of memory' / 'oom-killer' without kernel kill
@@ -4484,6 +4578,57 @@ class TestStartupScriptDetection:
         names = [e['name'] for e in data['boot_errors']]
         assert 'startup_script_failed' in names
 
+    def test_windows_startup_script_failures_detected(self):
+        """Red-team C3: Windows startup-script failures on COM1 were
+        completely undetected - both the exit-status form and the
+        guest-agent 'Script ... failed' form, across ps1/cmd and
+        sysprep-specialize variants, must now fire."""
+        lines = (
+            'GCEMetadataScripts: windows-startup-script-ps1 exit status 1',
+            'GCEMetadataScripts: Script "windows-startup-script-ps1" '
+            'failed with error: exit status 1',
+            'GCEMetadataScripts: windows-startup-script-cmd exit status 1',
+            'GCEMetadataScripts: sysprep-specialize-script-ps1 exit '
+            'status 1',
+        )
+        for line in lines:
+            serial = "Windows Boot Manager\n" + line + "\n"
+            result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                           'TERMINATED')
+            names = [e.name for e in result.boot_errors]
+            assert 'startup_script_failed' in names, line
+            severities = {e.name: e.severity for e in result.boot_errors}
+            assert severities['startup_script_failed'] == 'warning'
+
+    def test_windows_exit_status_zero_never_matches(self):
+        """The zero-unmatchable guard must survive the Windows
+        broadening: 'windows-startup-script-ps1 exit status 0' prints on
+        every healthy Windows boot."""
+        serial = (
+            "Windows Boot Manager\n"
+            "GCEMetadataScripts: windows-startup-script-ps1 exit "
+            "status 0\n"
+            "GCEMetadataScripts: Finished running startup scripts.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        assert 'startup_script' not in categories
+
+    def test_shutdown_script_failure_still_not_matched(self):
+        """Overlap guard kept from round 1 (SS-5): shutdown-script exit
+        codes are not startup failures and must stay unmatched by the
+        broadened regexes."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "google_metadata_script_runner[912]: shutdown-script exit "
+            "status 1\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        assert 'startup_script' not in categories
+
 
 # ---------------------------------------------------------------------------
 # TestCloudInitDetection (Wave 5 - cloud-init failures)
@@ -4679,6 +4824,44 @@ class TestNetworkBootDetection:
         data = _diagnose(serial)
         assert data['diagnosis_status'] == 'healthy'
         assert data['boot_errors'] == []
+
+    def test_wait_online_timeout_is_warning_not_unit_failure(self):
+        """Red-team C2: the wait-online console line contains BOTH the
+        unit name 'systemd-networkd-wait-online' and the description
+        'Wait for Network to be Configured' - on a stopped healthy VM it
+        was double-matched into ERROR 'core network service failed' with
+        rescue guidance. It is a benign timeout (boot continues, SSH
+        works): warning-severity wait-online pattern, and
+        network_unit_failed must NOT fire."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[FAILED] Failed to start systemd-networkd-wait-online."
+            "service - Wait for Network to be Configured.\n"
+            "[   42.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 38.1s (userspace) = 42.3s.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'network_unit_failed' not in names
+        assert 'network_wait_online_timeout' in names
+        severities = {e.name: e.severity for e in result.boot_errors}
+        assert severities['network_wait_online_timeout'] == 'warning'
+
+    def test_networkd_failure_still_error_despite_wait_online_lookahead(self):
+        """The (?!-wait-online) lookahead must not eat the real thing:
+        a genuine systemd-networkd.service failure on a stopped VM stays
+        an error-severity network_unit_failed."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[FAILED] Failed to start systemd-networkd.service - Network "
+            "Configuration.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        severities = {e.name: e.severity for e in result.boot_errors}
+        assert severities.get('network_unit_failed') == 'error'
+        assert 'network_wait_online_timeout' not in severities
 
     def test_benign_unit_failures_do_not_fire_network(self):
         """The healthy-noise units (apt-daily, motd-news style) must not

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -3459,6 +3459,24 @@ class TestSwitchrootDetection:
         # ownership), not an overlap bug.
         assert 'initramfs_busybox_shell' in names
 
+    def test_run_init_path_first_form_detected(self):
+        """Debian 12 klibc run-init prints the path-first form
+        'run-init: /sbin/init: No such file or directory' (no
+        "can't execute" wording) - exact sequence captured live on GCE
+        (2026-07). Fixture omits the 'Target filesystem' line so this
+        test proves the run-init regex alone carries detection."""
+        serial = (
+            "Begin: Running /scripts/init-bottom ... done.\n"
+            "run-init: /sbin/init: No such file or directory\n"
+            "run-init: /etc/init: No such file or directory\n"
+            "run-init: /bin/init: No such file or directory\n"
+            "/bin/sh: 0: can't access tty; job control turned off\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'switchroot_no_init' in names
+
     def test_no_working_init_panic_fires_switchroot_not_generic(self):
         """Modern kernels panic 'No working init found.' - switchroot owns
         that panic line, and the kernel_panic_generic lookahead must
@@ -3595,6 +3613,36 @@ class TestSystemdEarlyDetection:
             "cycle by deleting job cloud-init.service/start\n"
             "[    3.912500] systemd[1]: cloud-init.service: Job "
             "cloud-init.service/start deleted to break ordering cycle\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'systemd_ordering_cycle' in names
+
+    def test_ordering_cycle_job_deleted_wording_alone_detected(self):
+        """systemd 252 journal wording captured live on GCE (2026-07):
+        'Job X deleted to break ordering cycle starting with Y'. Must
+        fire even if the 'Found ordering cycle on' line is lost to
+        serial buffer truncation."""
+        serial = (
+            "[    2.661909] systemd[1]: cycleb.service: Job "
+            "cyclea.service/start deleted to break ordering cycle "
+            "starting with cycleb.service/start\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'systemd_ordering_cycle' in names
+
+    def test_ordering_cycle_console_skip_line_detected(self):
+        """Console status line captured live on GCE (2026-07):
+        '[ SKIP ] Ordering cycle found, skipping cyclea.service' -
+        printed even when journal-to-console forwarding is off, so it
+        must fire on its own."""
+        serial = (
+            "[ SKIP ] Ordering cycle found, skipping cyclea.service\n"
+            "[  OK  ] Started cron.service - Regular background program "
+            "processing daemon.\n"
         )
         result = analyze_serial_output(serial, 'test-vm', 'zone-a',
                                        'TERMINATED')

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -2432,3 +2432,761 @@ class TestFirmwareDetection:
         data = _diagnose(serial)
         assert data['diagnosis_status'] == 'healthy'
         assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestDracutInitramfsDetection (Wave 2: RHEL/Rocky/Alma/SLES dialect)
+# ---------------------------------------------------------------------------
+
+class TestDracutInitramfsDetection:
+    """Detection tests for the dracut initramfs dialect (RHEL-family).
+
+    Fixtures reproduce real Rocky 9 serial formatting: kernel timestamps
+    on dracut-initqueue lines, bare lines for the emergency shell.
+    """
+
+    ROCKY_DRACUT_TIMEOUT_SERIAL = (
+        "[  OK  ] Reached target Basic System.\n"
+        "[  135.209316] dracut-initqueue[550]: Warning: dracut-initqueue "
+        "timeout - starting timeout scripts\n"
+        "[  135.719813] dracut-initqueue[550]: Warning: dracut-initqueue "
+        "timeout - starting timeout scripts\n"
+        "[  191.964618] dracut-initqueue[550]: Warning: Could not boot.\n"
+        "[  191.976595] dracut-initqueue[550]: Warning: /dev/disk/by-uuid/"
+        "00000000-0000-0000-0000-000000000bad does not exist\n"
+        "         Starting Dracut Emergency Shell...\n"
+        "Warning: /dev/disk/by-uuid/00000000-0000-0000-0000-000000000bad "
+        "does not exist\n"
+        "\n"
+        "Generating \"/run/initramfs/rdsosreport.txt\"\n"
+        "\n"
+        "Entering emergency mode. Exit the shell to continue.\n"
+        "Type \"journalctl\" to view system logs.\n"
+        "You might want to save \"/run/initramfs/rdsosreport.txt\" to a "
+        "USB stick or /boot\n"
+        "after mounting them and attach it to a bug report.\n"
+        "\n"
+        "dracut:/# \n"
+    )
+
+    def test_rocky_dracut_timeout_and_emergency_detected(self):
+        """Full Rocky 9 bad-root-UUID buffer reports timeout + emergency."""
+        data = _diagnose(self.ROCKY_DRACUT_TIMEOUT_SERIAL)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_dracut_timeout' in names
+        assert 'initramfs_dracut_emergency' in names
+
+    def test_dracut_emergency_dedupes_fstab_emergency_mode(self):
+        """Overlap guard: the 'Entering emergency mode' line on a dracut
+        buffer fires fstab_emergency_mode (catch-all), but Tier-1 dedupe
+        must demote it in favor of the dracut root-cause findings --
+        never two findings for the same emergency state."""
+        data = _diagnose(self.ROCKY_DRACUT_TIMEOUT_SERIAL)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_emergency_mode' not in names
+
+    def test_dracut_emergency_alone_still_dedupes_fstab_emergency(self):
+        """Truncated buffer with only the emergency-shell tail: the dracut
+        emergency finding is the root cause; fstab_emergency_mode stays
+        deduped (no double-fire on 'Entering emergency mode')."""
+        serial = (
+            "Generating \"/run/initramfs/rdsosreport.txt\"\n"
+            "\n"
+            "Entering emergency mode. Exit the shell to continue.\n"
+            "Type \"journalctl\" to view system logs.\n"
+            "dracut:/# \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_dracut_emergency' in names
+        assert 'fstab_emergency_mode' not in names
+
+    def test_dracut_lines_do_not_fire_kernel_category(self):
+        """No panic string in the dracut buffer -- kernel must stay silent."""
+        data = _diagnose(self.ROCKY_DRACUT_TIMEOUT_SERIAL)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'kernel' not in categories
+
+    def test_dracut_fatal_detected(self):
+        serial = (
+            "[    2.113305] dracut: FATAL: FIPS integrity test failed\n"
+            "[    2.113400] dracut: Refusing to continue\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_dracut_fatal' in names
+
+    def test_sysroot_mount_failure_detected_as_initramfs_not_fstab(self):
+        """RHEL '/sysroot' failure is the initrd stage: it must report
+        initramfs_sysroot_mount_failed and must NOT fire the fstab
+        mount/dependency patterns (the (?!sysroot) carve-outs)."""
+        serial = (
+            "[    4.523310] XFS (sda4): Corruption warning: Metadata has "
+            "LSN ahead of current LSN\n"
+            "[FAILED] Failed to mount /sysroot.\n"
+            "See 'systemctl status sysroot.mount' for details.\n"
+            "[DEPEND] Dependency failed for Initrd Root File System.\n"
+            "[DEPEND] Dependency failed for Reload Configuration from the "
+            "Real Root.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_sysroot_mount_failed' in names
+        assert 'fstab_mount_failed' not in names
+        assert 'fstab_dependency_failed' not in names
+
+    def test_nvme_rename_sd_device_reports_guidance(self):
+        """dracut waiting for a legacy /dev/sdX device on an NVMe machine
+        family reports the rename guidance pattern (UUID advice)."""
+        serial = (
+            "[  138.210044] dracut-initqueue[544]: Warning: dracut-initqueue "
+            "timeout - starting timeout scripts\n"
+            "[  138.220000] dracut-initqueue[544]: Warning: /dev/sda1 does "
+            "not exist\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_nvme_device_rename' in names
+        finding = next(e for e in data['boot_errors']
+                       if e['name'] == 'initramfs_nvme_device_rename')
+        fixes = ' '.join(finding['suggested_fixes']).lower()
+        assert 'nvme' in fixes
+        assert 'uuid' in fixes
+
+    def test_healthy_rocky_boot_no_initramfs_findings(self):
+        """Healthy Rocky 9 boot (normal dracut hooks) must report healthy."""
+        serial = (
+            "[    0.000000] Linux version 5.14.0-427.13.1.el9_4.x86_64 "
+            "(mockbuild@x86-64-01.stream)\n"
+            "[    1.612345] dracut-cmdline[214]: dracut-057-53.git20240104."
+            "el9_4 dracut\n"
+            "[    2.412345] XFS (sda4): Mounting V5 Filesystem\n"
+            "[    2.512345] XFS (sda4): Ending clean mount\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+            "rocky9 login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestBusyBoxInitramfsDetection (Wave 2: Debian/Ubuntu dialect)
+# ---------------------------------------------------------------------------
+
+class TestBusyBoxInitramfsDetection:
+    """Detection tests for the BusyBox initramfs dialect (Debian-family).
+
+    BusyBox output is bare lines with no timestamps or unit prefixes.
+    """
+
+    def test_busybox_alert_and_prompt_detected(self):
+        serial = (
+            "Begin: Waiting for root file system ... Begin: Running "
+            "/scripts/local-block ... done.\n"
+            "done.\n"
+            "Gave up waiting for root file system device.  Common problems:\n"
+            " - Boot args (cat /proc/cmdline)\n"
+            "   - Check rootdelay= (did the system wait long enough?)\n"
+            " - Missing modules (cat /proc/modules; ls /dev)\n"
+            "ALERT!  /dev/disk/by-uuid/deadbeef-cafe-4bad-8bad-2bad2bad2bad "
+            "does not exist.  Dropping to a shell!\n"
+            "\n"
+            "BusyBox v1.35.0 (Debian 1:1.35.0-4+b3) built-in shell (ash)\n"
+            "Enter 'help' for a list of built-in commands.\n"
+            "\n"
+            "(initramfs) \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_busybox_shell' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'kernel' not in categories
+
+    def test_bare_initramfs_prompt_detected(self):
+        """A truncated buffer ending at the bare '(initramfs)' prompt line
+        must still be detected (line-start anchored, parens literal)."""
+        serial = (
+            "BusyBox v1.30.1 (Ubuntu 1:1.30.1-7ubuntu3) built-in shell "
+            "(ash)\n"
+            "Enter 'help' for a list of built-in commands.\n"
+            "\n"
+            "(initramfs) \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_busybox_shell' in names
+
+    def test_busybox_prompt_match_has_no_trailing_newline(self):
+        """The prompt regex uses [ \\t]*$ so the newline never leaks into
+        detected_pattern / JSON output."""
+        serial = (
+            "BusyBox v1.35.0 (Debian 1:1.35.0-4+b3) built-in shell (ash)\n"
+            "Enter 'help' for a list of built-in commands.\n"
+            "(initramfs) \n"
+        )
+        data = _diagnose(serial)
+        patterns = {e['name']: e['detected_pattern']
+                    for e in data['boot_errors']}
+        assert 'initramfs_busybox_shell' in patterns
+        assert '\n' not in patterns['initramfs_busybox_shell']
+
+    def test_gave_up_waiting_old_wording_detected(self):
+        """Older initramfs-tools prints 'Gave up waiting for root device.'"""
+        serial = (
+            "Begin: Running /scripts/local-premount ... done.\n"
+            "Gave up waiting for root device.  Common problems:\n"
+            " - Boot args (cat /proc/cmdline)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_busybox_shell' in names
+
+    def test_healthy_debian_initramfs_lines_not_flagged(self):
+        """Normal initramfs-tools Begin/done chatter plus a completed boot
+        must not fire any initramfs pattern."""
+        serial = (
+            "Begin: Loading essential drivers ... done.\n"
+            "Begin: Running /scripts/init-premount ... done.\n"
+            "Begin: Mounting root file system ... done.\n"
+            "Begin: Running /scripts/init-bottom ... done.\n"
+            "[    2.412345] EXT4-fs (sda1): mounted filesystem with ordered "
+            "data mode. Quota mode: none.\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestInitramfsUnpackAndRootDevice (Wave 2: unpack variants + VFS form)
+# ---------------------------------------------------------------------------
+
+class TestInitramfsUnpackAndRootDevice:
+    """Unpack-failure variants and the non-panic root-device form."""
+
+    def test_invalid_magic_detected(self):
+        serial = (
+            "[    0.000000] Linux version 5.14.0-427.13.1.el9_4.x86_64\n"
+            "[    0.905566] Initramfs unpacking failed: invalid magic at "
+            "start of compressed archive\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_load_failure' in names
+
+    def test_failed_to_decompress_bound_to_initramfs(self):
+        serial = (
+            "[    0.000000] Linux version 5.14.0-427.13.1.el9_4.x86_64\n"
+            "[    0.905566] Failed to decompress external initrd "
+            "(/boot/initramfs-5.14.0.img)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_load_failure' in names
+
+    def test_unrelated_decompress_failure_not_flagged(self):
+        """A 'Failed to decompress' line without initrd/initramfs context
+        (e.g. a firmware blob) must not fire initramfs_load_failure."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    3.101010] amdgpu: Failed to decompress firmware blob\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'initramfs' not in categories
+
+    def test_vfs_cannot_open_root_device_nonpanic_detected(self):
+        """The non-panic 'VFS: Cannot open root device' form (kernel keeps
+        retrying or panics much later) must report initramfs, and the
+        kernel catch-all must stay silent (no panic line present)."""
+        serial = (
+            "[    1.612345] VFS: Cannot open root device "
+            "\"PARTUUID=abcd1234-01\" or unknown-block(0,0): error -6\n"
+            "[    1.702211] Please append a correct \"root=\" boot option; "
+            "here are the available partitions:\n"
+            "[    1.750000] 0800     10485760 sda driver: sd\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_no_root_fs' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'kernel' not in categories
+
+    def test_vfs_panic_form_still_single_initramfs_finding(self):
+        """When both the Cannot-open line and the Unable-to-mount panic are
+        present, initramfs_no_root_fs reports once and kernel_panic_generic
+        stays excluded (lookahead unchanged by the new regex)."""
+        serial = (
+            "[    1.612345] VFS: Cannot open root device \"sda1\" or "
+            "unknown-block(0,0): error -6\n"
+            "[    1.803992] Kernel panic - not syncing: VFS: Unable to "
+            "mount root fs on unknown-block(0,0)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert names.count('initramfs_no_root_fs') == 1
+        assert 'kernel_panic_generic' not in names
+
+
+# ---------------------------------------------------------------------------
+# TestLvmDetection (Wave 2 new category)
+# ---------------------------------------------------------------------------
+
+class TestLvmDetection:
+    """Detection tests for lvm.yaml patterns."""
+
+    def test_vg_not_found_detected(self):
+        serial = (
+            "[    2.113305] dracut-cmdline[214]: dracut-057-53.git20240104"
+            ".el9_4\n"
+            "Volume group \"vg_root\" not found\n"
+            "Cannot process volume group vg_root\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'lvm_vg_not_found' in names
+
+    def test_escaped_mapper_timeout_is_lvm_not_fstab(self):
+        """dev-mapper device timeout (systemd \\x2d escaping) must report
+        lvm_device_timeout and must NOT fire fstab_device_timeout (the
+        (?!mapper) carve-outs)."""
+        serial = (
+            "systemd[1]: dev-mapper-vg\\x2droot.device: Job dev-mapper-"
+            "vg\\x2droot.device/start timed out.\n"
+            "systemd[1]: Timed out waiting for device dev-mapper-"
+            "vg\\x2droot.device - /dev/mapper/vg-root.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'lvm_device_timeout' in names
+        assert 'fstab_device_timeout' not in names
+
+    def test_plain_mapper_path_timeout_is_lvm_not_fstab(self):
+        serial = (
+            "systemd[1]: Timed out waiting for device /dev/mapper/"
+            "vgdata-lvdata.\n"
+            "[DEPEND] Dependency failed for /srv/data.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'lvm_device_timeout' in names
+        assert 'fstab_device_timeout' not in names
+
+    def test_dracut_mapper_wait_is_lvm_not_initramfs(self):
+        """dracut waiting on /dev/mapper/* is an LVM activation failure:
+        lvm.yaml owns it; the initramfs dracut regex excludes mapper."""
+        serial = (
+            "[  138.220000] dracut-initqueue[544]: Warning: "
+            "/dev/mapper/rhel-root does not exist\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'lvm_dracut_device_missing' in names
+        assert 'initramfs_dracut_timeout' not in names
+        assert 'initramfs_nvme_device_rename' not in names
+
+    def test_healthy_lvm_boot_not_flagged(self):
+        serial = (
+            "[    2.104501] lvm[321]: 1 logical volume(s) in volume group "
+            "\"vg00\" now active\n"
+            "Found volume group \"vg00\" using metadata type lvm2\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestCryptDetection (Wave 2 new category, detect-only)
+# ---------------------------------------------------------------------------
+
+class TestCryptDetection:
+    """Detection tests for crypt.yaml patterns (LUKS hangs)."""
+
+    def test_passphrase_prompt_detected(self):
+        """The prompt itself is the failure evidence (interactive hang)."""
+        serial = (
+            "[    4.104501] systemd[1]: Starting Cryptography Setup for "
+            "luks-2f4c...\n"
+            "Please enter passphrase for disk luks-2f4c8e11 on /: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'crypt_passphrase_prompt' in names
+
+    def test_please_unlock_disk_wording_detected(self):
+        serial = (
+            "systemd[1]: Starting Cryptography Setup for cr_root...\n"
+            "Please unlock disk cr_root: \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'crypt_passphrase_prompt' in names
+
+    def test_crypt_start_job_detected(self):
+        serial = (
+            "[ ***  ] A start job is running for Cryptography Setup for "
+            "luks-2f4c8e11 (1min 30s / no limit)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'crypt_unlock_wait' in names
+
+    def test_benign_start_job_not_flagged(self):
+        """FP guard: 'A start job is running for' is a benign transient on
+        every boot -- it must ONLY match when bound to crypt/LUKS wording,
+        even with no boot-success marker in the buffer."""
+        serial = (
+            "[  *** ] A start job is running for Wait for Network to be "
+            "Configured (9s / 2min 30s)\n"
+            "[ ***  ] A start job is running for dev-sdb1.device "
+            "(5s / 1min 30s)\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'crypt' not in categories
+
+    def test_cryptsetup_failure_bound_wording_detected(self):
+        serial = (
+            "[FAILED] Failed to start Cryptography Setup for luks-2f4c.\n"
+            "See 'systemctl status systemd-cryptsetup@luks.service'.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'crypt_setup_failed' in names
+
+    def test_healthy_cryptsetup_start_not_flagged(self):
+        """Bare systemd-cryptsetup unit chatter on a healthy encrypted-disk
+        boot must not fire (patterns are bound to failure wording)."""
+        serial = (
+            "systemd[1]: Started systemd-cryptsetup@luks-2f4c.service - "
+            "Cryptography Setup for luks-2f4c.\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestRaidDetection (Wave 2 new category)
+# ---------------------------------------------------------------------------
+
+class TestRaidDetection:
+    """Detection tests for raid.yaml patterns (mdadm)."""
+
+    def test_dirty_degraded_array_detected(self):
+        serial = (
+            "[    3.104501] md/raid:md0: not enough operational devices "
+            "(2/4 failed)\n"
+            "[    3.104999] md: pers->run() failed ...\n"
+            "[    3.105501] md0: Cannot start dirty degraded array.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'raid_dirty_degraded' in names
+
+    def test_raid1_mirrors_wording_detected(self):
+        serial = (
+            "[    3.104501] md/raid1:md127: not enough operational mirrors.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'raid_dirty_degraded' in names
+
+    def test_mdadm_unable_to_start_detected(self):
+        serial = (
+            "mdadm: Unable to start array /dev/md0: Input/output error\n"
+            "[DEPEND] Dependency failed for /srv/raid.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'raid_start_failed' in names
+
+    def test_healthy_raid_boot_not_flagged(self):
+        serial = (
+            "[    3.104501] md/raid1:md0: active with 2 out of 2 mirrors\n"
+            "[    3.204501] md0: detected capacity change from 0 to "
+            "1073741824\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestMachineIdDetection (Wave 2 new category)
+# ---------------------------------------------------------------------------
+
+class TestMachineIdDetection:
+    """Detection tests for machine_id.yaml (badly cloned images)."""
+
+    def test_machine_id_unreadable_detected(self):
+        serial = (
+            "systemd[1]: Failed to read /etc/machine-id: No such file or "
+            "directory\n"
+            "dbus-daemon[512]: Failed to open \"/var/lib/dbus/machine-id\": "
+            "No such file or directory\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'machine_id_missing' in names
+
+    def test_could_not_get_machine_id_detected(self):
+        serial = (
+            "Linux version 6.1.0-18-cloud-amd64 (debian-kernel@lists)\n"
+            "dbus[401]: Could not get machine ID: unable to load "
+            "/var/lib/dbus/machine-id\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'machine_id_missing' in names
+
+    def test_machine_id_cleared_by_completed_boot(self):
+        """Boot continues with a transient ID, so a completed later boot
+        clears the finding (no survives_boot_success)."""
+        serial = (
+            "systemd[1]: Failed to read /etc/machine-id: No such file or "
+            "directory\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+
+
+# ---------------------------------------------------------------------------
+# TestFilesystemDistroBroadening (Wave 2: Btrfs, XFS log, ext4 features)
+# ---------------------------------------------------------------------------
+
+class TestFilesystemDistroBroadening:
+    """Detection tests for the Wave 2 filesystem.yaml additions."""
+
+    def test_btrfs_open_ctree_failed_detected(self):
+        """openSUSE Btrfs root corruption (open_ctree) reports filesystem."""
+        serial = (
+            "[    4.121004] BTRFS error (device sda2): bad tree block "
+            "start, want 268435456 have 0\n"
+            "[    4.122500] BTRFS error (device sda2): failed to read "
+            "chunk root\n"
+            "[    4.124904] BTRFS error (device sda2): open_ctree failed\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_btrfs_corruption' in names
+
+    def test_btrfs_chunk_tree_and_transid_detected(self):
+        serial = (
+            "[    4.121004] BTRFS: failed to read chunk tree on sda2\n"
+            "[    4.122500] parent transid verify failed on 30408704 "
+            "wanted 4096 found 4098\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_btrfs_corruption' in names
+
+    def test_healthy_btrfs_info_lines_not_flagged(self):
+        """BTRFS info chatter on healthy SUSE boots must not fire the
+        corruption pattern."""
+        serial = (
+            "[    2.121004] BTRFS info (device sda2): using crc32c "
+            "(crc32c-intel) checksum algorithm\n"
+            "[    2.122500] BTRFS info (device sda2): enabling ssd "
+            "optimizations\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_xfs_log_recovery_failure_detected(self):
+        serial = (
+            "[    3.812345] XFS (sda4): Starting recovery (logdev: "
+            "internal)\n"
+            "[    3.912345] XFS (sda4): log mount/recovery failed: "
+            "error -117\n"
+            "[    3.913345] XFS (sda4): log mount failed\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_xfs_log_failure' in names
+
+    def test_xfs_corruption_detected_unmount_wording(self):
+        """Modern combined-line XFS wording joins filesystem_corruption."""
+        serial = (
+            "[    3.912345] XFS (sda4): Corruption detected. Unmount and "
+            "run xfs_repair\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+
+    def test_ext4_unsupported_features_detected(self):
+        serial = (
+            "[    4.412345] EXT4-fs (sdb1): couldn't mount because of "
+            "unsupported optional features (4000)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_ext4_feature_mismatch' in names
+
+    def test_xfs_duplicate_uuid_detected_with_rescue_guidance(self):
+        """The self-inflicted rescue-mode failure: original XFS disk
+        attached as secondary shares the rescue root's UUID. Fixes must
+        point at -o nouuid / xfs_admin -U generate."""
+        serial = (
+            "[  212.412345] XFS (sdb2): Filesystem has duplicate UUID "
+            "290cb251-77f1-46f5-9fc1-4bb2c767b0de - can't mount\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_xfs_duplicate_uuid' in names
+        finding = next(e for e in data['boot_errors']
+                       if e['name'] == 'filesystem_xfs_duplicate_uuid')
+        fixes = ' '.join(finding['suggested_fixes'])
+        assert 'nouuid' in fixes
+        assert 'xfs_admin -U generate' in fixes
+
+    def test_xfs_duplicate_uuid_survives_completed_boot(self):
+        """filesystem declares survives_boot_success -- the rescue VM boots
+        fine while the secondary mount keeps failing, so the finding must
+        not be cleared by the boot-success marker."""
+        serial = (
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+            "[  212.412345] XFS (sdb2): Filesystem has duplicate UUID "
+            "290cb251-77f1-46f5-9fc1-4bb2c767b0de - can't mount\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_xfs_duplicate_uuid' in names
+
+
+# ---------------------------------------------------------------------------
+# TestFstabDistroBroadening (Wave 2: \x2d units + maintenance prompt)
+# ---------------------------------------------------------------------------
+
+class TestFstabDistroBroadening:
+    """Wave 2 fstab.yaml additions: escaped device units, sulogin prompt."""
+
+    def test_escaped_uuid_timeout_matches_full_unit_name(self):
+        """RHEL/SLES escaped unit form: the explicit \\x2d regex must win
+        over the loose dev-\\w+ fallback so the FULL unit name (with the
+        UUID) lands in detected_pattern for identifier extraction."""
+        serial = (
+            "systemd[1]: Timed out waiting for device dev-disk-by\\x2duuid-"
+            "6c78e5d3\\x2d3672\\x2d4c05\\x2d8f65\\x2dfe4b9c1233a7.device.\n"
+            "[DEPEND] Dependency failed for /data.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_device_timeout' in names
+        finding = next(e for e in data['boot_errors']
+                       if e['name'] == 'fstab_device_timeout')
+        assert 'by\\x2duuid' in finding['detected_pattern']
+        assert '.device' in finding['detected_pattern']
+
+    def test_escaped_uuid_identifier_extracted(self):
+        """End-to-end: the formatter must decode the \\x2d escapes and
+        surface the real UUID as the finding identifier."""
+        from gce_rescue_v2.utils.report_formatter import _extract_identifier
+        serial = (
+            "systemd[1]: Timed out waiting for device dev-disk-by\\x2duuid-"
+            "6c78e5d3\\x2d3672\\x2d4c05\\x2d8f65\\x2dfe4b9c1233a7.device.\n"
+        )
+        data = _diagnose(serial)
+        finding = next(e for e in data['boot_errors']
+                       if e['name'] == 'fstab_device_timeout')
+        identifier = _extract_identifier(finding['detected_pattern'])
+        assert identifier == 'UUID=6c78e5d3-3672-4c05-8f65-fe4b9c1233a7'
+
+    def test_give_root_password_maintenance_prompt_detected(self):
+        """RHEL/SLES sulogin wording joins fstab_emergency_mode, and must
+        be detectable when the buffer holds nothing but the prompt."""
+        serial = (
+            "Give root password for maintenance\n"
+            "(or press Control-D to continue): \n"
+            "padding line so the buffer exceeds the minimum length .....\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_emergency_mode' in names
+
+    def test_live_rocky9_dracut_capture_detected_without_crypt_fp(self):
+        """LIVE (w2-rocky, Rocky 9.6, broken root=UUID): exact serial
+        wording differs from the canonical form ('dracut-initqueue:
+        timeout, still waiting for following initqueue hooks:'), and the
+        dumped devexists hook SCRIPT TEXT contains
+        'systemd-cryptsetup@*.service' - which must NOT fire the crypt
+        category (its patterns are bound to failure/prompt wording)."""
+        serial = (
+            "[  198.255076] dracut-initqueue[378]: Warning: "
+            "dracut-initqueue: timeout, still waiting for following "
+            "initqueue hooks:\n"
+            "[  198.269189] dracut-initqueue[378]: Warning: /lib/dracut/"
+            "hooks/initqueue/finished/devexists-\x2fdev\x2fdisk\x2fby-"
+            "uuid\x2f00000000-0000-0000-0000-000000000bad.sh: \"if ! "
+            "grep -q After=remote-fs-pre.target /run/systemd/generator/"
+            "systemd-cryptsetup@*.service 2>/dev/null; then\n"
+            "[  198.296147] dracut-initqueue[378]:     [ -e \"/dev/disk/"
+            "by-uuid/00000000-0000-0000-0000-000000000bad\" ]\n"
+            "[  198.839486] dracut-initqueue[378]: fi\"\n"
+            "[  198.839530] dracut-initqueue[378]: Warning: "
+            "dracut-initqueue: starting timeout scripts\n"
+            "[  198.839573] dracut-initqueue[378]: Warning: Could not "
+            "boot.\n"
+            "Warning: /dev/disk/by-uuid/00000000-0000-0000-0000-"
+            "000000000bad does not exist\n"
+            "\n"
+            "Generating \"/run/initramfs/rdsosreport.txt\"\n"
+            "\n"
+            "Entering emergency mode. Exit the shell to continue.\n"
+            "Type \"journalctl\" to view system logs.\n"
+            "dracut:/# \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_dracut_timeout' in names
+        assert 'initramfs_dracut_emergency' in names
+        assert 'fstab_emergency_mode' not in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'crypt' not in categories
+        assert 'kernel' not in categories
+
+    def test_live_opensuse_fstab_timeout_console_truncated_detected(self):
+        """LIVE (w2-suse, openSUSE Leap 16, bogus fstab UUID): the console
+        renders the device path ellipsized ('/dev/...000000bad'), and the
+        engine must still report the device timeout + UUID root cause."""
+        serial = (
+            "[ TIME ] Timed out waiting for device "
+            "/dev/…000000-0000-0000-0000-000000000bad.\n"
+            "[DEPEND] Dependency failed for File System "
+            "…000000-0000-0000-0000-000000000bad.\n"
+            "[DEPEND] Dependency failed for /data2.\n"
+            "[DEPEND] Dependency failed for Local File Systems.\n"
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_device_timeout' in names
+        assert 'fstab_emergency_mode' not in names

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -1979,6 +1979,86 @@ class TestGrubDetection:
         names = [e['name'] for e in data['boot_errors']]
         assert 'grub_file_not_found' in names
 
+    def test_rhel_prefixed_grub_errors_detected(self):
+        """RHEL/Fedora grub2 prefixes every error with its source location
+        (error: ../../grub-core/<file>.c:<line>:<message>). Red-team C1:
+        these exact lines produced ZERO findings before the optional
+        (?:\\S+\\.c:\\d+:)? prefix was added to every message-bound regex."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: ../../grub-core/fs/fshelp.c:258:file "
+            "`/vmlinuz-4.18.0-513.el8_9.x86_64' not found.\n"
+            "error: ../../grub-core/loader/i386/efi/linux.c:94:you need to "
+            "load the kernel first.\n"
+            "\n"
+            "Press any key to continue...\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_kernel_not_found' in names
+        assert 'grub_load_kernel_first' in names
+
+    def test_rhel_prefixed_filesystem_and_disk_errors_detected(self):
+        """Remaining RHEL-prefixed forms from the red-team C1 corpus."""
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "\n"
+            "error: ../../grub-core/kern/fs.c:120:unknown filesystem.\n"
+            "error: ../../grub-core/kern/disk.c:236:disk `hd0,gpt2' "
+            "not found.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_unknown_filesystem' in names
+        assert 'grub_disk_not_found' in names
+        assert 'grub_rescue_prompt' in names
+
+    def test_benign_rhel_grubenv_line_not_flagged(self):
+        """The well-known BENIGN RHEL-on-XFS line (grubenv unwritable, boot
+        continues fine) must NOT fire grub_file_not_found — without the
+        (?!grubenv) exclusion this is a critical FP on healthy RHEL VMs."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "error: ../../grub-core/fs/fshelp.c:257:file "
+            "`/boot/grub2/grubenv' not found.\n"
+            "[    0.000000] Linux version 4.18.0-513.el8_9.x86_64\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_unprefixed_grubenv_line_not_flagged(self):
+        """Same grubenv exclusion for the unprefixed (Debian-style) form,
+        with no completed boot in the buffer — proves the lookahead alone
+        (not boot-success suppression) rejects the line."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "error: file `/boot/grub2/grubenv' not found.\n"
+        )
+        data = _diagnose(serial)
+        assert data['boot_errors'] == []
+
+    def test_broken_grub2_module_still_flagged_despite_grubenv_exclusion(self):
+        """The (?!grubenv) lookahead must not swallow real /boot/grub2/*
+        failures (e.g. a missing module)."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: ../../grub-core/fs/fshelp.c:258:file "
+            "`/boot/grub2/i386-pc/normal.mod' not found.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_file_not_found' in names
+
     def test_grub_kernel_not_found_detected(self):
         """Missing vmlinuz referenced by grub.cfg, plus the follow-up
         'you need to load the kernel first' error."""
@@ -2244,6 +2324,48 @@ class TestFirmwareDetection:
         names = [e['name'] for e in data['boot_errors']]
         assert 'firmware_secure_boot_violation' in names
         assert 'grub_load_kernel_first' in names
+
+    def test_rhel_prefixed_bad_shim_signature_detected(self):
+        """RHEL grub2 source-location prefix on the shim rejection line
+        (red-team C1 companion fix in firmware.yaml)."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: ../../grub-core/kern/verifiers.c:119:bad shim "
+            "signature.\n"
+            "error: ../../grub-core/loader/i386/efi/linux.c:94:you need to "
+            "load the kernel first.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_secure_boot_violation' in names
+        assert 'grub_load_kernel_first' in names
+
+    def test_prose_mention_of_no_bootable_device_not_flagged(self):
+        """Red-team C4: a startup-script echo merely MENTIONING the phrase
+        mid-line must not fire firmware_no_bootable_device (start anchor)."""
+        serial = (
+            "[   12.345678] startup-script: INFO Watching for the "
+            "'No bootable device' marker in guest logs\n"
+            "[   13.000000] startup-script: INFO handler installed\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'firmware' not in categories
+
+    def test_glued_seabios_no_bootable_device_still_detected(self):
+        """Live S4 capture: SeaBIOS glues its banner onto the failure line
+        without a newline ('No bootable device.SeaBIOS ...'). The phrase
+        still starts the line, so the start anchor must keep matching."""
+        serial = (
+            "Booting from Hard Disk 0...\n"
+            "Boot failed: not a bootable disk\n"
+            "\n"
+            "No bootable device.SeaBIOS (version 1.8.2-google)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_no_bootable_device' in names
 
     def test_gpt_corrupt_detected(self):
         serial = (

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -1906,3 +1906,407 @@ class TestDiagnoseUnifiedEngineRedTeamRegressions:
         }
         assert 'disk_full_no_space' in patterns
         assert '\n' not in patterns['disk_full_no_space']
+
+
+# ---------------------------------------------------------------------------
+# TestGrubDetection
+# ---------------------------------------------------------------------------
+
+class TestGrubDetection:
+    """Detection tests for grub.yaml patterns (bootloader stage).
+
+    GRUB serial output carries no kernel timestamps and no systemd
+    prefixes — fixtures reproduce the real bare-line formatting.
+    """
+
+    def test_grub_rescue_prompt_detected(self):
+        """Drop to 'grub rescue>' reports the rescue prompt and its cause."""
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "\n"
+            "error: no such partition.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_rescue_prompt' in names
+        assert 'grub_no_such_partition' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert categories == {'grub'}
+        assert all(e['severity'] == 'critical' for e in data['boot_errors'])
+
+    def test_grub_normal_shell_detected(self):
+        """Minimal-BASH banner means boot stopped at the grub> shell."""
+        serial = (
+            "GNU GRUB  version 2.06-13+deb12u1\n"
+            "\n"
+            "Minimal BASH-like line editing is supported. For the first "
+            "word, TAB\n"
+            "lists possible command completions. Anywhere else TAB lists "
+            "possible\n"
+            "device or file completions.\n"
+            "\n"
+            "grub> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_normal_shell' in names
+
+    def test_grub_config_not_found_detected(self):
+        """Missing grub.cfg (Debian /boot/grub path)."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: file `/boot/grub/grub.cfg' not found.\n"
+            "grub> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_file_not_found' in names
+
+    def test_grub2_config_path_variant_detected(self):
+        """RHEL/SLES use /boot/grub2/grub.cfg — the regex must accept both."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: file `/boot/grub2/grub.cfg' not found.\n"
+            "grub> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_file_not_found' in names
+
+    def test_grub_kernel_not_found_detected(self):
+        """Missing vmlinuz referenced by grub.cfg, plus the follow-up
+        'you need to load the kernel first' error."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: file `/boot/vmlinuz-6.1.0-18-cloud-amd64' not found.\n"
+            "error: you need to load the kernel first.\n"
+            "\n"
+            "Press any key to continue...\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_kernel_not_found' in names
+        assert 'grub_load_kernel_first' in names
+
+    def test_grub_initrd_not_found_detected(self):
+        """Missing initrd referenced by grub.cfg."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: file `/boot/initrd.img-6.1.0-18-cloud-amd64' not found.\n"
+            "\n"
+            "Press any key to continue...\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_kernel_not_found' in names
+
+    def test_grub_symbol_not_found_detected(self):
+        """Core/module version skew (e.g. grub_calloc after an upgrade)."""
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "\n"
+            "error: symbol `grub_calloc' not found.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_symbol_not_found' in names
+
+    def test_grub_disk_not_found_detected(self):
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "\n"
+            "error: disk `hd0,gpt2' not found.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_disk_not_found' in names
+
+    def test_grub_unknown_filesystem_detected(self):
+        """GRUB 'error: unknown filesystem' is grub-category, and must not
+        cross-fire into the filesystem category."""
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "\n"
+            "error: unknown filesystem.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_unknown_filesystem' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'filesystem' not in categories
+
+    def test_grub_out_of_memory_detected(self):
+        """GRUB OOM is bound to the 'error:' prefix and must never be
+        confused with kernel OOM (kernel/disk_full categories)."""
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "\n"
+            "error: out of memory.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_out_of_memory' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'kernel' not in categories
+        assert 'disk_full' not in categories
+
+    def test_grub_invalid_magic_detected(self):
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: invalid magic number.\n"
+            "error: you need to load the kernel first.\n"
+            "\n"
+            "Press any key to continue...\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'grub_invalid_magic' in names
+
+    def test_healthy_boot_with_grub_banner_no_findings(self):
+        """The normal 'Welcome to GRUB!' banner on every healthy boot must
+        not fire any grub pattern (FP guard from the master plan)."""
+        serial = (
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Booting from Hard Disk 0...\n"
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 "
+            "(debian-kernel@lists.debian.org)\n"
+            "[    0.512345] Trying to unpack rootfs image as initramfs...\n"
+            "[    2.412345] EXT4-fs (sda1): mounted filesystem with ordered "
+            "data mode. Quota mode: none.\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_kernel_oom_lines_do_not_trigger_grub(self):
+        """Kernel OOM output (timestamp-prefixed 'Out of memory') must not
+        match grub_out_of_memory — proves the 'error:' line-start binding."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  512.103311] Out of memory: Killed process 1234 (java) "
+            "total-vm:8388608kB\n"
+            "[  512.209972] Kernel panic - not syncing: Out of memory: "
+            "system-wide panic_on_oom is enabled\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'grub' not in categories
+
+    def test_mount_unknown_filesystem_type_does_not_trigger_grub(self):
+        """The kernel/mount 'unknown filesystem type' wording never starts a
+        serial line with 'error:', so grub_unknown_filesystem must not fire."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    3.204333] mount[456]: mount: /data: unknown filesystem "
+            "type 'xfs'.\n"
+            "[    3.304333] systemd[1]: data.mount: Mount process exited, "
+            "code=exited, status=32/n/a\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'grub' not in categories
+
+    def test_fstab_errors_do_not_trigger_grub_or_firmware(self):
+        """fstab failure lines should not produce grub/firmware findings."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'grub' not in categories
+        assert 'firmware' not in categories
+
+    def test_stale_grub_error_cleared_by_later_successful_boot(self):
+        """The serial ring buffer keeps old boots: a grub failure followed
+        by a later completed boot on a RUNNING VM is stale noise and must
+        be suppressed (grub does not declare survives_boot_success)."""
+        serial = (
+            "GRUB loading.\n"
+            "Welcome to GRUB!\n"
+            "error: no such partition.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Booting from Hard Disk 0...\n"
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestFirmwareDetection
+# ---------------------------------------------------------------------------
+
+class TestFirmwareDetection:
+    """Detection tests for firmware.yaml patterns (BIOS/UEFI stage)."""
+
+    def test_bios_no_bootable_device_detected(self):
+        """SeaBIOS wiped-MBR failure reports firmware_no_bootable_device."""
+        serial = (
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Machine UUID 12345678-1234-1234-1234-123456789abc\n"
+            "Booting from Hard Disk 0...\n"
+            "Boot failed: not a bootable disk\n"
+            "\n"
+            "No bootable device.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_no_bootable_device' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert categories == {'firmware'}
+
+    def test_bios_could_not_read_boot_disk_detected(self):
+        serial = (
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Machine UUID 12345678-1234-1234-1234-123456789abc\n"
+            "Booting from Hard Disk 0...\n"
+            "Boot failed: could not read the boot disk\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_no_bootable_device' in names
+
+    def test_uefi_bds_load_failure_detected(self):
+        """OVMF BdsDxe failure (missing/unformatted ESP or lost NVRAM entry)."""
+        serial = (
+            "UEFI: Attempting to start image.\n"
+            "Description: UEFI Google PersistentDisk\n"
+            "BdsDxe: failed to load Boot0001 \"UEFI Google PersistentDisk\" "
+            "from PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0): Not Found\n"
+            "BdsDxe: No bootable option or device was found.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_uefi_boot_load_failed' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert categories == {'firmware'}
+
+    def test_secure_boot_violation_detected(self):
+        """Shielded VM Secure Boot rejection — the OVMF verification line.
+        A 'loading Boot0000' line must not fire the failed-to-load pattern."""
+        serial = (
+            "BdsDxe: loading Boot0000 \"UEFI Google PersistentDisk\" "
+            "from PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0)\n"
+            "Verification failed: (0x1A) Security Violation\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_secure_boot_violation' in names
+        assert 'firmware_uefi_boot_load_failed' not in names
+
+    def test_bad_shim_signature_detected(self):
+        """shim/GRUB-emitted Secure Boot rejection, with the realistic
+        follow-up grub error on the same screen (cross-category pairing)."""
+        serial = (
+            "GNU GRUB  version 2.06\n"
+            "\n"
+            "error: bad shim signature.\n"
+            "error: you need to load the kernel first.\n"
+            "\n"
+            "Press any key to continue...\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_secure_boot_violation' in names
+        assert 'grub_load_kernel_first' in names
+
+    def test_gpt_corrupt_detected(self):
+        serial = (
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Machine UUID 12345678-1234-1234-1234-123456789abc\n"
+            "Booting from Hard Disk 0...\n"
+            "Invalid partition table!\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'firmware_gpt_corrupt' in names
+
+    def test_healthy_seabios_boot_no_firmware_findings(self):
+        """'Booting from Hard Disk...' prints on EVERY healthy SeaBIOS boot
+        and must never fire firmware patterns (critic FP correction)."""
+        serial = (
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Machine UUID 12345678-1234-1234-1234-123456789abc\n"
+            "Booting from Hard Disk 0...\n"
+            "Welcome to GRUB!\n"
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    2.412345] EXT4-fs (sda1): mounted filesystem with ordered "
+            "data mode. Quota mode: none.\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_resized_disk_gpt_warning_not_flagged(self):
+        """The kernel's 'GPT: Primary header thinks Alt. header is not at
+        the end of the disk' warning fires on every resized-but-unexpanded
+        PD while the VM boots fine — it must NOT be reported (critic C1)."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    1.234567] GPT:Primary header thinks Alt. header is not at "
+            "the end of the disk.\n"
+            "[    1.234789] GPT:41943039 != 62914559\n"
+            "[    1.234901] GPT: Use GNU Parted to correct GPT errors.\n"
+            "[    2.412345] EXT4-fs (sda1): mounted filesystem with ordered "
+            "data mode. Quota mode: none.\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_stale_firmware_error_cleared_by_later_successful_boot(self):
+        """A firmware failure from an older boot followed by a completed
+        boot must be suppressed on a RUNNING VM (stale ring-buffer noise)."""
+        serial = (
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Booting from Hard Disk 0...\n"
+            "No bootable device.\n"
+            "SeaBIOS (version 1.8.2-20231011_165638-google)\n"
+            "Booting from Hard Disk 0...\n"
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 8.102s (userspace) = 12.306s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -513,7 +513,14 @@ class TestKernelPanicDetection:
         assert 'kernel_panic_generic' not in names
 
     def test_oom_panic_detected(self):
-        """OOM panic should report kernel_panic_oom, not generic."""
+        """OOM panic should report kernel_panic_oom, not generic.
+
+        CONTRACT CHANGE (Wave 4): the 'Out of memory: Killed process' line
+        used to match nothing; since oom.yaml landed it deliberately also
+        produces an oom finding (warning). Both are reported: the kill and
+        the panic are different, both-true findings, and the warning can
+        never suppress the critical (tier-1 requires CRITICAL severity and
+        _is_boot_root_cause excludes warnings/detect-only)."""
         serial = (
             "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
             "[  512.103311] Out of memory: Killed process 1234 (java) total-vm:8388608kB\n"
@@ -524,6 +531,10 @@ class TestKernelPanicDetection:
         names = [e['name'] for e in data['boot_errors']]
         assert 'kernel_panic_oom' in names
         assert 'kernel_panic_generic' not in names
+        assert 'oom_killed_process' in names
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities['kernel_panic_oom'] == 'critical'
+        assert severities['oom_killed_process'] == 'warning'
 
     def test_machine_check_panic_detected(self):
         """Fatal machine check panic should report kernel_panic_machine_check."""
@@ -588,6 +599,9 @@ class TestKernelPanicDetection:
         names = [e['name'] for e in data['boot_errors']]
         assert 'kernel_panic_oom' in names
         assert 'kernel_panic_generic' not in names
+        # Wave 4 contract change: the kill line now also reports oom
+        # (warning) alongside the critical panic - see oom.yaml header.
+        assert 'oom_killed_process' in names
 
     def test_compulsory_oom_panic_detected(self):
         """sysctl vm.panic_on_oom=2 variant ('compulsory ... is enabled')."""
@@ -2141,7 +2155,7 @@ class TestGrubDetection:
 
     def test_grub_out_of_memory_detected(self):
         """GRUB OOM is bound to the 'error:' prefix and must never be
-        confused with kernel OOM (kernel/disk_full categories)."""
+        confused with kernel OOM (kernel/disk_full/oom categories)."""
         serial = (
             "GRUB loading.\n"
             "Welcome to GRUB!\n"
@@ -2156,6 +2170,10 @@ class TestGrubDetection:
         categories = {e['category'] for e in data['boot_errors']}
         assert 'kernel' not in categories
         assert 'disk_full' not in categories
+        # Wave 4: the oom category's regexes are bound to kernel OOM-killer
+        # wording (PID / gfp_mask) - the GRUB 'error: out of memory.' line
+        # must not fire it either.
+        assert 'oom' not in categories
 
     def test_grub_invalid_magic_detected(self):
         serial = (
@@ -2193,7 +2211,10 @@ class TestGrubDetection:
 
     def test_kernel_oom_lines_do_not_trigger_grub(self):
         """Kernel OOM output (timestamp-prefixed 'Out of memory') must not
-        match grub_out_of_memory — proves the 'error:' line-start binding."""
+        match grub_out_of_memory — proves the 'error:' line-start binding.
+
+        (Wave 4: the same buffer now legitimately reports the oom
+        category — the guard here is only that grub must not fire.)"""
         serial = (
             "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
             "[  512.103311] Out of memory: Killed process 1234 (java) "
@@ -2204,6 +2225,7 @@ class TestGrubDetection:
         data = _diagnose(serial)
         categories = {e['category'] for e in data['boot_errors']}
         assert 'grub' not in categories
+        assert 'oom' in categories
 
     def test_mount_unknown_filesystem_type_does_not_trigger_grub(self):
         """The kernel/mount 'unknown filesystem type' wording never starts a
@@ -4038,6 +4060,708 @@ class TestWave3RedTeamRegressions:
             "myapp[1421]: Unable to handle request, retrying\n"
             "[   11.512345] systemd[1]: Startup finished in 3.1s (kernel) "
             "+ 8.4s (userspace) = 11.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestReadonlyDetection (Wave 4 - runtime read-only remount / disk I/O)
+# ---------------------------------------------------------------------------
+
+class TestReadonlyDetection:
+    """Detection tests for readonly.yaml (errors=remount-ro, I/O errors)."""
+
+    def test_ext4_remount_readonly_detected(self):
+        """The device-bound errors=remount-ro line is the critical signal."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[ 8123.412345] EXT4-fs error (device sda1): "
+            "ext4_journal_check_start:83: comm rsyslogd: Detected aborted "
+            "journal\n"
+            "[ 8123.512345] EXT4-fs (sda1): Remounting filesystem read-only\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'readonly_remount' in names
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities['readonly_remount'] == 'critical'
+
+    def test_bare_remount_readonly_detected(self):
+        """ext2/jbd2 print the remount line without the EXT4-fs prefix."""
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[ 4451.209871] Aborting journal on device sdb1-8.\n"
+            "[ 4451.312345] Remounting filesystem read-only\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'readonly_remount' in names
+
+    def test_block_io_errors_detected_as_error_severity(self):
+        """blk_update_request and the 5.18+ prefixless form both match;
+        severity stays error (degradation signal, not proof of fs death)."""
+        serial_old = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[ 7211.101234] blk_update_request: I/O error, dev sdb, "
+            "sector 409600 op 0x0:(READ) flags 0x80700 phys_seg 1 prio "
+            "class 0\n"
+        )
+        serial_new = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[ 7211.101234] I/O error, dev sda, sector 2048 op 0x1:(WRITE) "
+            "flags 0x800 phys_seg 8 prio class 2\n"
+            "[ 7211.202345] Buffer I/O error on dev sda1, logical block 0, "
+            "lost async page write\n"
+        )
+        for serial in (serial_old, serial_new):
+            data = _diagnose(serial)
+            names = [e['name'] for e in data['boot_errors']]
+            assert 'readonly_io_error' in names
+            severities = {e['name']: e['severity']
+                          for e in data['boot_errors']}
+            assert severities['readonly_io_error'] == 'error'
+
+    def test_readonly_and_filesystem_both_fire_on_same_incident(self):
+        """Overlap guard: the 'EXT4-fs error (device ...)' line belongs to
+        filesystem_corruption and the remount-ro line to readonly_remount.
+        Both categories firing on the same buffer is expected and correct
+        (different, both-true findings); neither may dedupe the other."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[ 8123.412345] EXT4-fs error (device sda1): "
+            "ext4_find_entry:1683: inode #2: comm cron: reading directory "
+            "lblock 0\n"
+            "[ 8123.512345] EXT4-fs (sda1): Remounting filesystem read-only\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'filesystem' in categories
+        assert 'readonly' in categories
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+        assert 'readonly_remount' in names
+
+    def test_readonly_survives_boot_success(self):
+        """A remount-ro BEFORE the boot-success marker must still be
+        reported on a RUNNING VM - the VM keeps 'running' while every
+        write fails, which is the entire point of this category."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    8.412345] EXT4-fs (sda1): Remounting filesystem read-only\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'readonly_remount' in names
+
+    def test_healthy_mount_lines_not_flagged(self):
+        """Healthy 'mounted filesystem' / 're-mounted' kernel lines must
+        not fire any readonly pattern."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    2.104233] EXT4-fs (sda1): mounted filesystem with ordered "
+            "data mode. Quota mode: none.\n"
+            "[    5.412345] EXT4-fs (sda1): re-mounted. Quota mode: none.\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestOomDetection (Wave 4 - live OOM kills, mode 55)
+# ---------------------------------------------------------------------------
+
+class TestOomDetection:
+    """Detection tests for oom.yaml (runtime OOM-killer events).
+
+    DELIBERATE CONTRACT CHANGE: before Wave 4 these lines matched nothing
+    (they only appeared as inert context in kernel_panic_oom fixtures and
+    as cross-fire negatives for grub/disk_full). They now produce a
+    warning-severity oom finding by design.
+    """
+
+    def test_historical_oom_kill_on_healthy_vm_is_warning_only(self):
+        """One historical OOM kill on a long-running, otherwise healthy VM:
+        the warning is shown (survives_boot_success), and it is the ONLY
+        finding - it must not drag in kernel/disk_full/grub."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "debian login: \n"
+            "[86412.103311] java invoked oom-killer: gfp_mask=0x140dca"
+            "(GFP_HIGHUSER_MOVABLE|__GFP_COMP|__GFP_ZERO), order=0, "
+            "oom_score_adj=0\n"
+            "[86412.209972] Out of memory: Killed process 1234 (java) "
+            "total-vm:8388608kB, anon-rss:3145728kB, file-rss:0kB\n"
+            "[86412.312345] oom_reaper: reaped process 1234 (java)\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        assert len(data['boot_errors']) == 1
+        err = data['boot_errors'][0]
+        assert err['name'] == 'oom_killed_process'
+        assert err['severity'] == 'warning'
+        assert err['category'] == 'oom'
+
+    def test_invoked_oom_killer_line_alone_detected(self):
+        """The invocation header alone (kill line lost to buffer rotation)
+        must still produce the single oom finding."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  512.103311] chrome invoked oom-killer: gfp_mask=0x140cca, "
+            "order=0, oom_score_adj=300\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert names.count('oom_killed_process') == 1
+
+    def test_panic_on_oom_reports_both_oom_and_kernel_panic(self):
+        """A panic_on_oom buffer reports BOTH the kill (oom, warning) and
+        the panic (kernel_panic_oom, critical) - and the warning does not
+        suppress or demote the critical (tier-1 suppressors require
+        CRITICAL severity; oom is warning + detect-only)."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  512.103311] Out of memory: Killed process 1234 (java) "
+            "total-vm:8388608kB\n"
+            "[  512.209972] Kernel panic - not syncing: Out of memory: "
+            "system-wide panic_on_oom is enabled\n"
+        )
+        data = _diagnose(serial)
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities.get('oom_killed_process') == 'warning'
+        assert severities.get('kernel_panic_oom') == 'critical'
+        assert 'kernel_panic_generic' not in severities
+
+    def test_panic_line_alone_does_not_fire_oom(self):
+        """The panic wording ('Out of memory: system-wide panic_on_oom is
+        enabled') carries no kill PID - the oom regexes must not match it,
+        proving they are bound to OOM-killer kill wording."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  600.001122] Kernel panic - not syncing: Out of memory: "
+            "system-wide panic_on_oom is enabled\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'kernel' in categories
+        assert 'oom' not in categories
+
+    def test_oom_warning_never_suppresses_emergency_mode(self):
+        """Tier-1 guard: emergency mode (catch-all, critical) may only be
+        replaced by a CRITICAL root cause - an oom warning must leave it
+        untouched, and both findings are reported."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  312.103311] Out of memory: Killed process 812 (mkfs.ext4) "
+            "total-vm:524288kB\n"
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view system logs.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'oom_killed_process' in names
+        assert 'fstab_emergency_mode' in names
+
+    def test_prose_oom_mentions_not_flagged(self):
+        """Prose quoting 'Out of memory' / 'oom-killer' without kernel kill
+        wording (PID, gfp_mask) must not match."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "startup-script[900]: INFO: page oncall if app logs show "
+            "\"Out of memory\" or the oom-killer was invoked\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestSelinuxDetection (Wave 4 - mode 51, RHEL family)
+# ---------------------------------------------------------------------------
+
+class TestSelinuxDetection:
+    """Detection tests for selinux.yaml."""
+
+    def test_policy_load_failure_freezing_detected(self):
+        """The classic one-line RHEL unbootable: 'Failed to load SELinux
+        policy, freezing.' - selinux fires; systemd_freeze must NOT
+        (its anchor is the distinct 'Freezing execution' wording)."""
+        serial = (
+            "[    1.912345] systemd[1]: Successfully made /usr/ read-only.\n"
+            "[    2.412345] systemd[1]: Failed to load SELinux policy, "
+            "freezing.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'selinux_policy_load_failure' in names
+        assert 'systemd_freeze' not in names
+        severities = {e.name: e.severity for e in result.boot_errors}
+        assert severities['selinux_policy_load_failure'] == 'critical'
+
+    def test_policy_load_failure_two_line_form_reports_both(self):
+        """Modern systemd splits cause and terminal action across lines:
+        selinux reports the cause, systemd_freeze the freeze - both are
+        true and both must surface."""
+        serial = (
+            "[    2.412345] systemd[1]: Failed to load SELinux policy.\n"
+            "[    2.412500] systemd[1]: Freezing execution.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'selinux_policy_load_failure' in names
+        assert 'systemd_freeze' in names
+
+    def test_kernel_policy_read_failure_detected(self):
+        """Kernel-side wording with its double space after 'SELinux:'."""
+        serial = (
+            "[    0.000000] Linux version 5.14.0-362.el9.x86_64\n"
+            "[    1.512345] SELinux:  policy read failure\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'selinux_policy_load_failure' in names
+
+    def test_relabel_banner_is_warning(self):
+        """The autorelabel banner is the start of a normal self-resolving
+        relabel run - warning, not critical."""
+        serial = (
+            "[    0.000000] Linux version 5.14.0-362.el9.x86_64\n"
+            "*** Warning -- SELinux targeted policy relabel is required. "
+            "***\n"
+            "*** Relabeling could take a very long time, depending on file "
+            "***\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        findings = [e for e in result.boot_errors
+                    if e.name == 'selinux_relabel_required']
+        assert findings
+        assert all(f.severity == 'warning' for f in findings)
+
+    def test_avc_denials_and_healthy_selinux_lines_not_flagged(self):
+        """Routine AVC denials and the healthy policy-load lines on an
+        enforcing RHEL boot must not produce selinux findings."""
+        serial = (
+            "[    0.000000] Linux version 5.14.0-362.el9.x86_64\n"
+            "[    1.512345] SELinux:  Initializing.\n"
+            "[    3.412345] systemd[1]: Successfully loaded SELinux policy "
+            "in 98.234ms.\n"
+            "[    9.812345] audit: type=1400 audit(1719900000.123:4): avc:  "
+            "denied  { read } for  pid=812 comm=\"httpd\" name=\"data\" "
+            "dev=\"sda1\" ino=1234\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_stale_selinux_failure_cleared_by_later_successful_boot(self):
+        """No survives_boot_success (deliberate): a later completed boot
+        proves the policy loaded, so the old failure is stale noise that
+        suppression must clear on a RUNNING VM."""
+        serial = (
+            "[    2.412345] systemd[1]: Failed to load SELinux policy, "
+            "freezing.\n"
+            "[    0.000000] Linux version 5.14.0-362.el9.x86_64 (second "
+            "boot)\n"
+            "[    3.412345] systemd[1]: Successfully loaded SELinux policy "
+            "in 98.234ms.\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestStartupScriptDetection (Wave 5 - GCE startup-script failures)
+# ---------------------------------------------------------------------------
+
+class TestStartupScriptDetection:
+    """Detection tests for startup_script.yaml."""
+
+    def test_nonzero_exit_status_detected_as_warning(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  OK  ] Started google-startup-scripts.service - Google "
+            "Compute Engine Startup Scripts.\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "google_metadata_script_runner[712]: startup-script exit "
+            "status 1\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        err = data['boot_errors'][0]
+        assert err['name'] == 'startup_script_failed'
+        assert err['severity'] == 'warning'
+        assert err['category'] == 'startup_script'
+
+    def test_exit_status_zero_never_matches(self):
+        """Overlap guard: the healthy 'startup-script exit status 0' line
+        prints on every successful boot and must produce zero findings."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "google_metadata_script_runner[712]: startup-script exit "
+            "status 0\n"
+            "google_metadata_script_runner[712]: Finished running startup "
+            "scripts.\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_exit_status_zero_alongside_real_failure_stays_silent(self):
+        """A successful startup script next to an unrelated boot failure
+        must not add a startup_script finding."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device /dev/disk/by-uuid/"
+            "deadbeef-1234-5678-9abc-def012345678\n"
+            "google_metadata_script_runner[712]: startup-script exit "
+            "status 0\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        assert 'fstab' in categories
+        assert 'startup_script' not in categories
+
+    def test_multidigit_exit_status_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "google_metadata_script_runner[712]: startup-script exit "
+            "status 127\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'startup_script_failed' in names
+
+    def test_startup_script_url_failure_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "google_metadata_script_runner[712]: startup-script-url exit "
+            "status 1\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'startup_script_failed' in names
+
+    def test_guest_agent_script_failed_wording_detected(self):
+        """Guest-agent variant: Script "startup-script" failed with error.
+        (No contiguous 'exit status' phrase - covered by the second
+        regex.)"""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "GCEMetadataScripts: Script \"startup-script\" failed with "
+            "error: exit status 127\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'startup_script_failed' in names
+
+
+# ---------------------------------------------------------------------------
+# TestCloudInitDetection (Wave 5 - cloud-init failures)
+# ---------------------------------------------------------------------------
+
+class TestCloudInitDetection:
+    """Detection tests for cloud_init.yaml."""
+
+    def test_module_traceback_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[   10.312478] cloud-init[981]: Traceback (most recent call "
+            "last):\n"
+            "[   10.312600] cloud-init[981]:   File \"/usr/lib/python3/"
+            "dist-packages/cloudinit/cmd/main.py\", line 761, in "
+            "status_wrapper\n"
+            "[   10.312700] cloud-init[981]: ValueError: bad user-data\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'cloud_init_stage_failure' in names
+
+    def test_failed_to_run_module_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[   11.412478] cloud-init[981]: 2026-07-04 10:00:00,123 - "
+            "util.py[WARNING]: Failed to run module scripts-user\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'cloud_init_stage_failure' in names
+
+    def test_cloud_init_unit_failure_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[FAILED] Failed to start Initial cloud-init job (metadata "
+            "service crawler).\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'cloud_init_unit_failed' in names
+
+    def test_cloud_config_unit_failure_detected(self):
+        """cloud-config.service's description carries no 'cloud-init'
+        token - covered by the dedicated cloud-(config|final) regex."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[FAILED] Failed to start Apply the settings specified in "
+            "cloud-config.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'cloud_init_unit_failed' in names
+
+    def test_healthy_cloud_init_lines_not_flagged(self):
+        """Normal cloud-init stage banners and the success 'finished'
+        line must produce zero findings."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[   10.312478] cloud-init[498]: Cloud-init v. 24.1.3 running "
+            "'modules:final' at Fri, 04 Jul 2026 10:00:00 +0000.\n"
+            "[   11.812345] cloud-init[498]: Cloud-init v. 24.1.3 finished "
+            "at Fri, 04 Jul 2026 10:00:01 +0000. Datasource DataSourceGCE. "
+            "Up 11.28 seconds\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_ordering_cycle_naming_cloud_init_does_not_fire_cloud_init(self):
+        """An ordering cycle that happens to delete cloud-init's job is a
+        systemd_early finding, not a cloud_init one."""
+        serial = (
+            "[    3.912345] systemd[1]: sysinit.target: Found ordering "
+            "cycle on sysinit.target/start\n"
+            "[    3.912400] systemd[1]: sysinit.target: Breaking ordering "
+            "cycle by deleting job cloud-init.service/start\n"
+            "[    3.912500] systemd[1]: cloud-init.service: Job "
+            "cloud-init.service/start deleted to break ordering cycle\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        assert 'systemd_early' in categories
+        assert 'cloud_init' not in categories
+
+    def test_provisioning_failure_survives_boot_success(self):
+        """cloud-init failures coexist with a completed boot by nature -
+        a RUNNING VM with the success marker AFTER the failure must still
+        report it."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[   11.412478] cloud-init[981]: 2026-07-04 10:00:00,123 - "
+            "util.py[WARNING]: Failed to run module scripts-user\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cloud_init_stage_failure' in names
+
+
+# ---------------------------------------------------------------------------
+# TestNetworkBootDetection (Wave 5 - network bring-up failures)
+# ---------------------------------------------------------------------------
+
+class TestNetworkBootDetection:
+    """Detection tests for network.yaml."""
+
+    def test_networkd_unit_failure_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[FAILED] Failed to start systemd-networkd.service - Network "
+            "Configuration.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'network_unit_failed' in names
+
+    def test_network_manager_unit_failure_detected(self):
+        serial = (
+            "[    0.000000] Linux version 5.14.0-362.el9.x86_64\n"
+            "[FAILED] Failed to start Network Manager.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'network_unit_failed' in names
+
+    def test_dhcp_no_offers_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "dhclient[612]: DHCPDISCOVER on eth0 to 255.255.255.255 port "
+            "67 interval 15\n"
+            "dhclient[612]: No DHCPOFFERS received.\n"
+            "dhclient[612]: No working leases in persistent database - "
+            "sleeping.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'network_dhcp_failure' in names
+
+    def test_failed_to_bring_up_eth0_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "ifup: failed to bring up eth0\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'network_dhcp_failure' in names
+
+    def test_post_boot_nic_death_reported_on_running_vm(self):
+        """THE support case this category exists for: the NIC dies after a
+        completed boot. The error lines sit AFTER the last success marker,
+        so the ordering check protects them from suppression even though
+        the category does not declare survives_boot_success."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "debian login: \n"
+            "dhclient[9812]: DHCPDISCOVER on eth0 to 255.255.255.255 port "
+            "67 interval 20\n"
+            "dhclient[9812]: No DHCPOFFERS received.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'network_dhcp_failure' in names
+
+    def test_benign_early_flap_cleared_by_boot_success(self):
+        """A bring-up failure that the boot recovered from (marker AFTER
+        the error) is exactly the transient noise survives_boot_success:
+        false exists to clear - the VM must report healthy."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "dhclient[612]: No DHCPOFFERS received.\n"
+            "[FAILED] Failed to start Wait for Network to be Configured.\n"
+            "dhclient[615]: DHCPACK of 10.128.0.14 from 169.254.169.254\n"
+            "[   22.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 18.1s (userspace) = 22.3s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_benign_unit_failures_do_not_fire_network(self):
+        """The healthy-noise units (apt-daily, motd-news style) must not
+        match the unit-bound network regexes."""
+        serial = (
+            "[    0.000000] Linux version 6.8.0-31-generic\n"
+            "[FAILED] Failed to start Update APT News.\n"
+            "[FAILED] Failed to start Download data for packages that "
+            "failed at package install time.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        assert 'network' not in categories
+
+
+# ---------------------------------------------------------------------------
+# TestSerialGettyDetection (Wave 5 - serial console access, ssh category)
+# ---------------------------------------------------------------------------
+
+class TestSerialGettyDetection:
+    """Detection tests for ssh_serial_getty_failed (lives in ssh.yaml:
+    the ssh category is the operator-access-paths category, and getty
+    failures are boot-completing access failures exactly like sshd's)."""
+
+    def test_getty_failed_result_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   14.512345] systemd[1]: serial-getty@ttyS0.service: Failed "
+            "with result 'exit-code'.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_serial_getty_failed' in names
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'ssh' in categories
+
+    def test_getty_restart_loop_detected(self):
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   14.512345] systemd[1]: serial-getty@ttyS0.service: Start "
+            "request repeated too quickly.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_serial_getty_failed' in names
+
+    def test_failed_to_start_serial_getty_detected(self):
+        """Console status-line form (unit description, no unit name)."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[FAILED] Failed to start Serial Getty on ttyS0.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_serial_getty_failed' in names
+
+    def test_getty_survives_boot_success(self):
+        """A dead getty does not block boot (ssh category semantics): the
+        finding must survive a RUNNING VM's boot-success marker."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   14.512345] systemd[1]: serial-getty@ttyS0.service: Failed "
+            "with result 'exit-code'.\n"
+            "[   16.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 12.1s (userspace) = 16.3s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_serial_getty_failed' in names
+
+    def test_healthy_started_getty_not_flagged(self):
+        """The healthy 'Started serial-getty@ttyS0.service' journal line
+        and console '[  OK  ] Started Serial Getty on ttyS0.' must not
+        match."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   14.512345] systemd[1]: Started serial-getty@ttyS0.service "
+            "- Serial Getty on ttyS0.\n"
+            "[  OK  ] Started Serial Getty on ttyS0.\n"
+            "[   16.512345] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 12.1s (userspace) = 16.3s.\n"
             "debian login: \n"
         )
         data = _diagnose(serial)

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -3212,3 +3212,186 @@ class TestFstabDistroBroadening:
         assert 'fstab_mount_failed' in names
         # Root cause wins; the generic emergency catch-all stays demoted.
         assert 'fstab_emergency_mode' not in names
+
+
+# ---------------------------------------------------------------------------
+# TestDistroBroadeningRedTeamRegressions
+# ---------------------------------------------------------------------------
+
+class TestDistroBroadeningRedTeamRegressions:
+    """Regressions from the adversarial review of the distro-broadening
+    branch (dracut/BusyBox/LVM/LUKS/RAID). Each test reproduces a confirmed
+    failing serial buffer from the red-team report."""
+
+    # C1: an S2-shaped dracut failure ALWAYS prints 'Entering emergency
+    # mode.' — once the incident is resolved and the VM boots, the stale
+    # emergency line must not veto boot-success suppression forever.
+    _RESOLVED_DRACUT_EMERGENCY = (
+        "[  135.209316] dracut-initqueue[550]: Warning: dracut-initqueue "
+        "timeout - starting timeout scripts\n"
+        "[  191.964618] dracut-initqueue[550]: Warning: Could not boot.\n"
+        "[  191.976595] dracut-initqueue[550]: Warning: /dev/disk/by-uuid/"
+        "00000000-0000-0000-0000-000000000bad does not exist\n"
+        "Generating \"/run/initramfs/rdsosreport.txt\"\n"
+        "Entering emergency mode. Exit the shell to continue.\n"
+        "dracut:/# \n"
+        "-- reboot --\n"
+        "[    2.412345] XFS (sda4): Ending clean mount\n"
+        "[    5.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+        "+ 8.102s (userspace) = 12.306s.\n"
+        "rocky9 login: \n"
+    )
+
+    def test_resolved_dracut_emergency_reports_healthy(self):
+        """C1: a resolved dracut emergency incident followed by a clean
+        boot on a RUNNING VM must report healthy — the stale 'Entering
+        emergency mode' line must not permanently block suppression."""
+        data = _diagnose(self._RESOLVED_DRACUT_EMERGENCY)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_resolved_fstab_emergency_reports_healthy(self):
+        """C1: same veto bug via the fstab wording ('You are in emergency
+        mode') — resolved incident + clean boot must report healthy."""
+        serial = (
+            "systemd[1]: Timed out waiting for device /dev/disk/by-uuid/"
+            "deadbeef-1234-5678-9abc-def012345678\n"
+            "systemd[1]: Dependency failed for /data.\n"
+            "You are in emergency mode. After logging in, type "
+            '"journalctl -xb" to view\n'
+            "-- reboot --\n"
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_unresolved_dracut_emergency_still_reported(self):
+        """C1 guard: when the emergency shell is the LATEST evidence (stale
+        success marker from an older boot first), the findings must be
+        retained — suppression stays position-based, not presence-based."""
+        serial = (
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+            "-- reboot --\n"
+            "[  135.209316] dracut-initqueue[550]: Warning: dracut-initqueue "
+            "timeout - starting timeout scripts\n"
+            "Entering emergency mode. Exit the shell to continue.\n"
+            "dracut:/# \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_dracut_timeout' in names
+        assert 'initramfs_dracut_emergency' in names
+
+    def test_mdadm_failed_to_run_array_detected(self):
+        """C2: the actual mdadm wording for a refused array start
+        (Assemble.c: 'failed to RUN_ARRAY') must fire raid_start_failed."""
+        serial = (
+            "mdadm: failed to RUN_ARRAY /dev/md0: Input/output error\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'raid_start_failed' in names
+
+    def test_mdadm_not_enough_to_start_assemble_wording_detected(self):
+        """C2: degraded raid1 refusal via mdadm --assemble ('- not enough
+        to start the array.') must fire raid_start_failed."""
+        serial = (
+            "mdadm: /dev/md0 assembled from 1 drive - not enough to "
+            "start the array.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'raid_start_failed' in names
+
+    def test_mdadm_not_enough_to_start_incremental_wording_detected(self):
+        """C2: the udev incremental-assembly path modern boots use
+        (Incremental.c: 'attached to ..., not enough to start (1).') must
+        fire raid_start_failed."""
+        serial = (
+            "mdadm: /dev/sdb1 attached to /dev/md/0, not enough to "
+            "start (1).\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'raid_start_failed' in names
+
+    def test_completed_cryptswap_job_on_stopped_vm_not_flagged(self):
+        """C3: a transient cryptsetup start-job spinner that COMPLETES must
+        not fire crypt_unlock_wait on a TERMINATED VM (boot-success
+        suppression is skipped there — the regex itself must reject it)."""
+        serial = (
+            "[ ***  ] A start job is running for Cryptography Setup for "
+            "cryptswap1 (11s / no limit)\n"
+            "[  OK  ] Started Cryptography Setup for cryptswap1.\n"
+            "[    9.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 5.102s (userspace) = 9.306s.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        assert result.diagnosis_status == 'healthy'
+        assert result.boot_errors == []
+
+    def test_completed_crypt_device_unit_job_on_stopped_vm_not_flagged(self):
+        """C3: Ubuntu device-unit spinner form, resolved by 'Found device'
+        — must also stay silent on a TERMINATED VM."""
+        serial = (
+            "[ ***  ] A start job is running for "
+            "dev-mapper-cryptswap1.device (7s / 1min 30s)\n"
+            "[  OK  ] Found device /dev/mapper/cryptswap1.\n"
+            "[    9.204333] systemd[1]: Startup finished in 4.204s (kernel) "
+            "+ 5.102s (userspace) = 9.306s.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        assert result.diagnosis_status == 'healthy'
+        assert result.boot_errors == []
+
+    def test_hung_crypt_job_still_detected_on_stopped_vm(self):
+        """C3 guard: a real hang repeats the spinner with no completion
+        line — crypt_unlock_wait must still fire (TERMINATED)."""
+        serial = (
+            "[ ***  ] A start job is running for Cryptography Setup for "
+            "luks-2f4c8e11 (30s / no limit)\n"
+            "[***   ] A start job is running for Cryptography Setup for "
+            "luks-2f4c8e11 (1min 30s / no limit)\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'crypt_unlock_wait' in names
+
+    def test_busybox_alert_uuid_line_does_not_fire_fstab(self):
+        """C4: the BusyBox 'ALERT!  UUID=... does not exist' line names the
+        root= kernel parameter — initramfs_busybox_shell owns it; the
+        fstab auto-repair guidance (wrong file) must NOT co-fire."""
+        serial = (
+            "Gave up waiting for root file system device.  Common "
+            "problems:\n"
+            " - Boot args (cat /proc/cmdline)\n"
+            "ALERT!  UUID=11111111-2222-3333-4444-555555555555 does not "
+            "exist.  Dropping to a shell!\n"
+            "BusyBox v1.30.1 (Ubuntu 1:1.30.1-7ubuntu3) built-in shell "
+            "(ash)\n"
+            "(initramfs) \n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_busybox_shell' in names
+        assert 'fstab_uuid_not_found' not in names
+
+    def test_non_alert_uuid_not_found_still_fires_fstab(self):
+        """C4 guard: the ALERT carve-out must not lose genuine fstab UUID
+        failures on ordinary systemd/mount lines."""
+        serial = (
+            "Linux version 6.1.0-18-cloud-amd64\n"
+            "mount: UUID=deadbeef-1234-5678-9abc-def012345678 does not "
+            "exist\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'fstab_uuid_not_found' in names

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -59,6 +59,14 @@ def _make_http_error(status_code, message="error"):
     return HttpError(resp, f'{{"error": {{"message": "{message}"}}}}'.encode())
 
 
+def _diagnose(serial: str):
+    """Run DiagnoseOperation against a serial excerpt, return rollback_data."""
+    compute = _make_compute(serial_output=serial)
+    op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+    result = op.execute('test-vm')
+    return result.rollback_data
+
+
 # ---------------------------------------------------------------------------
 # TestDiagnoseBasic
 # ---------------------------------------------------------------------------
@@ -478,3 +486,174 @@ class TestDiagnoseStabilization:
             result = op.execute('test-vm', stabilize=False)
             mock_stab.assert_not_called()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseCpuLockup
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseCpuLockup:
+    """Detection tests for the cpu_lockup category (soft/hard lockups, bus
+    locks, RCU stalls)."""
+
+    def test_soft_lockup_detected(self):
+        """Canonical soft-lockup watchdog line should be detected as error."""
+        serial = (
+            "[  241.693421] watchdog: BUG: soft lockup - CPU#0 stuck for 22s! [stress-ng-cpu:1523]\n"
+            "[  241.702118] Modules linked in: nft_ct nf_tables binfmt_misc virtio_net\n"
+            "[  241.710233] CPU: 0 PID: 1523 Comm: stress-ng-cpu Not tainted 6.1.0-18-cloud-amd64 #1\n"
+            "[  241.719544] Hardware name: Google Google Compute Engine/Google Compute Engine\n"
+            "[  241.728901] RIP: 0010:queued_spin_lock_slowpath+0x5b/0x1d0\n"
+            "[  241.737010] Call Trace:\n"
+            "[  241.741232]  <IRQ>\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        errors = data['boot_errors']
+        names = [e['name'] for e in errors]
+        assert 'cpu_lockup_soft_lockup' in names
+        err = next(e for e in errors if e['name'] == 'cpu_lockup_soft_lockup')
+        assert err['category'] == 'cpu_lockup'
+        assert err['severity'] == 'error'
+        assert len(err['suggested_fixes']) > 0
+
+    def test_hard_lockup_detected(self):
+        """NMI watchdog hard lockup should be detected as critical."""
+        serial = (
+            "[  312.099873] Uhhuh. NMI received for unknown reason 3d on CPU 2.\n"
+            "[  312.104501] NMI watchdog: Watchdog detected hard LOCKUP on cpu 2\n"
+            "[  312.110276] Modules linked in: virtio_scsi virtio_pci virtio_ring\n"
+            "[  312.118440] CPU: 2 PID: 887 Comm: kworker/2:1 Tainted: G L 5.15.0-91-generic\n"
+            "[  312.127655] Hardware name: Google Google Compute Engine/Google Compute Engine\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        err = next(
+            e for e in data['boot_errors']
+            if e['name'] == 'cpu_lockup_hard_lockup'
+        )
+        assert err['severity'] == 'critical'
+
+    def test_bus_lock_trap_detected(self):
+        """Kernel split-lock-detection trap line should be detected as warning."""
+        serial = (
+            "[  102.328812] x86/split lock detection: warning about user-space bus_locks\n"
+            "[  102.334455] x86/split lock detection: #DB: myapp/2211 took a bus_lock trap at address: 0x7f3c2a1b4d20\n"
+            "[  102.341102] perf: interrupt took too long (2503 > 2500), lowering kernel.perf_event_max_sample_rate\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        err = next(
+            e for e in data['boot_errors']
+            if e['name'] == 'cpu_lockup_bus_lock'
+        )
+        assert err['severity'] == 'warning'
+
+    def test_split_lock_phrase_detected(self):
+        """Plain 'split lock detected' phrasing should also match."""
+        serial = (
+            "[   88.120933] core: split lock detected in workload process sampler/1877\n"
+            "[   88.127544] core: this access severely degrades memory bus performance\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_bus_lock' in names
+
+    def test_rcu_stall_detected(self):
+        """rcu_sched stall report should be detected as error."""
+        serial = (
+            "[  455.220133] rcu: INFO: rcu_sched detected stalls on CPUs/tasks:\n"
+            "[  455.226801] rcu: \t3-...0: (1 GPs behind) idle=8a2/1/0x4000000000000000 softirq=8412/8413 fqs=2626\n"
+            "[  455.235477] rcu: \t(detected by 0, t=5252 jiffies, g=24829, q=1290)\n"
+            "[  455.244103] Sending NMI from CPU 0 to CPUs 3:\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        err = next(
+            e for e in data['boot_errors']
+            if e['name'] == 'cpu_lockup_rcu_stall'
+        )
+        assert err['severity'] == 'error'
+
+    def test_rcu_self_detected_stall_variant(self):
+        """Older self-detected stall phrasing should match the same pattern."""
+        serial = (
+            "[  978.301220] INFO: rcu_sched self-detected stall on CPU { 1}  (t=5250 jiffies g=4294 c=4293 q=880)\n"
+            "[  978.309912] Task dump for CPU 1:\n"
+            "[  978.316733] cruncher        R  running task        0  2231      1 0x00000008\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_rcu_stall' in names
+
+    def test_healthy_boot_matches_no_cpu_lockup_patterns(self):
+        """A clean boot must not produce any cpu_lockup findings."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel@lists.debian.org)\n"
+            "[    1.204551] EXT4-fs (sda1): mounted filesystem with ordered data mode\n"
+            "[    2.883104] systemd[1]: Detected virtualization google.\n"
+            "login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_benign_nmi_line_not_matched(self):
+        """'NMI received for unknown reason' alone is not a hard lockup."""
+        serial = (
+            "[  120.401220] Uhhuh. NMI received for unknown reason 31 on CPU 0.\n"
+            "[  120.407733] Do you have a strange power saving mode enabled?\n"
+            "[  120.414092] Dazed and confused, but trying to continue\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'cpu_lockup' not in categories
+
+    def test_fstab_errors_do_not_trigger_cpu_lockup_patterns(self):
+        """fstab failure lines must not produce cpu_lockup findings."""
+        serial = (
+            "[  241.693421] systemd[1]: Timed out waiting for device "
+            "/dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "[  241.702118] systemd[1]: Dependency failed for /mnt/data\n"
+            "[  241.710233] You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'cpu_lockup' not in categories
+        assert 'fstab' in categories
+
+    def test_cpu_lockup_lines_do_not_trigger_fstab_patterns(self):
+        """Lockup lines must not produce fstab findings."""
+        serial = (
+            "[  241.693421] watchdog: BUG: soft lockup - CPU#3 stuck for 26s! [dd:2210]\n"
+            "[  241.702118] CPU: 3 PID: 2210 Comm: dd Not tainted 6.1.0-18-cloud-amd64 #1\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert categories == {'cpu_lockup'}
+
+    def test_lockup_finding_suppresses_emergency_mode_catch_all(self):
+        """A cpu_lockup root cause should drop the emergency-mode catch-all
+        finding (tier-1 dedupe)."""
+        serial = (
+            "[  312.104501] NMI watchdog: Watchdog detected hard LOCKUP on cpu 1\n"
+            "[  320.220118] You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_hard_lockup' in names
+        assert 'fstab_emergency_mode' not in names
+
+    def test_recovered_lockup_before_boot_success_is_suppressed(self):
+        """A lockup that happened BEFORE the last successful boot marker on a
+        RUNNING VM is history: boot-success suppression clears it and the VM
+        reports healthy. This is intentional — a recovered soft lockup needs
+        no rescue action."""
+        serial = (
+            "[  241.693421] watchdog: BUG: soft lockup - CPU#0 stuck for 22s! [stress-ng-cpu:1523]\n"
+            "[  241.702118] CPU: 0 PID: 1523 Comm: stress-ng-cpu Not tainted 6.1.0-18-cloud-amd64 #1\n"
+            "[  400.101332] systemd[1]: Startup finished in 4.512s (kernel) + 11.204s (userspace) = 15.716s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -59,6 +59,14 @@ def _make_http_error(status_code, message="error"):
     return HttpError(resp, f'{{"error": {{"message": "{message}"}}}}'.encode())
 
 
+def _diagnose(serial: str):
+    """Run DiagnoseOperation against a serial excerpt, return rollback_data."""
+    compute = _make_compute(serial_output=serial)
+    op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+    result = op.execute('test-vm')
+    return result.rollback_data
+
+
 # ---------------------------------------------------------------------------
 # TestDiagnoseBasic
 # ---------------------------------------------------------------------------
@@ -478,3 +486,138 @@ class TestDiagnoseStabilization:
             result = op.execute('test-vm', stabilize=False)
             mock_stab.assert_not_called()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseFilesystemPatterns
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseFilesystemPatterns:
+    """Detection tests for the filesystem diagnose category."""
+
+    def test_bad_magic_number_detected(self):
+        """e2fsck bad superblock magic should fire filesystem_bad_superblock."""
+        serial = (
+            "[  OK  ] Reached target local-fs-pre.target - Preparation for Local File Systems.\n"
+            "         Starting systemd-fsck@dev-sdb.service - File System Check on /dev/sdb...\n"
+            "systemd-fsck[412]: fsck.ext4: Bad magic number in super-block while trying to open /dev/sdb\n"
+            "systemd-fsck[412]: fsck failed with exit status 8.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_bad_superblock' in names
+
+    def test_superblock_invalid_backup_blocks_detected(self):
+        """fsck falling back to backup superblocks should fire filesystem_bad_superblock."""
+        serial = (
+            "         Starting systemd-fsck@dev-sdb.service - File System Check on /dev/sdb...\n"
+            "systemd-fsck[388]: fsck.ext4: Superblock invalid, trying backup blocks...\n"
+            "systemd-fsck[388]: /dev/sdb was not cleanly unmounted, check forced.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_bad_superblock' in names
+
+    def test_superblock_could_not_be_read_detected(self):
+        """e2fsck superblock-unreadable guidance should fire filesystem_bad_superblock."""
+        serial = (
+            "systemd-fsck[395]: The superblock could not be read or does not describe a valid ext2/ext3/ext4\n"
+            "systemd-fsck[395]: filesystem.  If the device is valid and it really contains an ext2/ext3/ext4\n"
+            "systemd-fsck[395]: filesystem (and not swap or ufs or something else), then the superblock\n"
+            "systemd-fsck[395]: is corrupt, and you might try running e2fsck with an alternate superblock:\n"
+            "systemd-fsck[395]:     e2fsck -b 8193 <device>\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_bad_superblock' in names
+
+    def test_vfs_cant_find_ext4_detected(self):
+        """Kernel mount error for a wiped superblock (observed live on GCE
+        Debian 12 serial console) should fire filesystem_bad_superblock."""
+        serial = (
+            "         Mounting mnt-data.mount - /mnt/data...\n"
+            "[    4.444497] EXT4-fs (sda): VFS: Can't find ext4 filesystem\n"
+            "[FAILED] Failed to mount mnt-data.mount - /mnt/data.\n"
+            "[DEPEND] Dependency failed for local-fs.target - Local File Systems.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_bad_superblock' in names
+        # The generic fstab mount-failure symptom is suppressed (tier 2 dedupe)
+        # because the filesystem finding is a specific root cause.
+        assert 'fstab_mount_failed' not in names
+
+    def test_superblock_partition_table_corrupt_detected(self):
+        """e2fsck size-mismatch corruption verdict should fire filesystem_corruption."""
+        serial = (
+            "systemd-fsck[401]: The filesystem size (according to the superblock) is 2621440 blocks\n"
+            "systemd-fsck[401]: The physical size of the device is 2359296 blocks\n"
+            "systemd-fsck[401]: Either the superblock or the partition table is likely to be corrupt!\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+
+    def test_xfs_in_memory_corruption_detected(self):
+        """XFS in-memory corruption shutdown should fire filesystem_corruption."""
+        serial = (
+            "[  241.693421] XFS (sdb1): Corruption of in-memory data detected.  Shutting down filesystem\n"
+            "[  241.695832] XFS (sdb1): Please unmount the filesystem and rectify the problem(s)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+
+    def test_xfs_metadata_corruption_detected(self):
+        """XFS metadata verifier failure should fire filesystem_corruption."""
+        serial = (
+            "[   88.114532] XFS (sdb1): Metadata corruption detected at xfs_inode_buf_verify+0x15e/0x180 [xfs], xfs_inode block 0x80\n"
+            "[   88.117201] XFS (sdb1): Unmount and run xfs_repair\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+
+    def test_ext4_fs_error_detected(self):
+        """Kernel EXT4-fs error report should fire filesystem_corruption."""
+        serial = (
+            "[  152.208814] EXT4-fs error (device sdb1): ext4_find_entry:1455: inode #2: comm systemd: reading directory lblock 0\n"
+            "[  152.211903] Aborting journal on device sdb1-8.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+
+    def test_benign_ext4_mount_message_not_matched(self):
+        """Normal EXT4-fs mount messages must not fire filesystem patterns."""
+        serial = (
+            "[    1.812345] EXT4-fs (sda1): mounted filesystem with ordered data mode. Quota mode: none.\n"
+            "[    2.104211] EXT4-fs (sdb): recovery complete\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+
+    def test_fstab_errors_do_not_trigger_filesystem_patterns(self):
+        """Plain fstab config errors must not fire filesystem patterns."""
+        serial = (
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "You are in emergency mode. After logging in, type journalctl -xb\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'filesystem' not in categories
+
+    def test_healthy_boot_matches_no_filesystem_patterns(self):
+        """A clean boot log should produce a healthy diagnosis."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel@lists.debian.org)\n"
+            "[    2.410394] EXT4-fs (sda1): mounted filesystem with ordered data mode.\n"
+            "[  OK  ] Reached target multi-user.target - Multi-User System.\n"
+            "Debian GNU/Linux 12 test-vm ttyS0\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -1695,3 +1695,156 @@ class TestDiagnoseFilesystemRedTeamRegressions:
         data = _diagnose(serial)
         assert data['diagnosis_status'] == 'healthy'
         assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseUnifiedEngineRedTeamRegressions
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseUnifiedEngineRedTeamRegressions:
+    """Regressions from the adversarial review of the unified diagnose
+    engine (2.4.0 coverage integration). Each test reproduces a confirmed
+    failing serial buffer from the red-team report. The _diagnose helper
+    runs with vm_status RUNNING."""
+
+    def test_lone_ssh_error_does_not_erase_emergency_mode(self):
+        """C1: a single ssh auth error (survives-boot category, can never
+        explain emergency mode) must not qualify as a Tier-1 root cause and
+        delete the CRITICAL fstab_emergency_mode finding."""
+        serial = (
+            "You are in emergency mode. After logging in, type "
+            '"journalctl -xb" to view system logs.\n'
+            "sshd[401]: Authentication refused: bad ownership or modes "
+            "for directory /home/bob/.ssh\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_emergency_mode' in names
+        assert 'ssh_auth_permissions' in names
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities['fstab_emergency_mode'] == 'critical'
+
+    def test_lone_filesystem_error_does_not_erase_emergency_mode(self):
+        """C1 side effect (safe direction): a filesystem finding alone also
+        stops suppressing emergency mode — both findings are shown."""
+        serial = (
+            "[  152.208814] EXT4-fs error (device sdb1): "
+            "ext4_find_entry:1455: inode #2: comm systemd: "
+            "reading directory lblock 0\n"
+            "You are in emergency mode. After logging in, type "
+            '"journalctl -xb" to view system logs.\n'
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'filesystem_corruption' in names
+        assert 'fstab_emergency_mode' in names
+
+    def test_post_marker_filesystem_error_does_not_retain_stale_fstab(self):
+        """C2: a filesystem error AFTER the boot-success marker is exempt
+        from suppression anyway, so its position must not veto the clearing
+        of stale fstab noise from the previous failed boot."""
+        serial = (
+            "systemd[1]: Timed out waiting for device "
+            "dev-disk-by\\x2duuid-6c78e5d3.device.\n"
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+            "[FAILED] EXT4-fs error (device sdb1): ext4_find_entry:1463: "
+            "inode #2: comm ls: reading directory lblock 0\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'filesystem' in categories
+        assert 'fstab' not in categories
+
+    def test_post_marker_ssh_failure_does_not_retain_stale_fstab(self):
+        """C2: same veto bug via a post-marker sshd failure — the stale
+        fstab device timeout from the old boot must be cleared."""
+        serial = (
+            "systemd[1]: Timed out waiting for device "
+            "dev-disk-by\\x2duuid-6c78e5d3.device.\n"
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+            "systemd[1]: Failed to start ssh.service - OpenBSD Secure "
+            "Shell server.\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'ssh' in categories
+        assert 'fstab' not in categories
+
+    def test_kernel_panic_does_not_suppress_emergency_mode(self):
+        """C3 (engine side): kernel is detect-only — a panic must not act
+        as a Tier-1 root cause and hide a stale emergency-mode finding from
+        another boot; both findings are shown."""
+        serial = (
+            "You are in emergency mode. After logging in, type "
+            '"journalctl -xb" to view system logs.\n'
+            "-- reboot --\n"
+            "[   12.310221] Kernel panic - not syncing: Attempted to kill "
+            "init! exitcode=0x00007f00\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_generic' in names
+        assert 'fstab_emergency_mode' in names
+
+    def test_recovered_panic_before_boot_success_is_suppressed(self):
+        """C3 side effect: a panic BEFORE the last successful boot marker on
+        a RUNNING VM is history and is cleared — same intentional precedent
+        as the recovered-lockup suppression."""
+        serial = (
+            "[   30.104501] Kernel panic - not syncing: Attempted to kill "
+            "init! exitcode=0x00007f00\n"
+            "-- reboot --\n"
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_disk_full_survives_completed_boot(self):
+        """C4: a boot-success marker does not empty a full disk — the
+        disk_full finding must survive suppression on a RUNNING VM instead
+        of reporting healthy."""
+        serial = (
+            "systemd-journald[300]: Failed to write entry: "
+            "No space left on device\n"
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'disk_full_no_space' in names
+
+    def test_post_marker_disk_full_does_not_retain_stale_fstab(self):
+        """C4 secondary effect: disk_full lines AFTER the marker must not
+        keep stale fstab noise alive (they are exempt from suppression, so
+        their position must not veto the clearing)."""
+        serial = (
+            "systemd[1]: Timed out waiting for device "
+            "dev-disk-by\\x2duuid-6c78e5d3.device.\n"
+            "systemd[1]: Startup finished in 4.2s (kernel) + 8.1s "
+            "(userspace) = 12.3s.\n"
+            "systemd-journald[300]: Failed to write entry: "
+            "No space left on device\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'disk_full' in categories
+        assert 'fstab' not in categories
+
+    def test_disk_full_detected_pattern_has_no_trailing_newline(self):
+        """Minor: the anchored ENOSPC regex must stop at end-of-line so the
+        newline never leaks into detected_pattern / JSON output."""
+        serial = (
+            "systemd-journald[300]: Failed to write entry: "
+            "No space left on device\n"
+        )
+        data = _diagnose(serial)
+        patterns = {
+            e['name']: e['detected_pattern'] for e in data['boot_errors']
+        }
+        assert 'disk_full_no_space' in patterns
+        assert '\n' not in patterns['disk_full_no_space']

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -608,3 +608,139 @@ class TestDiagnoseSshPatterns:
         data = _diagnose(serial)
         assert data['diagnosis_status'] == 'healthy'
         assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseSshRedTeamRegressions
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseSshRedTeamRegressions:
+    """Regressions from red-team review of the ssh diagnose category.
+
+    Each test reproduces a confirmed failing serial-console scenario; serial
+    buffers accumulate across reboots, so several tests mix stale lines from
+    old boots with the failure of the latest boot.
+    """
+
+    def test_stale_ssh_noise_does_not_mask_fstab_emergency(self):
+        """C1: a stale ssh auth line must not erase fstab boot-blockers.
+
+        The stale 'Authentication refused' line is followed by a success
+        marker, then the VM reboots into an fstab emergency-mode failure.
+        Cross-category dedupe previously deleted the fstab criticals (and
+        in this ordering even reported the VM as healthy).
+        """
+        serial = (
+            "sshd[900]: Authentication refused: bad ownership or modes "
+            "for directory /home/bob/.ssh\n"
+            "systemd[1]: Startup finished in 1.2s (kernel) + 9.0s "
+            "(userspace) = 10.2s.\n"
+            "-- reboot --\n"
+            "systemd[1]: Dependency failed for /data.\n"
+            "systemd[1]: data.mount: Job data.mount/start failed with "
+            "result 'dependency'.\n"
+            "You are in emergency mode. After logging in, type "
+            '"journalctl -xb" to view\n'
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        categories = {e['category'] for e in data['boot_errors']}
+        # fstab findings must survive so `repair` can still auto-fix them
+        assert 'fstab' in categories
+        assert any(
+            e['category'] == 'fstab' and e['severity'] == 'critical'
+            for e in data['boot_errors']
+        )
+
+    def test_guest_agent_failure_survives_completed_boot(self):
+        """C2: guest agent failure never blocks boot, so a 'Startup
+        finished' marker must not suppress the finding on a RUNNING VM."""
+        serial = (
+            "systemd[1]: Starting google-guest-agent.service - "
+            "Google Compute Engine Guest Agent...\n"
+            "google_guest_agent[412]: panic: runtime error: invalid memory "
+            "address or nil pointer dereference\n"
+            "systemd[1]: google-guest-agent.service: Start request repeated "
+            "too quickly.\n"
+            "systemd[1]: Failed to start google-guest-agent.service - "
+            "Google Compute Engine Guest Agent.\n"
+            "systemd[1]: Reached target multi-user.target - Multi-User System.\n"
+            "systemd[1]: Startup finished in 1.226s (kernel) + 15.379s "
+            "(userspace) = 16.605s.\n"
+        )
+        data = _diagnose(serial)  # vm_status is RUNNING in this helper
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_guest_agent_failed' in names
+
+    def test_sshd_failure_survives_completed_boot(self):
+        """C2: sshd StartLimit exhausted before 'Startup finished' must
+        still be reported on a RUNNING VM (boot completes without sshd)."""
+        serial = (
+            "sshd[836]: /etc/ssh/sshd_config: line 124: Bad configuration "
+            "option: ThisIsNotAValidDirective\n"
+            "systemd[1]: ssh.service: Start request repeated too quickly.\n"
+            "systemd[1]: Failed to start ssh.service - OpenBSD Secure "
+            "Shell server.\n"
+            "systemd[1]: Startup finished in 1.226s (kernel) + 15.379s "
+            "(userspace) = 16.605s.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_auth_error_survives_later_sshd_restart(self):
+        """C2: an sshd restart (e.g. unattended-upgrades) after the auth
+        error must not re-suppress the ssh_auth_permissions finding."""
+        serial = (
+            "systemd[1]: Started ssh.service - OpenBSD Secure Shell server.\n"
+            "systemd[1]: Startup finished in 1.2s (kernel) + 9.0s "
+            "(userspace) = 10.2s.\n"
+            "sshd[900]: Authentication refused: bad ownership or modes "
+            "for directory /home/bob/.ssh\n"
+            "systemd[1]: Stopping ssh.service - OpenBSD Secure Shell server...\n"
+            "systemd[1]: Started ssh.service - OpenBSD Secure Shell server.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_auth_permissions' in names
+
+    def test_sshd_config_error_without_colon_detected(self):
+        """C3: OpenSSH variants print 'sshd_config line N' without a colon."""
+        serial = (
+            "sshd[512]: /etc/ssh/sshd_config line 12: "
+            "Bad configuration option: FooBar\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_sles_openssh_daemon_failure_detected(self):
+        """C4: SLES unit description is 'OpenSSH Daemon' (no unit name on
+        older systemd)."""
+        serial = (
+            "systemd[1]: Reached target Basic System.\n"
+            "systemd[1]: Failed to start OpenSSH Daemon.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'ssh_sshd_config_error' in names
+
+    def test_non_fatal_agent_log_not_matched(self):
+        """C5: 'non-fatal' agent lines must not match the fatal/panic regex."""
+        serial = (
+            "google_guest_agent[583]: retrying non-fatal metadata error\n"
+        )
+        data = _diagnose(serial)
+        assert 'ssh' not in {e['category'] for e in data['boot_errors']}
+        assert data['diagnosis_status'] == 'healthy'
+
+    def test_agent_shutdown_transient_not_matched(self):
+        """C6: 'Failed with result' during shutdown is a transient, not a
+        boot-time agent failure."""
+        serial = (
+            "systemd[1]: google-guest-agent.service: "
+            "Failed with result 'exit-code'.\n"
+        )
+        data = _diagnose(serial)
+        assert 'ssh' not in {e['category'] for e in data['boot_errors']}
+        assert data['diagnosis_status'] == 'healthy'

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -478,3 +478,279 @@ class TestDiagnoseStabilization:
             result = op.execute('test-vm', stabilize=False)
             mock_stab.assert_not_called()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestKernelPanicDetection
+# ---------------------------------------------------------------------------
+
+def _diagnose(serial: str):
+    """Run DiagnoseOperation against a serial excerpt, return boot_errors."""
+    compute = _make_compute(serial_output=serial)
+    op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+    result = op.execute('test-vm')
+    return result.rollback_data
+
+
+class TestKernelPanicDetection:
+    """Detection tests for kernel.yaml panic patterns."""
+
+    def test_hung_task_panic_detected(self):
+        """Hung-task panic should report kernel_panic_hung_task, not generic."""
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64 (debian-kernel@lists.debian.org)\n"
+            "[  241.693421] INFO: task jbd2/sda1-8:512 blocked for more than 120 seconds.\n"
+            "[  241.699830] \"echo 0 > /proc/sys/kernel/hung_task_timeout_secs\" disables this message.\n"
+            "[  362.812554] Kernel panic - not syncing: hung_task: blocked tasks\n"
+            "[  362.818992] CPU: 0 PID: 42 Comm: khungtaskd Not tainted 5.10.0-28-cloud-amd64 #1\n"
+            "[  362.825101] Call Trace:\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_hung_task' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_oom_panic_detected(self):
+        """OOM panic should report kernel_panic_oom, not generic."""
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[  512.103311] Out of memory: Killed process 1234 (java) total-vm:8388608kB\n"
+            "[  512.209972] Kernel panic - not syncing: out of memory. panic_on_oom is selected\n"
+            "[  512.216104] CPU: 1 PID: 55 Comm: oom_reaper Not tainted 5.10.0-28-cloud-amd64 #1\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_oom' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_machine_check_panic_detected(self):
+        """Fatal machine check panic should report kernel_panic_machine_check."""
+        serial = (
+            "[    0.000000] Linux version 5.14.0-362.el9.x86_64\n"
+            "[  100.001234] mce: [Hardware Error]: CPU 0: Machine Check Exception: 5 Bank 0\n"
+            "[  100.103421] Kernel panic - not syncing: Fatal Machine check\n"
+            "[  100.109553] Kernel Offset: disabled\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_machine_check' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_nmi_panic_detected(self):
+        """NMI panic should report kernel_panic_nmi, not generic."""
+        serial = (
+            "[    0.000000] Linux version 5.15.0-100-generic\n"
+            "[   88.004521] Uhhuh. NMI received for unknown reason 31 on CPU 0.\n"
+            "[   88.101233] Kernel panic - not syncing: NMI: Not continuing\n"
+            "[   88.107455] CPU: 0 PID: 0 Comm: swapper/0 Not tainted 5.15.0-100-generic #1\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_nmi' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_unrecognized_panic_reports_generic(self):
+        """A panic cause not covered by specific patterns falls to generic."""
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[    5.002311] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000009\n"
+            "[    5.008442] CPU: 0 PID: 1 Comm: init Not tainted 5.10.0-28-cloud-amd64 #1\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_generic' in names
+
+    def test_modern_oom_panic_detected(self):
+        """Modern (>=4.x) OOM panic wording must be detected, not report healthy.
+
+        Regression: kernels since ~4.x panic with 'Out of memory: ...
+        panic_on_oom is enabled' (not the pre-4.x 'is selected'). The old
+        regex missed it AND the generic lookahead excluded it -> the engine
+        reported a genuinely panicked VM as healthy.
+        """
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  512.103311] Out of memory: Killed process 1234 (java) total-vm:8388608kB\n"
+            "[  512.209972] Kernel panic - not syncing: Out of memory: system-wide panic_on_oom is enabled\n"
+            "[  512.216104] CPU: 1 PID: 55 Comm: oom_reaper Not tainted 6.1.0-18-cloud-amd64 #1\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_oom' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_compulsory_oom_panic_detected(self):
+        """sysctl vm.panic_on_oom=2 variant ('compulsory ... is enabled')."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  600.001122] Kernel panic - not syncing: Out of memory: compulsory panic_on_oom is enabled\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_oom' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_evidence_anchors_on_actual_match_not_first_occurrence(self):
+        """Evidence must quote the line the regex matched, not an earlier
+        line containing the same text.
+
+        Regression (live Test 3): buffer held an old OOM panic and a fresh
+        sysrq panic. kernel_panic_generic matched the sysrq line (lookahead
+        rejects the OOM line), but context extraction re-searched for the
+        matched text 'Kernel panic - not syncing' and anchored the evidence
+        on the FIRST occurrence — the OOM line. Context must be derived
+        from the match offset instead.
+        """
+        serial = (
+            "[    0.000000] Linux version 6.1.0-49-cloud-amd64\n"
+            "[   85.365705] Kernel panic - not syncing: Out of memory: system-wide panic_on_oom is enabled\n"
+            "[   85.374092] CPU: 1 PID: 1138 Comm: tail Not tainted 6.1.0-49-cloud-amd64 #1\n"
+            "[    0.000000] Linux version 6.1.0-49-cloud-amd64 (second boot)\n"
+            "[   18.500000] sysrq: Trigger a crash\n"
+            "[   18.600000] Kernel panic - not syncing: sysrq triggered crash\n"
+            "[   18.830725] ---[ end Kernel panic - not syncing: sysrq triggered crash ]---\n"
+        )
+        data = _diagnose(serial)
+        generic = [e for e in data['boot_errors']
+                   if e['name'] == 'kernel_panic_generic']
+        assert generic, "kernel_panic_generic should fire on the sysrq line"
+        err = generic[0]
+        matched_line = err['context_lines'][err['matched_line_index']]
+        assert 'sysrq triggered crash' in matched_line
+        assert 'panic_on_oom' not in matched_line
+
+    def test_vfs_panic_variant_falls_to_generic(self):
+        """A VFS root-fs panic that is NOT unknown-block must not vanish.
+
+        Regression: the generic lookahead excluded any 'VFS: Unable to mount
+        root fs' while initramfs only matches the 'on unknown-block' form ->
+        e.g. an NFS-root panic matched nothing and reported healthy. Exclusion
+        terms must mirror the positive patterns exactly.
+        """
+        serial = (
+            "[    0.000000] Linux version 5.15.0-100-generic\n"
+            "[    9.912345] Kernel panic - not syncing: VFS: Unable to mount root fs via NFS.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_panic_generic' in names
+        assert 'initramfs_no_root_fs' not in names
+
+    def test_fstab_errors_do_not_trigger_kernel_patterns(self):
+        """fstab failure lines should not produce kernel-category findings."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'kernel' not in categories
+
+    def test_healthy_boot_matches_no_kernel_patterns(self):
+        """A clean boot log should produce no kernel findings."""
+        serial = (
+            "[    0.000000] Linux version 5.15.0-100-generic (builder@server)\n"
+            "[    0.000000] Booting Linux on physical CPU 0x0\n"
+            "[    2.412345] EXT4-fs (sda1): mounted filesystem with ordered data mode\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestInitramfsDetection
+# ---------------------------------------------------------------------------
+
+class TestInitramfsDetection:
+    """Detection tests for initramfs.yaml patterns, including kernel overlap."""
+
+    def test_no_root_fs_panic_detected_as_initramfs(self):
+        """VFS root-mount panic reports initramfs, NOT generic kernel panic.
+
+        The panic line itself contains 'Kernel panic - not syncing', so
+        kernel_panic_generic must exclude it via negative lookahead.
+        """
+        serial = (
+            "[    0.000000] Linux version 4.18.0-425.el8.x86_64\n"
+            "[    1.523311] md: Waiting for all devices to be available before autodetect\n"
+            "[    1.612345] VFS: Cannot open root device \"sda1\" or unknown-block(0,0): error -6\n"
+            "[    1.702211] Please append a correct \"root=\" boot option; here are the available partitions:\n"
+            "[    1.803992] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)\n"
+            "[    1.810221] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 4.18.0-425.el8.x86_64 #1\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_no_root_fs' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_unpacking_failure_detected(self):
+        """Corrupt initramfs (junk in compressed archive) should be detected."""
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[    0.812345] Trying to unpack rootfs image as initramfs...\n"
+            "[    0.905566] Initramfs unpacking failed: junk in compressed archive\n"
+            "[    1.002211] Freeing initrd memory: 24576K\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_load_failure' in names
+
+    def test_unpacking_failure_is_error_not_critical(self):
+        """'junk ... compressed archive' is benign on some kernels (microcode
+        cpio padding, ~5.4-5.15) where boot proceeds normally. Without a
+        following VFS panic it is ambiguous, so it must report severity
+        'error', not 'critical' (the unambiguous case is initramfs_no_root_fs).
+        """
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[    0.905566] Initramfs unpacking failed: junk in compressed archive\n"
+        )
+        data = _diagnose(serial)
+        findings = [e for e in data['boot_errors']
+                    if e['name'] == 'initramfs_load_failure']
+        assert findings, "initramfs_load_failure should be detected"
+        assert all(f['severity'] == 'error' for f in findings)
+
+    def test_load_failure_variant_detected(self):
+        """'Failed to load initramfs' variant should also be detected."""
+        serial = (
+            "[    0.000000] Linux version 5.15.0-100-generic\n"
+            "[    0.712345] Failed to load initramfs image from /boot/initrd.img-5.15.0-100-generic\n"
+            "[    0.809982] Kernel command line: BOOT_IMAGE=/boot/vmlinuz-5.15.0-100-generic root=UUID=abc\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'initramfs_load_failure' in names
+
+    def test_benign_decoding_message_not_matched(self):
+        """'Initramfs unpacking failed: Decoding failed' is benign on some
+        kernels (LZ4 fallback) and must NOT trigger initramfs_load_failure."""
+        serial = (
+            "[    0.000000] Linux version 5.4.0-100-generic (buildd@lcy02)\n"
+            "[    0.905566] Initramfs unpacking failed: Decoding failed\n"
+            "[    2.412345] EXT4-fs (sda1): mounted filesystem with ordered data mode\n"
+            "ubuntu login: \n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'initramfs' not in categories
+
+    def test_fstab_errors_do_not_trigger_initramfs_patterns(self):
+        """fstab failure lines should not produce initramfs-category findings."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'initramfs' not in categories

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -552,15 +552,22 @@ class TestKernelPanicDetection:
         assert 'kernel_panic_generic' not in names
 
     def test_unrecognized_panic_reports_generic(self):
-        """A panic cause not covered by specific patterns falls to generic."""
+        """A panic cause not covered by specific patterns falls to generic.
+
+        'Attempted to kill the idle task!' deliberately sits one word away
+        from the kernel_attempted_kill_init exclusion ('Attempted to kill
+        init') - it must fall through to generic, proving the exclusion
+        term is exactly as tight as its positive.
+        """
         serial = (
             "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
-            "[    5.002311] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000009\n"
-            "[    5.008442] CPU: 0 PID: 1 Comm: init Not tainted 5.10.0-28-cloud-amd64 #1\n"
+            "[    5.002311] Kernel panic - not syncing: Attempted to kill the idle task!\n"
+            "[    5.008442] CPU: 0 PID: 0 Comm: swapper/0 Not tainted 5.10.0-28-cloud-amd64 #1\n"
         )
         data = _diagnose(serial)
         names = [e['name'] for e in data['boot_errors']]
         assert 'kernel_panic_generic' in names
+        assert 'kernel_attempted_kill_init' not in names
 
     def test_modern_oom_panic_detected(self):
         """Modern (>=4.x) OOM panic wording must be detected, not report healthy.
@@ -1839,7 +1846,7 @@ class TestDiagnoseUnifiedEngineRedTeamRegressions:
             '"journalctl -xb" to view system logs.\n'
             "-- reboot --\n"
             "[   12.310221] Kernel panic - not syncing: Attempted to kill "
-            "init! exitcode=0x00007f00\n"
+            "the idle task!\n"
         )
         data = _diagnose(serial)
         names = [e['name'] for e in data['boot_errors']]
@@ -3395,3 +3402,434 @@ class TestDistroBroadeningRedTeamRegressions:
                                        'TERMINATED')
         names = [e.name for e in result.boot_errors]
         assert 'fstab_uuid_not_found' in names
+
+
+# ---------------------------------------------------------------------------
+# TestSwitchrootDetection (Wave 3 - boot stage 6)
+# ---------------------------------------------------------------------------
+
+class TestSwitchrootDetection:
+    """Detection tests for switchroot.yaml (switch_root / init handover)."""
+
+    def test_systemd_switch_root_failure_detected(self):
+        """systemd's 'Failed to switch root' (not an OS tree) is detected."""
+        serial = (
+            "[    3.412345] systemd[1]: Starting Switch Root...\n"
+            "[    3.512345] systemd[1]: Failed to switch root: Specified "
+            "switch root path '/sysroot' does not seem to be an OS tree. "
+            "os-release file is missing.\n"
+            "[    3.612345] systemd[1]: Failed to start Switch Root.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'switchroot_failed' in names
+
+    def test_switch_root_mount_moving_detected(self):
+        """util-linux switch_root 'failed to mount moving' is detected."""
+        serial = (
+            "[    2.812345] EXT4-fs (sda1): mounted filesystem with ordered "
+            "data mode\n"
+            "switch_root: failed to mount moving /dev to /sysroot/dev: "
+            "Invalid argument\n"
+            "switch_root: forcing unmount of /dev\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'switchroot_failed' in names
+
+    def test_initramfs_tools_run_init_failure_detected(self):
+        """Debian initramfs-tools no-init sequence (run-init wording)."""
+        serial = (
+            "Begin: Running /scripts/init-bottom ... done.\n"
+            "run-init: can't execute '/sbin/init': No such file or "
+            "directory\n"
+            "Target filesystem doesn't have requested /sbin/init.\n"
+            "run-init: can't execute '/etc/init': No such file or directory\n"
+            "No init found. Try passing init= bootarg.\n"
+            "BusyBox v1.30.1 (Debian 1:1.30.1-6+b3) built-in shell (ash)\n"
+            "(initramfs) \n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'switchroot_no_init' in names
+        # The BusyBox prompt is a real second finding (different stage
+        # ownership), not an overlap bug.
+        assert 'initramfs_busybox_shell' in names
+
+    def test_no_working_init_panic_fires_switchroot_not_generic(self):
+        """Modern kernels panic 'No working init found.' - switchroot owns
+        that panic line, and the kernel_panic_generic lookahead must
+        mirror the exclusion (INVARIANT drift guard)."""
+        serial = (
+            "[    2.123456] Run /sbin/init as init process\n"
+            "[    2.124512] Failed to execute /sbin/init (error -2)\n"
+            "[    2.125624] Kernel panic - not syncing: No working init "
+            "found. Try passing init= option to kernel. See Linux "
+            "Documentation/admin-guide/init.rst for guidance.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'switchroot_no_init' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_old_kernel_no_init_panic_fires_switchroot_not_generic(self):
+        """Old-kernel wording 'No init found. Try passing init=' - same
+        exclusion-mirror guard as the modern form."""
+        serial = (
+            "[    1.912345] VFS: Mounted root (ext4 filesystem) readonly "
+            "on device 8:1.\n"
+            "[    2.025624] Kernel panic - not syncing: No init found.  "
+            "Try passing init= option to kernel. See Linux "
+            "Documentation/init.txt for guidance.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'switchroot_no_init' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_init_shared_library_failure_detected(self):
+        """init failing on a missing shared library is a switchroot finding."""
+        serial = (
+            "[    2.612345] Run /sbin/init as init process\n"
+            "/sbin/init: error while loading shared libraries: libc.so.6: "
+            "cannot open shared object file: No such file or directory\n"
+            "[    2.812345] Kernel panic - not syncing: Attempted to kill "
+            "init! exitcode=0x00007f00\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'switchroot_init_libs' in names
+
+    def test_userspace_shared_library_failure_not_flagged(self):
+        """'error while loading shared libraries' from an ordinary daemon
+        on a RUNNING vm must NOT fire switchroot_init_libs - unbound, the
+        string is a guaranteed false positive (any broken userspace
+        dependency prints it after a perfectly healthy boot)."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  OK  ] Started OpenBSD Secure Shell server.\n"
+            "[   11.512345] systemd[1]: Startup finished in 3.1s (kernel) "
+            "+ 8.4s (userspace) = 11.5s.\n"
+            "debian login: \n"
+            "myapp[1421]: /usr/local/bin/myapp: error while loading shared "
+            "libraries: libfoo.so.1: cannot open shared object file\n"
+            "cloud-init[892]: /usr/bin/cloud-init: error while loading "
+            "shared libraries: libpython3.11.so.1.0: cannot open shared "
+            "object file\n"
+            "systemd-networkd[315]: error while loading shared libraries: "
+            "libsystemd-shared-252.so: cannot open shared object file\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'switchroot' not in categories
+
+    def test_busybox_root_device_drop_does_not_fire_switchroot(self):
+        """A BusyBox drop caused by a MISSING ROOT DEVICE (stage 4) has no
+        init strings - it must stay an initramfs finding only."""
+        serial = (
+            "Gave up waiting for root file system device.  Common "
+            "problems:\n"
+            "ALERT!  UUID=11111111-2222-3333-4444-555555555555 does not "
+            "exist.  Dropping to a shell!\n"
+            "BusyBox v1.30.1 (Ubuntu 1:1.30.1-7ubuntu3) built-in shell "
+            "(ash)\n"
+            "(initramfs) \n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'initramfs' in categories
+        assert 'switchroot' not in categories
+
+    def test_healthy_boot_no_switchroot_findings(self):
+        """A clean boot (including the healthy switch-root transition line)
+        must produce zero switchroot findings."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[    2.912345] systemd[1]: Starting Switch Root...\n"
+            "[    3.012345] systemd[1]: Switching root.\n"
+            "[    5.412345] EXT4-fs (sda1): re-mounted. Quota mode: none.\n"
+            "[   10.512345] systemd[1]: Startup finished in 3.1s (kernel) "
+            "+ 7.4s (userspace) = 10.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestSystemdEarlyDetection (Wave 3 - boot stage 7)
+# ---------------------------------------------------------------------------
+
+class TestSystemdEarlyDetection:
+    """Detection tests for systemd_early.yaml (PID1 / early services)."""
+
+    def test_ordering_cycle_detected_with_unit_names(self):
+        """Realistic ordering-cycle block (systemd <=v249 wording)."""
+        serial = (
+            "[    4.112345] systemd[1]: local-fs.target: Found ordering "
+            "cycle on local-fs.target/start\n"
+            "[    4.112400] systemd[1]: local-fs.target: Found dependency "
+            "on mnt-data.mount/start\n"
+            "[    4.112500] systemd[1]: local-fs.target: Job "
+            "mnt-data.mount/start deleted to break ordering cycle starting "
+            "with local-fs.target/start\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        findings = [e for e in result.boot_errors
+                    if e.name == 'systemd_ordering_cycle']
+        assert findings, "systemd_ordering_cycle should be detected"
+        assert all(f.severity == 'error' for f in findings)
+
+    def test_ordering_cycle_modern_wording_detected(self):
+        """systemd v250+ wording: 'Breaking ordering cycle by deleting job'."""
+        serial = (
+            "[    3.912345] systemd[1]: sysinit.target: Found ordering "
+            "cycle on sysinit.target/start\n"
+            "[    3.912400] systemd[1]: sysinit.target: Breaking ordering "
+            "cycle by deleting job cloud-init.service/start\n"
+            "[    3.912500] systemd[1]: cloud-init.service: Job "
+            "cloud-init.service/start deleted to break ordering cycle\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'systemd_ordering_cycle' in names
+
+    def test_ordering_cycle_suppressed_after_successful_boot(self):
+        """When systemd breaks the cycle and boot completes on a RUNNING
+        vm, boot-success suppression clears the finding - by design
+        (severity error, no survives_boot_success: diagnose targets boot
+        failures, and this boot succeeded)."""
+        serial = (
+            "[    4.112345] systemd[1]: local-fs.target: Found ordering "
+            "cycle on local-fs.target/start\n"
+            "[    4.112500] systemd[1]: local-fs.target: Job "
+            "mnt-data.mount/start deleted to break ordering cycle starting "
+            "with local-fs.target/start\n"
+            "[   12.512345] systemd[1]: Startup finished in 4.1s (kernel) "
+            "+ 8.4s (userspace) = 12.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+
+    def test_pid1_freeze_detected_as_critical(self):
+        """systemd[1] freezing execution is a hard boot stop."""
+        serial = (
+            "[    3.212345] systemd[1]: Caught <SEGV>, dumped core as pid "
+            "412.\n"
+            "[    3.312345] systemd[1]: Freezing execution.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        findings = [e for e in result.boot_errors
+                    if e.name == 'systemd_freeze']
+        assert findings, "systemd_freeze should be detected"
+        assert all(f.severity == 'critical' for f in findings)
+
+    def test_root_locked_console_detected_alongside_root_cause(self):
+        """The sulogin lockout line (root account locked) must be reported
+        next to the fstab root cause - it explains why emergency mode is
+        a dead end on cloud images."""
+        serial = (
+            "[  TIME ] Timed out waiting for device "
+            "/dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678.\n"
+            "[DEPEND] Dependency failed for /mnt/data.\n"
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view system logs.\n"
+            "Cannot open access to console, the root account is locked. "
+            "See sulogin(8) man page for more details.\n"
+            "Press Enter to continue.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'systemd_no_console' in names
+        assert 'fstab_device_timeout' in names
+
+    def test_benign_unit_failures_do_not_fire_systemd_early(self):
+        """Scoping guard: ordinary '[FAILED] Failed to start ...' unit
+        failures on an otherwise healthy boot must produce ZERO
+        systemd_early findings (the category deliberately ships no
+        generic Failed-to-start pattern)."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[FAILED] Failed to start Update APT News.\n"
+            "[    8.412345] systemd[1]: apt-news.service: Main process "
+            "exited, code=exited, status=1/FAILURE\n"
+            "[FAILED] Failed to start Download data for packages that "
+            "failed at package install time.\n"
+            "[   11.512345] systemd[1]: Startup finished in 3.1s (kernel) "
+            "+ 8.4s (userspace) = 11.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestKernelEarlyFaultDetection (Wave 3 - kernel.yaml broadening)
+# ---------------------------------------------------------------------------
+
+class TestKernelEarlyFaultDetection:
+    """Detection tests for kernel_attempted_kill_init, kernel_bug_oops and
+    kernel_decompress_fail, including catch-all and grub overlap guards."""
+
+    def test_attempted_kill_init_fires_specific_not_generic(self):
+        """The Attempted-to-kill-init panic must report the specific
+        pattern; the generic lookahead mirrors it (INVARIANT guard)."""
+        serial = (
+            "[    0.000000] Linux version 5.10.0-28-cloud-amd64\n"
+            "[    5.002311] Kernel panic - not syncing: Attempted to kill "
+            "init! exitcode=0x0000000b\n"
+            "[    5.008442] CPU: 0 PID: 1 Comm: systemd Not tainted "
+            "5.10.0-28-cloud-amd64 #1\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'kernel_attempted_kill_init' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_run_init_failure_reports_switchroot_and_kill_init(self):
+        """run-init exec failure + resulting panic: the switchroot category
+        names the on-disk cause, kernel names the panic - both fire."""
+        serial = (
+            "run-init: can't execute '/sbin/init': No such file or "
+            "directory\n"
+            "[    2.512345] Kernel panic - not syncing: Attempted to kill "
+            "init! exitcode=0x00000100\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'switchroot_no_init' in names
+        assert 'kernel_attempted_kill_init' in names
+        assert 'kernel_panic_generic' not in names
+
+    def test_bug_unable_to_handle_and_oops_detected(self):
+        """Classic NULL-dereference Oops block reports kernel_bug_oops."""
+        serial = (
+            "[  184.123456] BUG: unable to handle kernel NULL pointer "
+            "dereference at 0000000000000000\n"
+            "[  184.130211] #PF: supervisor read access in kernel mode\n"
+            "[  184.136122] Oops: 0002 [#1] SMP PTI\n"
+            "[  184.141233] RIP: 0010:broken_driver_fn+0x12/0x40 "
+            "[broken_driver]\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        findings = [e for e in result.boot_errors
+                    if e.name == 'kernel_bug_oops']
+        assert findings, "kernel_bug_oops should be detected"
+        assert all(f.severity == 'error' for f in findings)
+
+    def test_kernel_bug_at_file_line_detected(self):
+        """'kernel BUG at <file>:<line>!' form reports kernel_bug_oops."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   92.512345] kernel BUG at fs/ext4/inode.c:1731!\n"
+            "[   92.518442] invalid opcode: 0000 [#1] PREEMPT SMP NOPTI\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'kernel_bug_oops' in names
+
+    def test_oops_in_prose_not_flagged(self):
+        """Bare 'Oops'/'oops' in ordinary log prose must never match - the
+        pattern requires the Oops header with a 4-digit error code."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "myapp[1421]: Oops! Upload failed, retrying in 5s\n"
+            "installer: we hit an oops in the parser, continuing\n"
+            "There was a kernel bug at startup last week, now fixed\n"
+            "[   11.512345] systemd[1]: Startup finished in 3.1s (kernel) "
+            "+ 8.4s (userspace) = 11.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_decompressor_corruption_detected(self):
+        """Corrupt vmlinuz: decompressor error + '-- System halted' stub."""
+        serial = (
+            "Loading Linux 6.1.0-18-cloud-amd64 ...\n"
+            "Loading initial ramdisk ...\n"
+            "Decompressing Linux... \n"
+            "\n"
+            "XZ-compressed data is corrupt\n"
+            "\n"
+            " -- System halted\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        findings = [e for e in result.boot_errors
+                    if e.name == 'kernel_decompress_fail']
+        assert findings, "kernel_decompress_fail should be detected"
+        assert all(f.severity == 'critical' for f in findings)
+
+    def test_healthy_decompress_line_not_flagged(self):
+        """The healthy 'Decompressing Linux... Parsing ELF... done.' line
+        must never match (same-line failed/error binding)."""
+        serial = (
+            "Loading Linux 6.1.0-18-cloud-amd64 ...\n"
+            "Decompressing Linux... Parsing ELF... Performing "
+            "relocations... done.\n"
+            "Booting the kernel.\n"
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   11.512345] systemd[1]: Startup finished in 3.1s (kernel) "
+            "+ 8.4s (userspace) = 11.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_reboot_system_halted_not_flagged(self):
+        """The kernel's ordinary shutdown line 'reboot: System halted' has
+        no '-- ' stub prefix and must NOT fire kernel_decompress_fail."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[  831.512345] systemd-shutdown[1]: Syncing filesystems and "
+            "block devices.\n"
+            "[  832.612345] reboot: System halted\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'kernel_decompress_fail' not in names
+
+    def test_decompress_fail_and_grub_invalid_magic_do_not_cross_fire(self):
+        """Overlap guard: GRUB's 'error: invalid magic number' stays a grub
+        finding; the decompressor stub stays a kernel finding."""
+        grub_serial = (
+            "GRUB loading.\n"
+            "error: invalid magic number.\n"
+            "Entering rescue mode...\n"
+            "grub rescue> \n"
+        )
+        result = analyze_serial_output(grub_serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'grub_invalid_magic' in names
+        assert 'kernel_decompress_fail' not in names
+
+        stub_serial = (
+            "Loading Linux 6.1.0-18-cloud-amd64 ...\n"
+            "Decompressing Linux... \n"
+            "LZ4-compressed data is corrupt\n"
+            " -- System halted\n"
+        )
+        result = analyze_serial_output(stub_serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        names = [e.name for e in result.boot_errors]
+        assert 'kernel_decompress_fail' in names
+        assert 'grub' not in categories

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -3881,3 +3881,165 @@ class TestKernelEarlyFaultDetection:
         names = [e.name for e in result.boot_errors]
         assert 'kernel_decompress_fail' in names
         assert 'grub' not in categories
+
+
+# ---------------------------------------------------------------------------
+# TestWave3RedTeamRegressions
+# ---------------------------------------------------------------------------
+
+class TestWave3RedTeamRegressions:
+    """Regressions from the adversarial review of the Wave 3 branch
+    (switchroot / systemd_early / kernel early faults). Each test
+    reproduces a confirmed failing serial buffer from the red-team report."""
+
+    # C1: root is locked on every GCP image, so sulogin prints the
+    # locked-console line on EVERY emergency-mode entry. The error-level
+    # systemd_no_console companion must never suppress the CRITICAL
+    # emergency-mode catch-all via Tier-1 dedupe: only a finding that names
+    # a CRITICAL root cause may replace it.
+    def test_locked_console_does_not_erase_emergency_mode_running(self):
+        serial = (
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view system logs.\n"
+            "Cannot open access to console, the root account is locked. "
+            "See sulogin(8) man page for more details.\n"
+            "Press Enter to continue.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_emergency_mode' in names
+        assert 'systemd_no_console' in names
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities['fstab_emergency_mode'] == 'critical'
+
+    def test_locked_console_does_not_erase_emergency_mode_terminated(self):
+        serial = (
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view system logs.\n"
+            "Cannot open access to console, the root account is locked. "
+            "See sulogin(8) man page for more details.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'fstab_emergency_mode' in names
+        assert 'systemd_no_console' in names
+
+    def test_ordering_cycle_does_not_erase_emergency_mode(self):
+        """An error-level ordering-cycle report is context, not a root
+        cause: systemd_early.yaml documents that a cycle blocking boot is
+        'reported by the pattern that put the VM in emergency mode' - so
+        the emergency catch-all must survive alongside it."""
+        serial = (
+            "[    4.112345] systemd[1]: local-fs.target: Job "
+            "mnt-data.mount/start deleted to break ordering cycle starting "
+            "with local-fs.target/start\n"
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view system logs.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_emergency_mode' in names
+        assert 'systemd_ordering_cycle' in names
+
+    def test_critical_root_cause_still_demotes_emergency_catchall(self):
+        """Control (X3c): a CRITICAL fstab root cause still suppresses the
+        emergency catch-all under the tightened Tier-1 gate, and the
+        no-console companion keeps being reported next to it."""
+        serial = (
+            "[  TIME ] Timed out waiting for device "
+            "/dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678.\n"
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view system logs.\n"
+            "Cannot open access to console, the root account is locked. "
+            "See sulogin(8) man page for more details.\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_device_timeout' in names
+        assert 'systemd_no_console' in names
+        assert 'fstab_emergency_mode' not in names
+
+    # C2: when journal-to-console forwarding is off, the '[FAILED]' unit
+    # status line is the ONLY switch-root output on the serial console -
+    # the journal 'Failed to switch root:' line never appears.
+    def test_rhel9_switch_root_unit_failed_line_detected(self):
+        serial = (
+            "[FAILED] Failed to start initrd-switch-root.service - "
+            "Switch Root.\n"
+            "See 'systemctl status initrd-switch-root.service' for "
+            "details.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'switchroot_failed' in names
+
+    def test_rhel8_switch_root_unit_failed_line_detected(self):
+        serial = (
+            "[  OK  ] Reached target Initrd File Systems.\n"
+            "         Starting Switch Root...\n"
+            "[FAILED] Failed to start Switch Root.\n"
+            "See 'systemctl status initrd-switch-root.service' for "
+            "details.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'switchroot_failed' in names
+
+    # C3: arm64 (T2A) fault headers differ from x86 - 'Internal error:
+    # Oops: <code>' and an unprefixed 'Unable to handle kernel ...' line.
+    # Modern x86 (>= 5.1) reports 'BUG: unable to handle page fault for
+    # address:'. All three were complete misses.
+    def test_arm64_oops_detected(self):
+        serial = (
+            "[  184.123456] Unable to handle kernel NULL pointer "
+            "dereference at virtual address 0000000000000010\n"
+            "[  184.130211] Mem abort info:\n"
+            "[  184.136122] Internal error: Oops: 96000004 [#1] PREEMPT "
+            "SMP\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'kernel_bug_oops' in names
+
+    def test_arm64_paging_request_header_alone_detected(self):
+        serial = (
+            "[   92.512345] Unable to handle kernel paging request at "
+            "virtual address ffff8000122d4000\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'kernel_bug_oops' in names
+
+    def test_modern_x86_page_fault_header_alone_detected(self):
+        """The >= 5.1 wording dropped 'kernel' from the BUG header; must be
+        caught even when the Oops line is truncated off the buffer."""
+        serial = (
+            "[  184.123456] BUG: unable to handle page fault for address: "
+            "ffffffffc0a01000\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a',
+                                       'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'kernel_bug_oops' in names
+
+    def test_warn_on_trace_still_not_flagged_by_new_oops_regexes(self):
+        """A WARN_ON trace and userspace 'Unable to handle' prose must not
+        match the broadened kernel_bug_oops regexes."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64\n"
+            "[   42.123456] WARNING: CPU: 0 PID: 42 at "
+            "kernel/sched/core.c:9999 finish_task_switch+0x1a/0x2b0\n"
+            "[   42.130211] Call Trace:\n"
+            "myapp[1421]: Unable to handle request, retrying\n"
+            "[   11.512345] systemd[1]: Startup finished in 3.1s (kernel) "
+            "+ 8.4s (userspace) = 11.5s.\n"
+            "debian login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -572,3 +572,70 @@ class TestDiagnoseDiskFull:
         data = _diagnose(serial)
         assert data['diagnosis_status'] == 'healthy'
         assert data['boot_errors'] == []
+
+    def test_inotify_exhaustion_enospc_not_flagged(self):
+        """inotify watch exhaustion returns ENOSPC with a healthy disk.
+
+        These messages appear at RUNTIME (after boot success), so the
+        boot-success suppression does not protect against them — the
+        regex itself must exclude them.
+        """
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel)\n"
+            "[   12.000000] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "systemd[1]: Failed to add /run/systemd/ask-password to "
+            "directory watch: No space left on device\n"
+            "tail: inotify cannot be used, reverting to polling: "
+            "no space left on device\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_cgroup_limit_enospc_not_flagged(self):
+        """cgroup-limit ENOSPC on container hosts is not a full disk."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel)\n"
+            "[   12.000000] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            "kubelet[1543]: mkdir /sys/fs/cgroup/memory/kubepods/pod9f3: "
+            "no space left on device\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_quoted_enospc_string_not_flagged(self):
+        """A line merely quoting the phrase mid-sentence must not match."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel)\n"
+            "[   12.000000] systemd[1]: Startup finished in 4.2s (kernel) "
+            "+ 8.1s (userspace) = 12.3s.\n"
+            'startup-script[900]: INFO: monitor app logs for '
+            '"No space left on device" and page oncall\n'
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []
+
+    def test_enospc_noise_does_not_mask_fstab_finding(self):
+        """inotify ENOSPC noise must not dedupe away a real fstab failure.
+
+        Regression for red-team D2: before the regex fix, the noise line
+        counted as a disk_full "root cause" and the generic-symptom tier
+        deleted the fstab dependency finding, hiding the actual problem.
+        Uses the engine directly with TERMINATED status (no suppression).
+        """
+        from gce_rescue_v2.core.diagnosis import analyze_serial_output
+
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel)\n"
+            "Dependency failed for /data.\n"
+            "tail: inotify cannot be used, reverting to polling: "
+            "no space left on device\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'TERMINATED')
+        categories = {e.category for e in result.boot_errors}
+        assert 'disk_full' not in categories
+        assert 'fstab' in categories

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -59,6 +59,14 @@ def _make_http_error(status_code, message="error"):
     return HttpError(resp, f'{{"error": {{"message": "{message}"}}}}'.encode())
 
 
+def _diagnose(serial: str):
+    """Run DiagnoseOperation against a serial excerpt, return rollback_data."""
+    compute = _make_compute(serial_output=serial)
+    op = DiagnoseOperation(compute, 'proj', 'zone-a', _make_logger())
+    result = op.execute('test-vm')
+    return result.rollback_data
+
+
 # ---------------------------------------------------------------------------
 # TestDiagnoseBasic
 # ---------------------------------------------------------------------------
@@ -478,3 +486,89 @@ class TestDiagnoseStabilization:
             result = op.execute('test-vm', stabilize=False)
             mock_stab.assert_not_called()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseDiskFull
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseDiskFull:
+    """Detection tests for disk_full category patterns."""
+
+    def test_disk_full_no_space_detected(self):
+        """Kernel/journald ENOSPC message should trigger disk_full_no_space."""
+        serial = (
+            "[  241.693421] EXT4-fs (sda1): mounted filesystem with ordered data mode\n"
+            "[  242.104233] systemd-journald[312]: Failed to write entry "
+            "(23 items, 812 bytes), ignoring: No space left on device\n"
+            "[  242.512345] systemd[1]: Failed to start Rotate log files.\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'disk_full_no_space' in names
+
+    def test_disk_full_guest_agent_detected(self):
+        """Guest agent temp-directory failure should trigger disk_full_guest_agent."""
+        serial = (
+            "[  120.001234] google_guest_agent[512]: ERROR instance_setup.go:160 "
+            "Failed to generate SSH host keys: [Errno 2] "
+            "No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp']\n"
+            "[  120.442211] OSConfigAgent Error: unexpected end of JSON input\n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'boot_errors_detected'
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'disk_full_guest_agent' in names
+
+    def test_both_disk_full_patterns_detected_together(self):
+        """A truly full disk usually shows both symptoms; both should be reported."""
+        serial = (
+            "[  310.104233] systemd-journald[312]: Failed to write entry, "
+            "ignoring: No space left on device\n"
+            "[  312.001234] google_guest_agent[512]: ERROR non_windows_accounts.go:144 "
+            "Error updating SSH keys: [Errno 2] No usable temporary directory found "
+            "in ['/tmp', '/var/tmp', '/usr/tmp']\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'disk_full_no_space' in names
+        assert 'disk_full_guest_agent' in names
+
+    def test_disk_full_severities(self):
+        """disk_full_no_space is critical; disk_full_guest_agent is error."""
+        serial = (
+            "[  310.104233] systemd-journald[312]: Failed to write entry, "
+            "ignoring: No space left on device\n"
+            "[  312.001234] google_guest_agent[512]: [Errno 2] "
+            "No usable temporary directory found in ['/tmp', '/var/tmp']\n"
+        )
+        data = _diagnose(serial)
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities['disk_full_no_space'] == 'critical'
+        assert severities['disk_full_guest_agent'] == 'error'
+
+    def test_fstab_errors_do_not_trigger_disk_full_patterns(self):
+        """fstab-only failures must not produce disk_full findings."""
+        serial = (
+            "Linux version 5.15.0\n"
+            "Timed out waiting for device "
+            "/dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "Dependency failed for /mnt/data\n"
+            "You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'disk_full' not in categories
+
+    def test_healthy_boot_matches_no_disk_full_patterns(self):
+        """A normal boot with free space must not trigger disk_full."""
+        serial = (
+            "[    0.000000] Linux version 6.1.0-18-cloud-amd64 (debian-kernel)\n"
+            "[    2.104233] EXT4-fs (sda1): mounted filesystem with ordered data mode\n"
+            "[    4.512345] systemd[1]: Reached target Local File Systems.\n"
+            "login: \n"
+        )
+        data = _diagnose(serial)
+        assert data['diagnosis_status'] == 'healthy'
+        assert data['boot_errors'] == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch, MagicMock
 import pytest
 from googleapiclient.errors import HttpError
 
+from gce_rescue_v2.core.diagnosis import analyze_serial_output
 from gce_rescue_v2.operations.diagnose import DiagnoseOperation
 
 
@@ -621,3 +622,117 @@ class TestDiagnoseFilesystemPatterns:
         data = _diagnose(serial)
         assert data['diagnosis_status'] == 'healthy'
         assert data['boot_errors'] == []
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseFilesystemRedTeamRegressions
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseFilesystemRedTeamRegressions:
+    """Regression tests for red-team findings against the filesystem category.
+
+    Each test uses the exact failing serial line from the red-team report.
+    """
+
+    # Healthy "try mount, else mkfs" startup-script probe on a blank disk.
+    # The VFS line lands AFTER the boot-success markers (the unit STARTS
+    # before the script output), which defeated ordering-based suppression.
+    _MKFS_PROBE_SERIAL = (
+        "[  OK  ] Reached target multi-user.target - Multi-User System.\n"
+        "[  OK  ] Started google-startup-scripts.service - Google Compute Engine Startup Scripts.\n"
+        "[   15.221133] EXT4-fs (sdb): VFS: Can't find ext4 filesystem\n"
+        "mke2fs 1.47.0 (5-Feb-2023)\n"
+        "Creating filesystem with 2621440 4k blocks and 655360 inodes\n"
+    )
+
+    def test_mkfs_probe_on_running_vm_is_healthy(self):
+        """C1: mount-probe-then-mkfs on a blank disk must not fire
+        filesystem_bad_superblock, even when the VFS line lands after the
+        last boot-success marker (RUNNING)."""
+        result = analyze_serial_output(
+            self._MKFS_PROBE_SERIAL, 'test-vm', 'zone-a', 'RUNNING'
+        )
+        assert result.diagnosis_status == 'healthy'
+        assert result.boot_errors == []
+
+    def test_mkfs_probe_on_terminated_vm_is_healthy(self):
+        """C1: same buffer on a TERMINATED VM (boot-success suppression is
+        skipped entirely) must also stay healthy — the anchored regex, not
+        suppression, has to reject the probe."""
+        result = analyze_serial_output(
+            self._MKFS_PROBE_SERIAL, 'test-vm', 'zone-a', 'TERMINATED'
+        )
+        assert result.diagnosis_status == 'healthy'
+        assert result.boot_errors == []
+
+    def test_vfs_cant_find_ext4_anchored_match_is_single_line(self):
+        """C1: the anchored regex must still fire on a real mount failure and
+        keep detected_pattern single-line (lookahead, no multi-line blob)."""
+        serial = (
+            "         Mounting mnt-data.mount - /mnt/data...\n"
+            "[    4.444497] EXT4-fs (sda): VFS: Can't find ext4 filesystem\n"
+            "[FAILED] Failed to mount mnt-data.mount - /mnt/data.\n"
+            "[DEPEND] Dependency failed for local-fs.target - Local File Systems.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'TERMINATED')
+        errors = {e.name: e for e in result.boot_errors}
+        assert 'filesystem_bad_superblock' in errors
+        assert '\n' not in errors['filesystem_bad_superblock'].detected_pattern
+
+    def test_xfs_metadata_corruption_on_device_mapper_detected(self):
+        """C2: XFS corruption on device-mapper devices (dm-0, LVM on
+        RHEL/SAP images) must fire filesystem_corruption; \\w+ missed the
+        hyphen in the device name."""
+        serial = (
+            "[  102.5] XFS (dm-0): Metadata corruption detected at xfs_inode_buf_verify+0x15a/0x180 [xfs]\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'filesystem_corruption' in names
+
+    def test_xfs_metadata_crc_error_detected(self):
+        """C3: modern-kernel XFS 'Metadata CRC error detected' wording must
+        fire filesystem_corruption."""
+        serial = (
+            "[   88.1] XFS (sda1): Metadata CRC error detected at xfs_agi_read_verify+0xd0/0xf0 [xfs], xfs_agi block 0x2\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'filesystem_corruption' in names
+
+    def test_xfs_unmount_and_run_xfs_repair_detected(self):
+        """C3: the canonical companion line emitted for both XFS corruption
+        wordings must fire filesystem_corruption on its own."""
+        serial = (
+            "[   88.1] XFS (sdb1): Mounting V5 Filesystem\n"
+            "[   88.2] XFS (sdb1): Unmount and run xfs_repair\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'TERMINATED')
+        names = [e.name for e in result.boot_errors]
+        assert 'filesystem_corruption' in names
+
+    def test_corrupt_nofail_secondary_disk_survives_boot_success(self):
+        """C4: a corrupt nofail secondary disk on a VM that boots fine must
+        still be reported on RUNNING — boot-success suppression must not
+        clear filesystem-category findings."""
+        serial = (
+            "[    5.1] EXT4-fs error (device sdb1): ext4_find_entry:1455: inode #2: comm systemd: reading directory lblock 0\n"
+            "[  OK  ] Reached target multi-user.target - Multi-User System.\n"
+            "[  OK  ] Startup finished in 5.2s.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'RUNNING')
+        assert result.diagnosis_status == 'boot_errors_detected'
+        names = [e.name for e in result.boot_errors]
+        assert 'filesystem_corruption' in names
+
+    def test_boot_success_still_clears_fstab_noise(self):
+        """C4 guard: the exemption is filesystem-only — fstab timeout noise
+        on a successfully booted RUNNING VM must still be cleared."""
+        serial = (
+            "Timed out waiting for device /dev/disk/by-uuid/deadbeef-1234-5678-9abc-def012345678\n"
+            "[  OK  ] Reached target multi-user.target - Multi-User System.\n"
+            "[  OK  ] Startup finished in 6.1s.\n"
+        )
+        result = analyze_serial_output(serial, 'test-vm', 'zone-a', 'RUNNING')
+        assert result.diagnosis_status == 'healthy'
+        assert result.boot_errors == []

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -534,6 +534,34 @@ class TestDiagnoseCpuLockup:
         )
         assert err['severity'] == 'critical'
 
+    def test_hard_lockup_detected_kernel_6_5_plus_prefix(self):
+        """Red-team C2: kernel >= 6.5 (Ubuntu 24.04 = 6.8) logs the hard
+        lockup with a 'watchdog:' prefix, not 'NMI watchdog:'. On GCE the
+        buddy detector (6.5+ prefix) is the realistic reporter since guests
+        have no PMU."""
+        serial = (
+            "[ 3600.200000] watchdog: Watchdog detected hard LOCKUP on cpu 2\n"
+            "[ 3600.208113] Modules linked in: virtio_scsi virtio_pci\n"
+        )
+        data = _diagnose(serial)
+        err = next(
+            e for e in data['boot_errors']
+            if e['name'] == 'cpu_lockup_hard_lockup'
+        )
+        assert err['severity'] == 'critical'
+
+    def test_benign_watchdog_boot_lines_not_matched(self):
+        """Healthy watchdog boot lines (present on every GCE boot) must not
+        trigger the hard lockup pattern."""
+        serial = (
+            "[    0.512331] NMI watchdog: Perf NMI watchdog permanently disabled\n"
+            "[    0.520114] watchdog: Delayed init of the lockup detector failed: -19\n"
+            "[    0.527448] watchdog: Hard watchdog permanently disabled\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'cpu_lockup' not in categories
+
     def test_bus_lock_trap_detected(self):
         """Kernel split-lock-detection trap line should be detected as warning."""
         serial = (
@@ -586,6 +614,58 @@ class TestDiagnoseCpuLockup:
         names = [e['name'] for e in data['boot_errors']]
         assert 'cpu_lockup_rcu_stall' in names
 
+    def test_rcu_preempt_stall_detected(self):
+        """Red-team C3: rcu_preempt is the default RCU flavor on Ubuntu
+        22.04/24.04 (PREEMPT_DYNAMIC) — the most common modern GCE case."""
+        serial = (
+            "[  512.882314] rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:\n"
+            "[  512.890120] rcu: \t1-...!: (0 ticks this GP) idle=b6ac/0/0x0 softirq=9241/9241 fqs=0\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_rcu_stall' in names
+
+    def test_rcu_stall_old_kernel_format_detected(self):
+        """Red-team C3: kernels < 4.19 / RHEL 7 log without the 'rcu:'
+        prefix."""
+        serial = (
+            "[  455.220133] INFO: rcu_sched detected stalls on CPUs/tasks: { 1} (detected by 0, t=60002 jiffies)\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_rcu_stall' in names
+
+    def test_rcu_expedited_stall_detected(self):
+        """Red-team C3: expedited grace-period stalls should also match."""
+        serial = (
+            "[  600.101220] rcu: INFO: rcu_sched detected expedited stalls on CPUs/tasks: { 2-... } 6620 jiffies s: 141\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_rcu_stall' in names
+
+    def test_rcu_preempt_self_detected_stall_detected(self):
+        """Red-team C3: self-detected stall with the rcu_preempt flavor."""
+        serial = (
+            "[  711.400913] rcu: INFO: rcu_preempt self-detected stall on CPU\n"
+            "[  711.408122] rcu: \t2-....: (5249 ticks this GP) idle=e3e/1/0x4000000000000002\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_rcu_stall' in names
+
+    def test_healthy_rcu_boot_banners_not_matched(self):
+        """Healthy RCU boot banners must not trigger the stall pattern."""
+        serial = (
+            "[    0.010220] rcu: Hierarchical RCU implementation.\n"
+            "[    0.014331] rcu: \tRCU restricting CPUs from NR_CPUS=8192 to nr_cpu_ids=2.\n"
+            "[    0.020144] rcu: Hierarchical SRCU implementation.\n"
+            "[    0.031228] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'cpu_lockup' not in categories
+
     def test_healthy_boot_matches_no_cpu_lockup_patterns(self):
         """A clean boot must not produce any cpu_lockup findings."""
         serial = (
@@ -632,9 +712,10 @@ class TestDiagnoseCpuLockup:
         categories = {e['category'] for e in data['boot_errors']}
         assert categories == {'cpu_lockup'}
 
-    def test_lockup_finding_suppresses_emergency_mode_catch_all(self):
-        """A cpu_lockup root cause should drop the emergency-mode catch-all
-        finding (tier-1 dedupe)."""
+    def test_lockup_finding_does_not_suppress_emergency_mode(self):
+        """cpu_lockup findings are runtime conditions, never a boot-config
+        root cause, so they must NOT suppress the emergency-mode catch-all
+        (tier-1 dedupe must ignore them)."""
         serial = (
             "[  312.104501] NMI watchdog: Watchdog detected hard LOCKUP on cpu 1\n"
             "[  320.220118] You are in emergency mode\n"
@@ -642,7 +723,34 @@ class TestDiagnoseCpuLockup:
         data = _diagnose(serial)
         names = [e['name'] for e in data['boot_errors']]
         assert 'cpu_lockup_hard_lockup' in names
-        assert 'fstab_emergency_mode' not in names
+        assert 'fstab_emergency_mode' in names
+
+    def test_bus_lock_warning_does_not_suppress_emergency_mode(self):
+        """Red-team C1: a warning-severity bus_lock finding must not hide a
+        CRITICAL fstab emergency-mode finding."""
+        serial = (
+            "[  102.334455] x86/split lock detection: #DB: myapp/2211 took a bus_lock trap at address: 0x7f3c2a1b4d20\n"
+            "[  180.220118] You are in emergency mode\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'cpu_lockup_bus_lock' in names
+        assert 'fstab_emergency_mode' in names
+        severities = {e['name']: e['severity'] for e in data['boot_errors']}
+        assert severities['fstab_emergency_mode'] == 'critical'
+
+    def test_bus_lock_warning_does_not_suppress_dependency_failures(self):
+        """Red-team C1: a warning-severity bus_lock finding must not strip
+        generic-symptom fstab criticals (tier-2 dedupe)."""
+        serial = (
+            "[  102.334455] x86/split lock detection: #DB: myapp/2211 took a bus_lock trap at address: 0x7f3c2a1b4d20\n"
+            "[  150.101332] systemd[1]: Dependency failed for /mnt/disks/data.\n"
+            "[  150.109221] systemd[1]: Dependency failed for File System Check on /dev/sdb1.\n"
+        )
+        data = _diagnose(serial)
+        categories = {e['category'] for e in data['boot_errors']}
+        assert 'cpu_lockup' in categories
+        assert 'fstab' in categories
 
     def test_recovered_lockup_before_boot_success_is_suppressed(self):
         """A lockup that happened BEFORE the last successful boot marker on a

--- a/gce_rescue_v2/tests/test_diagnose.py
+++ b/gce_rescue_v2/tests/test_diagnose.py
@@ -3190,3 +3190,25 @@ class TestFstabDistroBroadening:
         names = [e['name'] for e in data['boot_errors']]
         assert 'fstab_device_timeout' in names
         assert 'fstab_emergency_mode' not in names
+
+    def test_live_opensuse_plain_failed_to_mount_detected(self):
+        """LIVE (t-w2-suse, openSUSE Leap 16, wiped-superblock secondary
+        disk): the console prints the PLAIN form '[FAILED] Failed to mount
+        /mnt/data.' - no .mount suffix, no systemd[1]: prefix - and the
+        only DEPEND lines name non-path targets ('Local File Systems'),
+        so before the plain-form regex this buffer produced nothing but
+        the emergency-mode catch-all."""
+        serial = (
+            "[  OK  ] Mounted /var.\n"
+            "[FAILED] Failed to mount /mnt/data.\n"
+            "See 'systemctl status mnt-data.mount' for details.\n"
+            "[DEPEND] Dependency failed for Local File Systems.\n"
+            "[DEPEND] Dependency failed for Early Kernel Boot Messages.\n"
+            "You are in emergency mode. After logging in, type "
+            "\"journalctl -xb\" to view\n"
+        )
+        data = _diagnose(serial)
+        names = [e['name'] for e in data['boot_errors']]
+        assert 'fstab_mount_failed' in names
+        # Root cause wins; the generic emergency catch-all stays demoted.
+        assert 'fstab_emergency_mode' not in names

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -454,6 +454,50 @@ class TestShippedFixInfo:
                 "core/diagnose_rules/machine_id.yaml"
             )
 
+    def test_switchroot_fix_guidance_loaded(self):
+        assert 'switchroot' in CATEGORY_FIX_GUIDANCE
+
+    def test_switchroot_is_not_auto_repairable(self):
+        """switchroot stays auto_repair: false until switchroot_fix.sh lands."""
+        assert 'switchroot' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_switchroot_patterns_have_fixes(self):
+        """Every switchroot pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        sr_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'switchroot'
+        ]
+        assert len(sr_patterns) > 0
+        for pattern in sr_patterns:
+            fixes = get_fixes_for_pattern('switchroot', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/switchroot.yaml"
+            )
+
+    def test_systemd_early_fix_guidance_loaded(self):
+        assert 'systemd_early' in CATEGORY_FIX_GUIDANCE
+
+    def test_systemd_early_is_not_auto_repairable(self):
+        """systemd_early stays auto_repair: false until systemd_early_fix.sh lands."""
+        assert 'systemd_early' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_systemd_early_patterns_have_fixes(self):
+        """Every systemd_early pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        se_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'systemd_early'
+        ]
+        assert len(se_patterns) > 0
+        for pattern in se_patterns:
+            fixes = get_fixes_for_pattern('systemd_early', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/systemd_early.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -211,6 +211,25 @@ class TestShippedFixInfo:
                 f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/fstab.yaml"
             )
 
+    def test_filesystem_fix_guidance_loaded(self):
+        assert 'filesystem' in CATEGORY_FIX_GUIDANCE
+
+    def test_filesystem_is_not_auto_repairable(self):
+        """filesystem stays auto_repair: false until filesystem_fix.sh lands."""
+        assert 'filesystem' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_filesystem_patterns_have_fixes(self):
+        """Every filesystem pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        fs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'filesystem']
+        for pattern in fs_patterns:
+            fixes = get_fixes_for_pattern('filesystem', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/filesystem.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -211,6 +211,28 @@ class TestShippedFixInfo:
                 f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/fstab.yaml"
             )
 
+    def test_disk_full_fix_guidance_loaded(self):
+        assert 'disk_full' in CATEGORY_FIX_GUIDANCE
+
+    def test_disk_full_is_not_auto_repairable(self):
+        """disk_full stays auto_repair: false until disk_full_fix.sh lands."""
+        assert 'disk_full' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_disk_full_patterns_have_fixes(self):
+        """Every disk_full pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        disk_full_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'disk_full'
+        ]
+        assert len(disk_full_patterns) > 0
+        for pattern in disk_full_patterns:
+            fixes = get_fixes_for_pattern('disk_full', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/disk_full.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -211,6 +211,27 @@ class TestShippedFixInfo:
                 f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/fstab.yaml"
             )
 
+    def test_cpu_lockup_fix_guidance_loaded(self):
+        assert 'cpu_lockup' in CATEGORY_FIX_GUIDANCE
+
+    def test_cpu_lockup_is_not_auto_repairable(self):
+        """cpu_lockup is detect-only; auto_repair stays false until a
+        startup_scripts/fixes/cpu_lockup_fix.sh lands (lockups are workload
+        conditions, not on-disk boot configuration)."""
+        assert 'cpu_lockup' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_cpu_lockup_patterns_have_fixes(self):
+        """Every cpu_lockup pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        cpu_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'cpu_lockup']
+        for pattern in cpu_patterns:
+            fixes = get_fixes_for_pattern('cpu_lockup', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                f"core/diagnose_rules/cpu_lockup.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -369,6 +369,91 @@ class TestShippedFixInfo:
                 "core/diagnose_rules/firmware.yaml"
             )
 
+    def test_lvm_fix_guidance_loaded(self):
+        assert 'lvm' in CATEGORY_FIX_GUIDANCE
+
+    def test_lvm_is_not_auto_repairable(self):
+        """lvm stays auto_repair: false until lvm_fix.sh lands."""
+        assert 'lvm' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_lvm_patterns_have_fixes(self):
+        """Every lvm pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        lvm_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'lvm']
+        assert len(lvm_patterns) > 0
+        for pattern in lvm_patterns:
+            fixes = get_fixes_for_pattern('lvm', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/lvm.yaml"
+            )
+
+    def test_crypt_fix_guidance_loaded(self):
+        """crypt is detect-only, so its fix_guidance is what the formatter
+        renders - it must be present in the catalog."""
+        assert 'crypt' in CATEGORY_FIX_GUIDANCE
+
+    def test_crypt_is_not_auto_repairable(self):
+        """crypt is detect-only forever: a LUKS disk cannot be unlocked
+        from the rescue disk without the passphrase/keyfile."""
+        assert 'crypt' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_crypt_patterns_have_fixes(self):
+        """Every crypt pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        crypt_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'crypt']
+        assert len(crypt_patterns) > 0
+        for pattern in crypt_patterns:
+            fixes = get_fixes_for_pattern('crypt', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/crypt.yaml"
+            )
+
+    def test_raid_fix_guidance_loaded(self):
+        assert 'raid' in CATEGORY_FIX_GUIDANCE
+
+    def test_raid_is_not_auto_repairable(self):
+        """raid stays auto_repair: false until raid_fix.sh lands."""
+        assert 'raid' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_raid_patterns_have_fixes(self):
+        """Every raid pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        raid_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'raid']
+        assert len(raid_patterns) > 0
+        for pattern in raid_patterns:
+            fixes = get_fixes_for_pattern('raid', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/raid.yaml"
+            )
+
+    def test_machine_id_fix_guidance_loaded(self):
+        assert 'machine_id' in CATEGORY_FIX_GUIDANCE
+
+    def test_machine_id_is_not_auto_repairable(self):
+        """machine_id stays auto_repair: false until machine_id_fix.sh lands."""
+        assert 'machine_id' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_machine_id_patterns_have_fixes(self):
+        """Every machine_id pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        mid_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'machine_id'
+        ]
+        assert len(mid_patterns) > 0
+        for pattern in mid_patterns:
+            fixes = get_fixes_for_pattern('machine_id', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/machine_id.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -141,7 +141,7 @@ class TestBuildExports:
     def test_guidance_extracted(self, tmp_path):
         _write_yaml(tmp_path, 'test.yaml', VALID_FIX_YAML)
         fix_data = _load_fix_files(tmp_path)
-        guidance, _, _ = _build_exports(fix_data)
+        guidance, _, _, _ = _build_exports(fix_data)
 
         assert guidance == {'test_cat': "sudo nano /mnt/sysroot/etc/test"}
 
@@ -149,7 +149,7 @@ class TestBuildExports:
         _write_yaml(tmp_path, 'a.yaml', VALID_FIX_YAML)
         _write_yaml(tmp_path, 'b.yaml', NO_AUTO_REPAIR_YAML)
         fix_data = _load_fix_files(tmp_path)
-        _, supported, _ = _build_exports(fix_data)
+        _, supported, _, _ = _build_exports(fix_data)
 
         assert 'test_cat' in supported
         assert 'manual_cat' not in supported
@@ -157,7 +157,7 @@ class TestBuildExports:
     def test_pattern_fixes_extracted(self, tmp_path):
         _write_yaml(tmp_path, 'test.yaml', VALID_FIX_YAML)
         fix_data = _load_fix_files(tmp_path)
-        _, _, pattern_fixes = _build_exports(fix_data)
+        _, _, _, pattern_fixes = _build_exports(fix_data)
 
         assert 'test_cat' in pattern_fixes
         assert pattern_fixes['test_cat']['test_pattern_a'] == [

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -211,6 +211,24 @@ class TestShippedFixInfo:
                 f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/fstab.yaml"
             )
 
+    def test_ssh_fix_guidance_loaded(self):
+        assert 'ssh' in CATEGORY_FIX_GUIDANCE
+
+    def test_ssh_is_not_auto_repairable(self):
+        """ssh must stay auto_repair: false until startup_scripts/fixes/ssh_fix.sh lands."""
+        assert 'ssh' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_ssh_patterns_have_fixes(self):
+        """Every ssh pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        ssh_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'ssh']
+        for pattern in ssh_patterns:
+            fixes = get_fixes_for_pattern('ssh', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/ssh.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -329,6 +329,46 @@ class TestShippedFixInfo:
                 f"core/diagnose_rules/cpu_lockup.yaml"
             )
 
+    def test_grub_fix_guidance_loaded(self):
+        assert 'grub' in CATEGORY_FIX_GUIDANCE
+
+    def test_grub_is_not_auto_repairable(self):
+        """grub stays auto_repair: false until startup_scripts/fixes/grub_fix.sh lands."""
+        assert 'grub' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_grub_patterns_have_fixes(self):
+        """Every grub pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        grub_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'grub']
+        assert len(grub_patterns) > 0
+        for pattern in grub_patterns:
+            fixes = get_fixes_for_pattern('grub', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/grub.yaml"
+            )
+
+    def test_firmware_fix_guidance_loaded(self):
+        assert 'firmware' in CATEGORY_FIX_GUIDANCE
+
+    def test_firmware_is_not_auto_repairable(self):
+        """firmware stays auto_repair: false until firmware_fix.sh lands."""
+        assert 'firmware' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_firmware_patterns_have_fixes(self):
+        """Every firmware pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        fw_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'firmware']
+        assert len(fw_patterns) > 0
+        for pattern in fw_patterns:
+            fixes = get_fixes_for_pattern('firmware', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/firmware.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -211,6 +211,44 @@ class TestShippedFixInfo:
                 f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/fstab.yaml"
             )
 
+    def test_kernel_fix_guidance_loaded(self):
+        """kernel category has fix_guidance, so it must appear in the catalog."""
+        assert 'kernel' in CATEGORY_FIX_GUIDANCE
+
+    def test_initramfs_fix_guidance_loaded(self):
+        """initramfs category has fix_guidance, so it must appear in the catalog."""
+        assert 'initramfs' in CATEGORY_FIX_GUIDANCE
+
+    def test_kernel_is_not_auto_repairable(self):
+        """kernel is detect-only (auto_repair: false) — no fix script exists."""
+        assert 'kernel' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_initramfs_is_not_auto_repairable(self):
+        """initramfs ships with auto_repair: false until initramfs_fix.sh lands."""
+        assert 'initramfs' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_kernel_patterns_have_fixes(self):
+        """Every kernel pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        kernel_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'kernel']
+        for pattern in kernel_patterns:
+            fixes = get_fixes_for_pattern('kernel', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/kernel.yaml"
+            )
+
+    def test_initramfs_patterns_have_fixes(self):
+        """Every initramfs pattern should have at least one fix suggestion."""
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        initramfs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'initramfs']
+        for pattern in initramfs_patterns:
+            fixes = get_fixes_for_pattern('initramfs', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in core/diagnose_rules/initramfs.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_fix_info.py
+++ b/gce_rescue_v2/tests/test_fix_info.py
@@ -498,6 +498,140 @@ class TestShippedFixInfo:
                 "core/diagnose_rules/systemd_early.yaml"
             )
 
+    # -- Wave 4/5 categories ------------------------------------------------
+
+    def test_readonly_fix_guidance_loaded(self):
+        assert 'readonly' in CATEGORY_FIX_GUIDANCE
+
+    def test_readonly_is_not_auto_repairable(self):
+        """readonly stays auto_repair: false until readonly_fix.sh lands."""
+        assert 'readonly' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_readonly_patterns_have_fixes(self):
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        ro_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'readonly'
+        ]
+        assert len(ro_patterns) > 0
+        for pattern in ro_patterns:
+            fixes = get_fixes_for_pattern('readonly', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/readonly.yaml"
+            )
+
+    def test_oom_fix_guidance_loaded(self):
+        """oom is detect-only, so its fix_guidance is what the formatter
+        renders - it must be present in the catalog."""
+        assert 'oom' in CATEGORY_FIX_GUIDANCE
+
+    def test_oom_is_not_auto_repairable(self):
+        """oom is detect-only: nothing on the rescued disk to edit
+        (memory sizing/workload condition)."""
+        assert 'oom' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_oom_patterns_have_fixes(self):
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        oom_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'oom'
+        ]
+        assert len(oom_patterns) > 0
+        for pattern in oom_patterns:
+            fixes = get_fixes_for_pattern('oom', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/oom.yaml"
+            )
+
+    def test_selinux_fix_guidance_loaded(self):
+        assert 'selinux' in CATEGORY_FIX_GUIDANCE
+
+    def test_selinux_is_not_auto_repairable(self):
+        """selinux stays auto_repair: false until selinux_fix.sh lands
+        (future fix: touch /.autorelabel on the mounted root)."""
+        assert 'selinux' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_selinux_patterns_have_fixes(self):
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        se_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'selinux'
+        ]
+        assert len(se_patterns) > 0
+        for pattern in se_patterns:
+            fixes = get_fixes_for_pattern('selinux', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/selinux.yaml"
+            )
+
+    def test_startup_script_fix_guidance_loaded(self):
+        assert 'startup_script' in CATEGORY_FIX_GUIDANCE
+
+    def test_startup_script_is_not_auto_repairable(self):
+        """startup_script is detect-only: the failing code lives in VM
+        metadata, not on the rescued disk."""
+        assert 'startup_script' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_startup_script_patterns_have_fixes(self):
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        ss_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'startup_script'
+        ]
+        assert len(ss_patterns) > 0
+        for pattern in ss_patterns:
+            fixes = get_fixes_for_pattern('startup_script', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/startup_script.yaml"
+            )
+
+    def test_cloud_init_fix_guidance_loaded(self):
+        assert 'cloud_init' in CATEGORY_FIX_GUIDANCE
+
+    def test_cloud_init_is_not_auto_repairable(self):
+        """cloud_init is detect-only: user-data/datasource config, not
+        on-disk boot configuration a fix script could safely edit."""
+        assert 'cloud_init' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_cloud_init_patterns_have_fixes(self):
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        ci_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'cloud_init'
+        ]
+        assert len(ci_patterns) > 0
+        for pattern in ci_patterns:
+            fixes = get_fixes_for_pattern('cloud_init', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/cloud_init.yaml"
+            )
+
+    def test_network_fix_guidance_loaded(self):
+        assert 'network' in CATEGORY_FIX_GUIDANCE
+
+    def test_network_is_not_auto_repairable(self):
+        """network stays auto_repair: false until network_fix.sh lands."""
+        assert 'network' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_network_patterns_have_fixes(self):
+        from gce_rescue_v2.core.diagnosis import BOOT_ERROR_PATTERNS
+
+        net_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'network'
+        ]
+        assert len(net_patterns) > 0
+        for pattern in net_patterns:
+            fixes = get_fixes_for_pattern('network', pattern.name)
+            assert len(fixes) > 0, (
+                f"Pattern '{pattern.name}' has no fixes in "
+                "core/diagnose_rules/network.yaml"
+            )
+
     def test_fix_script_exists_for_supported_categories(self):
         """Every auto-repairable category should have a fix script."""
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -377,29 +377,33 @@ class TestShippedPatterns:
             )
 
     def test_survives_boot_success_flags(self):
-        """ssh/filesystem failures are not resolved by a completed boot, so
-        their YAML declares survives_boot_success; boot-blocking categories
-        must not declare it."""
+        """ssh/filesystem/disk_full failures are not resolved by a completed
+        boot (a full disk stays full after 'Startup finished'), so their YAML
+        declares survives_boot_success; boot-blocking categories must not
+        declare it."""
         from gce_rescue_v2.core.diagnosis import (
             SURVIVES_BOOT_SUCCESS_CATEGORIES,
         )
         assert 'ssh' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'filesystem' in SURVIVES_BOOT_SUCCESS_CATEGORIES
-        for cat in ('fstab', 'kernel', 'initramfs', 'disk_full'):
+        assert 'disk_full' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        for cat in ('fstab', 'kernel', 'initramfs'):
             assert cat not in SURVIVES_BOOT_SUCCESS_CATEGORIES
 
     def test_detect_only_flags(self):
-        """cpu_lockup is detect-only (runtime condition, never a suppressing
-        root cause); detect_only does NOT imply survives_boot_success, and
-        rescue-workflow categories must not declare it."""
+        """cpu_lockup and kernel are detect-only (manual investigation, never
+        a rescue/restore fix); detect_only does NOT imply
+        survives_boot_success, and rescue-workflow categories must not
+        declare it."""
         from gce_rescue_v2.core.diagnosis import (
             DETECT_ONLY_CATEGORIES,
             SURVIVES_BOOT_SUCCESS_CATEGORIES,
         )
         assert 'cpu_lockup' in DETECT_ONLY_CATEGORIES
+        assert 'kernel' in DETECT_ONLY_CATEGORIES
         assert 'cpu_lockup' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
-        for cat in ('fstab', 'kernel', 'initramfs', 'disk_full', 'ssh',
-                    'filesystem'):
+        assert 'kernel' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        for cat in ('fstab', 'initramfs', 'disk_full', 'ssh', 'filesystem'):
             assert cat not in DETECT_ONLY_CATEGORIES
 
     def test_detect_only_sets_agree(self):

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -253,3 +253,43 @@ class TestShippedPatterns:
             assert len(pattern.fixes) > 0, (
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
+
+    def test_kernel_patterns_present(self):
+        kernel_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'kernel']
+        assert len(kernel_patterns) == 5
+
+    def test_kernel_patterns_have_inline_fixes(self):
+        """All kernel patterns should have inline fixes from merged YAML."""
+        kernel_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'kernel']
+        for pattern in kernel_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_initramfs_patterns_present(self):
+        initramfs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'initramfs']
+        assert len(initramfs_patterns) == 2
+
+    def test_initramfs_patterns_have_inline_fixes(self):
+        """All initramfs patterns should have inline fixes from merged YAML."""
+        initramfs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'initramfs']
+        for pattern in initramfs_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_all_kernel_pattern_names_prefixed(self):
+        """Kernel pattern names should follow the category-prefix convention."""
+        kernel_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'kernel']
+        for pattern in kernel_patterns:
+            assert pattern.name.startswith('kernel_'), (
+                f"Pattern '{pattern.name}' missing 'kernel_' prefix"
+            )
+
+    def test_all_initramfs_pattern_names_prefixed(self):
+        """Initramfs pattern names should follow the category-prefix convention."""
+        initramfs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'initramfs']
+        for pattern in initramfs_patterns:
+            assert pattern.name.startswith('initramfs_'), (
+                f"Pattern '{pattern.name}' missing 'initramfs_' prefix"
+            )

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -253,3 +253,27 @@ class TestShippedPatterns:
             assert len(pattern.fixes) > 0, (
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
+
+    def test_disk_full_patterns_present(self):
+        disk_full_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'disk_full'
+        ]
+        assert len(disk_full_patterns) == 2
+
+    def test_disk_full_patterns_have_category_prefix(self):
+        """disk_full pattern names should be prefixed with the category."""
+        disk_full_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'disk_full'
+        ]
+        for pattern in disk_full_patterns:
+            assert pattern.name.startswith('disk_full_')
+
+    def test_disk_full_patterns_have_inline_fixes(self):
+        """All disk_full patterns should have inline fixes from merged YAML."""
+        disk_full_patterns = [
+            p for p in BOOT_ERROR_PATTERNS if p.category == 'disk_full'
+        ]
+        for pattern in disk_full_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -375,3 +375,36 @@ class TestShippedPatterns:
             assert pattern.name.startswith('cpu_lockup_'), (
                 f"Pattern '{pattern.name}' missing 'cpu_lockup_' prefix"
             )
+
+    def test_survives_boot_success_flags(self):
+        """ssh/filesystem failures are not resolved by a completed boot, so
+        their YAML declares survives_boot_success; boot-blocking categories
+        must not declare it."""
+        from gce_rescue_v2.core.diagnosis import (
+            SURVIVES_BOOT_SUCCESS_CATEGORIES,
+        )
+        assert 'ssh' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        assert 'filesystem' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        for cat in ('fstab', 'kernel', 'initramfs', 'disk_full'):
+            assert cat not in SURVIVES_BOOT_SUCCESS_CATEGORIES
+
+    def test_detect_only_flags(self):
+        """cpu_lockup is detect-only (runtime condition, never a suppressing
+        root cause); detect_only does NOT imply survives_boot_success, and
+        rescue-workflow categories must not declare it."""
+        from gce_rescue_v2.core.diagnosis import (
+            DETECT_ONLY_CATEGORIES,
+            SURVIVES_BOOT_SUCCESS_CATEGORIES,
+        )
+        assert 'cpu_lockup' in DETECT_ONLY_CATEGORIES
+        assert 'cpu_lockup' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        for cat in ('fstab', 'kernel', 'initramfs', 'disk_full', 'ssh',
+                    'filesystem'):
+            assert cat not in DETECT_ONLY_CATEGORIES
+
+    def test_detect_only_sets_agree(self):
+        """A detect_only category must declare fix_guidance (its prose is what
+        the formatter renders), keeping engine and formatter sets identical."""
+        from gce_rescue_v2.core import fix_catalog, diagnosis
+        assert (fix_catalog.DETECT_ONLY_CATEGORIES
+                == set(diagnosis.DETECT_ONLY_CATEGORIES))

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -256,7 +256,7 @@ class TestShippedPatterns:
 
     def test_kernel_patterns_present(self):
         kernel_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'kernel']
-        assert len(kernel_patterns) == 5
+        assert len(kernel_patterns) == 8
 
     def test_kernel_patterns_have_inline_fixes(self):
         """All kernel patterns should have inline fixes from merged YAML."""
@@ -499,6 +499,72 @@ class TestShippedPatterns:
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
 
+    def test_switchroot_patterns_present(self):
+        sr_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'switchroot']
+        assert len(sr_patterns) == 3
+
+    def test_switchroot_pattern_names_prefixed(self):
+        """switchroot pattern names should carry the category prefix."""
+        sr_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'switchroot']
+        for pattern in sr_patterns:
+            assert pattern.name.startswith('switchroot_'), (
+                f"Pattern '{pattern.name}' missing 'switchroot_' prefix"
+            )
+
+    def test_switchroot_patterns_have_inline_fixes(self):
+        """All switchroot patterns should have inline fixes."""
+        sr_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'switchroot']
+        for pattern in sr_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_switchroot_patterns_all_critical(self):
+        """Stage-6 failures always leave the VM unbootable - all critical."""
+        sr_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'switchroot']
+        for pattern in sr_patterns:
+            assert pattern.severity == 'critical'
+
+    def test_systemd_early_patterns_present(self):
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'systemd_early']
+        assert len(se_patterns) == 3
+
+    def test_systemd_early_pattern_names_prefixed(self):
+        """systemd_early pattern names should carry the category prefix."""
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'systemd_early']
+        for pattern in se_patterns:
+            assert pattern.name.startswith('systemd_'), (
+                f"Pattern '{pattern.name}' missing 'systemd_' prefix"
+            )
+
+    def test_systemd_early_patterns_have_inline_fixes(self):
+        """All systemd_early patterns should have inline fixes."""
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'systemd_early']
+        for pattern in se_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_systemd_early_no_generic_failed_to_start(self):
+        """systemd_early must never ship a bare 'Failed to start' regex -
+        it fires on every non-fatal unit failure on healthy boots (the
+        scoping decision documented in systemd_early.yaml)."""
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'systemd_early']
+        for pattern in se_patterns:
+            for regex in pattern.patterns:
+                assert 'Failed to start' not in regex, (
+                    f"Pattern '{pattern.name}' carries the FP-prone "
+                    f"'Failed to start' anchor: {regex}"
+                )
+
     def test_survives_boot_success_flags(self):
         """ssh/filesystem/disk_full failures are not resolved by a completed
         boot (a full disk stays full after 'Startup finished'), so their YAML
@@ -511,7 +577,8 @@ class TestShippedPatterns:
         assert 'filesystem' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'disk_full' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         for cat in ('fstab', 'kernel', 'initramfs', 'grub', 'firmware',
-                    'lvm', 'crypt', 'raid', 'machine_id'):
+                    'lvm', 'crypt', 'raid', 'machine_id', 'switchroot',
+                    'systemd_early'):
             assert cat not in SURVIVES_BOOT_SUCCESS_CATEGORIES
 
     def test_detect_only_flags(self):
@@ -530,7 +597,8 @@ class TestShippedPatterns:
         assert 'kernel' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'crypt' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         for cat in ('fstab', 'initramfs', 'disk_full', 'ssh', 'filesystem',
-                    'grub', 'firmware', 'lvm', 'raid', 'machine_id'):
+                    'grub', 'firmware', 'lvm', 'raid', 'machine_id',
+                    'switchroot', 'systemd_early'):
             assert cat not in DETECT_ONLY_CATEGORIES
 
     def test_detect_only_sets_agree(self):

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -253,3 +253,23 @@ class TestShippedPatterns:
             assert len(pattern.fixes) > 0, (
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
+
+    def test_ssh_patterns_present(self):
+        ssh_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'ssh']
+        assert len(ssh_patterns) == 3
+
+    def test_ssh_patterns_have_inline_fixes(self):
+        """All ssh patterns should have inline fixes from merged YAML."""
+        ssh_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'ssh']
+        for pattern in ssh_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_ssh_pattern_names_have_category_prefix(self):
+        """All ssh pattern names should carry the ssh_ prefix convention."""
+        ssh_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'ssh']
+        for pattern in ssh_patterns:
+            assert pattern.name.startswith('ssh_'), (
+                f"Pattern '{pattern.name}' missing 'ssh_' prefix"
+            )

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -253,3 +253,21 @@ class TestShippedPatterns:
             assert len(pattern.fixes) > 0, (
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
+
+    def test_filesystem_patterns_present(self):
+        fs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'filesystem']
+        assert len(fs_patterns) == 2
+
+    def test_filesystem_pattern_names_prefixed(self):
+        """All filesystem pattern names should carry the category prefix."""
+        fs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'filesystem']
+        for pattern in fs_patterns:
+            assert pattern.name.startswith('filesystem_')
+
+    def test_filesystem_patterns_have_inline_fixes(self):
+        """All filesystem patterns should have inline fixes from merged YAML."""
+        fs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'filesystem']
+        for pattern in fs_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -687,9 +687,11 @@ class TestShippedPatterns:
             )
 
     def test_network_patterns_present(self):
+        # 3 since the red-team C2 fix split the benign wait-online
+        # timeout out of network_unit_failed into its own warning.
         net_patterns = [p for p in BOOT_ERROR_PATTERNS
                         if p.category == 'network']
-        assert len(net_patterns) == 2
+        assert len(net_patterns) == 3
 
     def test_network_pattern_names_prefixed(self):
         net_patterns = [p for p in BOOT_ERROR_PATTERNS

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -331,8 +331,10 @@ class TestShippedPatterns:
             )
 
     def test_ssh_patterns_present(self):
+        # 4 = 3 original + ssh_serial_getty_failed (Wave 5: the serial
+        # console is the second operator access path next to SSH).
         ssh_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'ssh']
-        assert len(ssh_patterns) == 3
+        assert len(ssh_patterns) == 4
 
     def test_ssh_patterns_have_inline_fixes(self):
         """All ssh patterns should have inline fixes from merged YAML."""
@@ -552,6 +554,180 @@ class TestShippedPatterns:
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
 
+    # -- Wave 4/5 categories ------------------------------------------------
+
+    def test_readonly_patterns_present(self):
+        ro_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'readonly']
+        assert len(ro_patterns) == 2
+
+    def test_readonly_pattern_names_prefixed(self):
+        """readonly pattern names should carry the category prefix."""
+        ro_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'readonly']
+        for pattern in ro_patterns:
+            assert pattern.name.startswith('readonly_'), (
+                f"Pattern '{pattern.name}' missing 'readonly_' prefix"
+            )
+
+    def test_readonly_patterns_have_inline_fixes(self):
+        """All readonly patterns should have inline fixes."""
+        ro_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'readonly']
+        for pattern in ro_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_oom_patterns_present(self):
+        """One pattern only: 'invoked oom-killer' and 'Out of memory:
+        Killed process' are two halves of the same kill event and must
+        produce a single finding."""
+        oom_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'oom']
+        assert len(oom_patterns) == 1
+
+    def test_oom_pattern_is_warning(self):
+        """A single OOM kill on a running VM is non-alarmist by design -
+        severity warning, so it can never act as a dedupe suppressor
+        (_is_boot_root_cause excludes warnings)."""
+        oom_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'oom']
+        for pattern in oom_patterns:
+            assert pattern.severity == 'warning'
+
+    def test_oom_pattern_names_prefixed(self):
+        oom_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'oom']
+        for pattern in oom_patterns:
+            assert pattern.name.startswith('oom_'), (
+                f"Pattern '{pattern.name}' missing 'oom_' prefix"
+            )
+
+    def test_oom_patterns_have_inline_fixes(self):
+        oom_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'oom']
+        for pattern in oom_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_selinux_patterns_present(self):
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'selinux']
+        assert len(se_patterns) == 2
+
+    def test_selinux_pattern_names_prefixed(self):
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'selinux']
+        for pattern in se_patterns:
+            assert pattern.name.startswith('selinux_'), (
+                f"Pattern '{pattern.name}' missing 'selinux_' prefix"
+            )
+
+    def test_selinux_patterns_have_inline_fixes(self):
+        se_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'selinux']
+        for pattern in se_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_startup_script_patterns_present(self):
+        ss_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'startup_script']
+        assert len(ss_patterns) == 1
+
+    def test_startup_script_pattern_names_prefixed(self):
+        ss_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'startup_script']
+        for pattern in ss_patterns:
+            assert pattern.name.startswith('startup_script_'), (
+                f"Pattern '{pattern.name}' missing 'startup_script_' prefix"
+            )
+
+    def test_startup_script_patterns_have_inline_fixes(self):
+        ss_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'startup_script']
+        for pattern in ss_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_startup_script_regex_excludes_exit_status_zero(self):
+        """The success line 'startup-script exit status 0' prints on every
+        healthy boot - the exit-status regex must be structurally unable
+        to match a zero status."""
+        import re
+        ss_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'startup_script']
+        healthy = ("google_metadata_script_runner[712]: startup-script "
+                   "exit status 0")
+        for pattern in ss_patterns:
+            for regex in pattern.patterns:
+                assert not re.search(regex, healthy, re.IGNORECASE), (
+                    f"Regex '{regex}' matches the healthy exit-status-0 line"
+                )
+
+    def test_cloud_init_patterns_present(self):
+        ci_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'cloud_init']
+        assert len(ci_patterns) == 2
+
+    def test_cloud_init_pattern_names_prefixed(self):
+        ci_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'cloud_init']
+        for pattern in ci_patterns:
+            assert pattern.name.startswith('cloud_init_'), (
+                f"Pattern '{pattern.name}' missing 'cloud_init_' prefix"
+            )
+
+    def test_cloud_init_patterns_have_inline_fixes(self):
+        ci_patterns = [p for p in BOOT_ERROR_PATTERNS
+                       if p.category == 'cloud_init']
+        for pattern in ci_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_network_patterns_present(self):
+        net_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'network']
+        assert len(net_patterns) == 2
+
+    def test_network_pattern_names_prefixed(self):
+        net_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'network']
+        for pattern in net_patterns:
+            assert pattern.name.startswith('network_'), (
+                f"Pattern '{pattern.name}' missing 'network_' prefix"
+            )
+
+    def test_network_patterns_have_inline_fixes(self):
+        net_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'network']
+        for pattern in net_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_network_failed_to_start_regexes_are_unit_bound(self):
+        """network may use 'Failed to start' ONLY when bound to a specific
+        network unit name/description - a bare 'Failed to start .*' would
+        fire on every benign unit failure (the systemd_early scoping
+        rule)."""
+        net_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'network']
+        for pattern in net_patterns:
+            for regex in pattern.patterns:
+                if 'Failed to start' in regex:
+                    assert regex != 'Failed to start .*', (
+                        "Unbound 'Failed to start' regex in network category"
+                    )
+                    assert any(tok in regex for tok in (
+                        'networkd', 'Network ?Manager', 'networking',
+                        'Raise network interfaces', 'Wait for Network',
+                    )), (
+                        f"'Failed to start' regex not bound to a network "
+                        f"unit: {regex}"
+                    )
+
     def test_systemd_early_no_generic_failed_to_start(self):
         """systemd_early must never ship a bare 'Failed to start' regex -
         it fires on every non-fatal unit failure on healthy boots (the
@@ -569,23 +745,41 @@ class TestShippedPatterns:
         """ssh/filesystem/disk_full failures are not resolved by a completed
         boot (a full disk stays full after 'Startup finished'), so their YAML
         declares survives_boot_success; boot-blocking categories must not
-        declare it."""
+        declare it.
+
+        Wave 4/5 additions: readonly (errors=remount-ro is a RUNNING-VM
+        condition), oom (runtime kills persist), startup_script/cloud_init
+        (the boot-success marker always appears around provisioning
+        failures). selinux and network deliberately do NOT survive: a later
+        completed boot proves the policy loaded / the transient DHCP flap
+        recovered, and a post-boot NIC death sits after the last success
+        marker so ordering already protects it from suppression."""
         from gce_rescue_v2.core.diagnosis import (
             SURVIVES_BOOT_SUCCESS_CATEGORIES,
         )
         assert 'ssh' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'filesystem' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'disk_full' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        assert 'readonly' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        assert 'oom' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        assert 'startup_script' in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        assert 'cloud_init' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         for cat in ('fstab', 'kernel', 'initramfs', 'grub', 'firmware',
                     'lvm', 'crypt', 'raid', 'machine_id', 'switchroot',
-                    'systemd_early'):
+                    'systemd_early', 'selinux', 'network'):
             assert cat not in SURVIVES_BOOT_SUCCESS_CATEGORIES
 
     def test_detect_only_flags(self):
         """cpu_lockup/kernel/crypt are detect-only (manual investigation or,
         for crypt, an encrypted disk that rescue mode cannot unlock);
         detect_only does NOT imply survives_boot_success, and
-        rescue-workflow categories must not declare it."""
+        rescue-workflow categories must not declare it.
+
+        Wave 4/5 additions: oom (workload sizing, nothing on disk to edit),
+        startup_script (user code in VM metadata) and cloud_init (user-data/
+        datasource config) are detect-only; readonly, selinux and network
+        are NOT - they are fixable from rescue mode (offline fsck,
+        autorelabel/selinux=0, on-disk network config)."""
         from gce_rescue_v2.core.diagnosis import (
             DETECT_ONLY_CATEGORIES,
             SURVIVES_BOOT_SUCCESS_CATEGORIES,
@@ -593,12 +787,16 @@ class TestShippedPatterns:
         assert 'cpu_lockup' in DETECT_ONLY_CATEGORIES
         assert 'kernel' in DETECT_ONLY_CATEGORIES
         assert 'crypt' in DETECT_ONLY_CATEGORIES
+        assert 'oom' in DETECT_ONLY_CATEGORIES
+        assert 'startup_script' in DETECT_ONLY_CATEGORIES
+        assert 'cloud_init' in DETECT_ONLY_CATEGORIES
         assert 'cpu_lockup' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'kernel' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'crypt' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         for cat in ('fstab', 'initramfs', 'disk_full', 'ssh', 'filesystem',
                     'grub', 'firmware', 'lvm', 'raid', 'machine_id',
-                    'switchroot', 'systemd_early'):
+                    'switchroot', 'systemd_early', 'readonly', 'selinux',
+                    'network'):
             assert cat not in DETECT_ONLY_CATEGORIES
 
     def test_detect_only_sets_agree(self):

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -376,6 +376,46 @@ class TestShippedPatterns:
                 f"Pattern '{pattern.name}' missing 'cpu_lockup_' prefix"
             )
 
+    def test_grub_patterns_present(self):
+        grub_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'grub']
+        assert len(grub_patterns) == 12
+
+    def test_grub_pattern_names_prefixed(self):
+        """grub pattern names should carry the category prefix."""
+        grub_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'grub']
+        for pattern in grub_patterns:
+            assert pattern.name.startswith('grub_'), (
+                f"Pattern '{pattern.name}' missing 'grub_' prefix"
+            )
+
+    def test_grub_patterns_have_inline_fixes(self):
+        """All grub patterns should have inline fixes from merged YAML."""
+        grub_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'grub']
+        for pattern in grub_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_firmware_patterns_present(self):
+        fw_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'firmware']
+        assert len(fw_patterns) == 4
+
+    def test_firmware_pattern_names_prefixed(self):
+        """firmware pattern names should carry the category prefix."""
+        fw_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'firmware']
+        for pattern in fw_patterns:
+            assert pattern.name.startswith('firmware_'), (
+                f"Pattern '{pattern.name}' missing 'firmware_' prefix"
+            )
+
+    def test_firmware_patterns_have_inline_fixes(self):
+        """All firmware patterns should have inline fixes from merged YAML."""
+        fw_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'firmware']
+        for pattern in fw_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
     def test_survives_boot_success_flags(self):
         """ssh/filesystem/disk_full failures are not resolved by a completed
         boot (a full disk stays full after 'Startup finished'), so their YAML
@@ -387,7 +427,7 @@ class TestShippedPatterns:
         assert 'ssh' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'filesystem' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'disk_full' in SURVIVES_BOOT_SUCCESS_CATEGORIES
-        for cat in ('fstab', 'kernel', 'initramfs'):
+        for cat in ('fstab', 'kernel', 'initramfs', 'grub', 'firmware'):
             assert cat not in SURVIVES_BOOT_SUCCESS_CATEGORIES
 
     def test_detect_only_flags(self):
@@ -403,7 +443,8 @@ class TestShippedPatterns:
         assert 'kernel' in DETECT_ONLY_CATEGORIES
         assert 'cpu_lockup' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'kernel' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
-        for cat in ('fstab', 'initramfs', 'disk_full', 'ssh', 'filesystem'):
+        for cat in ('fstab', 'initramfs', 'disk_full', 'ssh', 'filesystem',
+                    'grub', 'firmware'):
             assert cat not in DETECT_ONLY_CATEGORIES
 
     def test_detect_only_sets_agree(self):

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -253,3 +253,23 @@ class TestShippedPatterns:
             assert len(pattern.fixes) > 0, (
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
+
+    def test_cpu_lockup_patterns_present(self):
+        cpu_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'cpu_lockup']
+        assert len(cpu_patterns) == 4
+
+    def test_cpu_lockup_patterns_have_inline_fixes(self):
+        """All cpu_lockup patterns should have inline fixes from merged YAML."""
+        cpu_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'cpu_lockup']
+        for pattern in cpu_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_cpu_lockup_pattern_names_prefixed(self):
+        """cpu_lockup pattern names should carry the category prefix."""
+        cpu_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'cpu_lockup']
+        for pattern in cpu_patterns:
+            assert pattern.name.startswith('cpu_lockup_'), (
+                f"Pattern '{pattern.name}' missing 'cpu_lockup_' prefix"
+            )

--- a/gce_rescue_v2/tests/test_pattern_loader.py
+++ b/gce_rescue_v2/tests/test_pattern_loader.py
@@ -268,7 +268,7 @@ class TestShippedPatterns:
 
     def test_initramfs_patterns_present(self):
         initramfs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'initramfs']
-        assert len(initramfs_patterns) == 2
+        assert len(initramfs_patterns) == 8
 
     def test_initramfs_patterns_have_inline_fixes(self):
         """All initramfs patterns should have inline fixes from merged YAML."""
@@ -352,7 +352,7 @@ class TestShippedPatterns:
 
     def test_filesystem_patterns_present(self):
         fs_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'filesystem']
-        assert len(fs_patterns) == 2
+        assert len(fs_patterns) == 6
 
     def test_filesystem_pattern_names_prefixed(self):
         """All filesystem pattern names should carry the category prefix."""
@@ -416,6 +416,89 @@ class TestShippedPatterns:
                 f"Pattern '{pattern.name}' has no inline fixes"
             )
 
+    def test_lvm_patterns_present(self):
+        lvm_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'lvm']
+        assert len(lvm_patterns) == 3
+
+    def test_lvm_pattern_names_prefixed(self):
+        """lvm pattern names should carry the category prefix."""
+        lvm_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'lvm']
+        for pattern in lvm_patterns:
+            assert pattern.name.startswith('lvm_'), (
+                f"Pattern '{pattern.name}' missing 'lvm_' prefix"
+            )
+
+    def test_lvm_patterns_have_inline_fixes(self):
+        """All lvm patterns should have inline fixes from merged YAML."""
+        lvm_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'lvm']
+        for pattern in lvm_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_crypt_patterns_present(self):
+        crypt_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'crypt']
+        assert len(crypt_patterns) == 3
+
+    def test_crypt_pattern_names_prefixed(self):
+        """crypt pattern names should carry the category prefix."""
+        crypt_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'crypt']
+        for pattern in crypt_patterns:
+            assert pattern.name.startswith('crypt_'), (
+                f"Pattern '{pattern.name}' missing 'crypt_' prefix"
+            )
+
+    def test_crypt_patterns_have_inline_fixes(self):
+        """All crypt patterns should have inline fixes from merged YAML."""
+        crypt_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'crypt']
+        for pattern in crypt_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_raid_patterns_present(self):
+        raid_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'raid']
+        assert len(raid_patterns) == 2
+
+    def test_raid_pattern_names_prefixed(self):
+        """raid pattern names should carry the category prefix."""
+        raid_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'raid']
+        for pattern in raid_patterns:
+            assert pattern.name.startswith('raid_'), (
+                f"Pattern '{pattern.name}' missing 'raid_' prefix"
+            )
+
+    def test_raid_patterns_have_inline_fixes(self):
+        """All raid patterns should have inline fixes from merged YAML."""
+        raid_patterns = [p for p in BOOT_ERROR_PATTERNS if p.category == 'raid']
+        for pattern in raid_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
+    def test_machine_id_patterns_present(self):
+        mid_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'machine_id']
+        assert len(mid_patterns) == 1
+
+    def test_machine_id_pattern_names_prefixed(self):
+        """machine_id pattern names should carry the category prefix."""
+        mid_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'machine_id']
+        for pattern in mid_patterns:
+            assert pattern.name.startswith('machine_id_'), (
+                f"Pattern '{pattern.name}' missing 'machine_id_' prefix"
+            )
+
+    def test_machine_id_patterns_have_inline_fixes(self):
+        """All machine_id patterns should have inline fixes."""
+        mid_patterns = [p for p in BOOT_ERROR_PATTERNS
+                        if p.category == 'machine_id']
+        for pattern in mid_patterns:
+            assert len(pattern.fixes) > 0, (
+                f"Pattern '{pattern.name}' has no inline fixes"
+            )
+
     def test_survives_boot_success_flags(self):
         """ssh/filesystem/disk_full failures are not resolved by a completed
         boot (a full disk stays full after 'Startup finished'), so their YAML
@@ -427,24 +510,27 @@ class TestShippedPatterns:
         assert 'ssh' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'filesystem' in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'disk_full' in SURVIVES_BOOT_SUCCESS_CATEGORIES
-        for cat in ('fstab', 'kernel', 'initramfs', 'grub', 'firmware'):
+        for cat in ('fstab', 'kernel', 'initramfs', 'grub', 'firmware',
+                    'lvm', 'crypt', 'raid', 'machine_id'):
             assert cat not in SURVIVES_BOOT_SUCCESS_CATEGORIES
 
     def test_detect_only_flags(self):
-        """cpu_lockup and kernel are detect-only (manual investigation, never
-        a rescue/restore fix); detect_only does NOT imply
-        survives_boot_success, and rescue-workflow categories must not
-        declare it."""
+        """cpu_lockup/kernel/crypt are detect-only (manual investigation or,
+        for crypt, an encrypted disk that rescue mode cannot unlock);
+        detect_only does NOT imply survives_boot_success, and
+        rescue-workflow categories must not declare it."""
         from gce_rescue_v2.core.diagnosis import (
             DETECT_ONLY_CATEGORIES,
             SURVIVES_BOOT_SUCCESS_CATEGORIES,
         )
         assert 'cpu_lockup' in DETECT_ONLY_CATEGORIES
         assert 'kernel' in DETECT_ONLY_CATEGORIES
+        assert 'crypt' in DETECT_ONLY_CATEGORIES
         assert 'cpu_lockup' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         assert 'kernel' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
+        assert 'crypt' not in SURVIVES_BOOT_SUCCESS_CATEGORIES
         for cat in ('fstab', 'initramfs', 'disk_full', 'ssh', 'filesystem',
-                    'grub', 'firmware'):
+                    'grub', 'firmware', 'lvm', 'raid', 'machine_id'):
             assert cat not in DETECT_ONLY_CATEGORIES
 
     def test_detect_only_sets_agree(self):

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -880,6 +880,14 @@ class TestSupportedCategories:
     def test_grub_is_not_supported(self):
         assert 'grub' not in SUPPORTED_FIX_CATEGORIES
 
+    def test_kernel_is_not_supported(self):
+        """kernel is detect-only — no auto-repair fix script exists."""
+        assert 'kernel' not in SUPPORTED_FIX_CATEGORIES
+
+    def test_initramfs_is_not_supported(self):
+        """initramfs stays unsupported until fixes/initramfs_fix.sh lands."""
+        assert 'initramfs' not in SUPPORTED_FIX_CATEGORIES
+
     def test_fix_script_exists_for_each_supported_category(self):
         """Every supported category should have a corresponding fix script."""
         fixes_dir = (

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -679,6 +679,15 @@ class TestWave2CategoryLabels:
         assert (_category_label('systemd_early')
                 == 'Fix early systemd boot failure')
 
+    def test_wave45_category_labels_defined(self):
+        from gce_rescue_v2.utils.report_formatter import _category_label
+        assert _category_label('readonly') == 'Recover read-only filesystem'
+        assert _category_label('oom') == 'Investigate out-of-memory kills'
+        assert _category_label('selinux') == 'Fix SELinux policy/relabel'
+        assert _category_label('startup_script') == 'Fix startup script'
+        assert _category_label('cloud_init') == 'Fix cloud-init configuration'
+        assert _category_label('network') == 'Fix network configuration'
+
     def test_crypt_rendered_as_detect_only_guidance(self, formatter):
         """crypt is detect-only: no rescue/restore workflow is offered."""
         diagnosis = {

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -660,3 +660,53 @@ class TestDetectOnlyFixSection:
         assert 'Check kernel:' in report
         assert ('- Reset the VM and select a previous kernel from the GRUB '
                 'menu via the serial console') in report
+
+
+class TestWave2CategoryLabels:
+    """Labels for the Wave 2 categories (lvm, crypt, raid, machine_id)."""
+
+    def test_new_category_labels_defined(self):
+        from gce_rescue_v2.utils.report_formatter import _category_label
+        assert _category_label('lvm') == 'Activate LVM volume group'
+        assert _category_label('crypt') == 'Handle encrypted (LUKS) disk'
+        assert _category_label('raid') == 'Repair RAID array'
+        assert _category_label('machine_id') == 'Regenerate machine-id'
+
+    def test_crypt_rendered_as_detect_only_guidance(self, formatter):
+        """crypt is detect-only: no rescue/restore workflow is offered."""
+        diagnosis = {
+            'vm_name': 'luks-vm',
+            'zone': 'us-central1-a',
+            'status': 'RUNNING',
+            'os_type': 'linux',
+            'os_flavor': 'rhel-9',
+            'architecture': 'x86_64',
+            'license_type': 'payg',
+            'diagnosis_status': 'boot_errors_detected',
+            'boot_errors': [
+                {
+                    'name': 'crypt_passphrase_prompt',
+                    'category': 'crypt',
+                    'severity': 'critical',
+                    'description': 'Boot is waiting for a LUKS passphrase '
+                                   'on the console',
+                    'detected_pattern': 'Please enter passphrase for disk '
+                                        'luks-2f4c8e11 on /:',
+                    'suggested_fixes': [
+                        'Connect to the interactive serial console and type '
+                        'the passphrase: gcloud compute '
+                        'connect-to-serial-port VM_NAME --zone=ZONE',
+                    ],
+                    'context_lines': [
+                        'Please enter passphrase for disk luks-2f4c8e11 on /:'
+                    ],
+                    'matched_line_index': 0,
+                }
+            ],
+            'recommendations': [],
+        }
+        report = formatter.format_report(diagnosis)
+        assert 'Handle encrypted (LUKS) disk:' in report
+        assert 'Enter rescue mode' not in report
+        assert 'gce-rescue rescue' not in report
+        assert 'connect-to-serial-port luks-vm --zone=us-central1-a' in report

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -618,3 +618,45 @@ class TestDetectOnlyFixSection:
         assert '$ Identify' not in report
         # cpu_lockup guidance must not appear inside step 2's command list
         assert '- Identify the offending process/workload' in report
+
+    def test_kernel_panic_only_report_has_no_fake_command(self, formatter):
+        """Integration red-team C3: kernel is detect-only — a panic-only
+        report must not render the prose fix_guidance behind a '$ ' prompt
+        or wrap it in a rescue/restore cycle that does not apply."""
+        diagnosis = {
+            'vm_name': 'vm-1',
+            'zone': 'asia-south1-b',
+            'status': 'TERMINATED',
+            'os_type': 'linux',
+            'os_flavor': 'debian-12',
+            'architecture': 'x86_64',
+            'license_type': 'free',
+            'diagnosis_status': 'boot_errors_detected',
+            'boot_errors': [
+                {
+                    'category': 'kernel',
+                    'severity': 'critical',
+                    'description': 'Kernel panic detected during boot',
+                    'detected_pattern': 'Kernel panic - not syncing: '
+                                        'Attempted to kill init!',
+                    'suggested_fixes': [
+                        'Reset the VM: gcloud compute instances reset '
+                        'VM_NAME --zone=ZONE',
+                    ],
+                    'context_lines': [
+                        'Kernel panic - not syncing: Attempted to kill init!'
+                    ],
+                    'matched_line_index': 0,
+                }
+            ],
+            'recommendations': [],
+        }
+        report = formatter.format_report(diagnosis)
+        assert '$ Reset the VM' not in report
+        assert 'Enter rescue mode' not in report
+        assert 'gce-rescue rescue' not in report
+        assert 'gce-rescue restore' not in report
+        # Guidance rendered as prose bullets under the category label
+        assert 'Check kernel:' in report
+        assert ('- Reset the VM and select a previous kernel from the GRUB '
+                'menu via the serial console') in report

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -672,6 +672,13 @@ class TestWave2CategoryLabels:
         assert _category_label('raid') == 'Repair RAID array'
         assert _category_label('machine_id') == 'Regenerate machine-id'
 
+    def test_wave3_category_labels_defined(self):
+        from gce_rescue_v2.utils.report_formatter import _category_label
+        assert (_category_label('switchroot')
+                == 'Restore working init (switch_root)')
+        assert (_category_label('systemd_early')
+                == 'Fix early systemd boot failure')
+
     def test_crypt_rendered_as_detect_only_guidance(self, formatter):
         """crypt is detect-only: no rescue/restore workflow is offered."""
         diagnosis = {

--- a/gce_rescue_v2/tests/test_report_formatter.py
+++ b/gce_rescue_v2/tests/test_report_formatter.py
@@ -532,3 +532,89 @@ class TestAutoRepairSuggestion:
         """Auto-repair suggestion should include the zone."""
         report = formatter.format_report(single_error_diagnosis)
         assert '--zone=us-central1-a' in report
+
+
+class TestDetectOnlyFixSection:
+    """Red-team C4: detect-only categories (cpu_lockup) must not be rendered
+    as shell commands inside a rescue/restore workflow."""
+
+    @pytest.fixture
+    def cpu_lockup_diagnosis(self):
+        return {
+            'vm_name': 'prod-db-1',
+            'zone': 'us-central1-a',
+            'status': 'RUNNING',
+            'os_type': 'linux',
+            'os_flavor': 'ubuntu-24.04',
+            'architecture': 'x86_64',
+            'license_type': 'free',
+            'diagnosis_status': 'boot_errors_detected',
+            'boot_errors': [
+                {
+                    'category': 'cpu_lockup',
+                    'severity': 'warning',
+                    'description': 'Bus lock or split lock detected (performance-degrading memory access)',
+                    'detected_pattern': 'took a bus_lock trap',
+                    'suggested_fixes': [
+                        'Identify the application named in the message and fix its misaligned atomic memory access',
+                        'If the VM is unresponsive, reset it: gcloud compute instances reset VM_NAME --zone=ZONE',
+                    ],
+                    'context_lines': ['x86/split lock detection: #DB: myapp/2211 took a bus_lock trap at address: 0x7f3c'],
+                    'matched_line_index': 0,
+                }
+            ],
+            'recommendations': [],
+        }
+
+    def test_no_rescue_restore_steps_for_detect_only(
+        self, formatter, cpu_lockup_diagnosis
+    ):
+        """cpu_lockup-only reports must not tell the user to enter rescue
+        mode — there is nothing to fix on the rescued disk."""
+        report = formatter.format_report(cpu_lockup_diagnosis)
+        assert 'gce-rescue rescue' not in report
+        assert 'gce-rescue restore' not in report
+        assert 'Enter rescue mode' not in report
+
+    def test_prose_guidance_not_rendered_as_command(
+        self, formatter, cpu_lockup_diagnosis
+    ):
+        """Prose fix_guidance must not be printed with a '$ ' prompt."""
+        report = formatter.format_report(cpu_lockup_diagnosis)
+        assert '$ Identify' not in report
+        assert 'Identify the offending process/workload' in report
+        assert 'Investigate CPU lockup' in report
+
+    def test_placeholders_substituted_in_detect_only_fixes(
+        self, formatter, cpu_lockup_diagnosis
+    ):
+        """VM_NAME/ZONE in per-issue fixes should be substituted."""
+        report = formatter.format_report(cpu_lockup_diagnosis)
+        assert 'gcloud compute instances reset prod-db-1 --zone=us-central1-a' in report
+        assert 'VM_NAME' not in report
+
+    def test_mixed_categories_keep_rescue_steps_for_disk_issues(
+        self, formatter, cpu_lockup_diagnosis
+    ):
+        """When a disk category (fstab) co-occurs with cpu_lockup, the
+        rescue steps stay for fstab but cpu_lockup guidance is rendered in
+        its own prose block."""
+        diagnosis = dict(cpu_lockup_diagnosis)
+        diagnosis['boot_errors'] = diagnosis['boot_errors'] + [
+            {
+                'category': 'fstab',
+                'severity': 'critical',
+                'description': 'UUID specified in /etc/fstab cannot be found',
+                'detected_pattern': 'UUID=abc123 does not exist',
+                'suggested_fixes': ['Comment out or fix the invalid UUID entry'],
+                'context_lines': ['UUID=abc123 does not exist'],
+                'matched_line_index': 0,
+            }
+        ]
+        report = formatter.format_report(diagnosis)
+        assert 'gce-rescue rescue prod-db-1' in report
+        assert 'gce-rescue restore prod-db-1' in report
+        assert 'Investigate CPU lockup' in report
+        assert '$ Identify' not in report
+        # cpu_lockup guidance must not appear inside step 2's command list
+        assert '- Identify the offending process/workload' in report

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -435,6 +435,7 @@ def _category_label(category: str) -> str:
     labels = {
         'fstab': 'Fix /etc/fstab',
         'grub': 'Repair GRUB',
+        'firmware': 'Repair boot device',
         'kernel': 'Check kernel',
         'filesystem': 'Fix filesystem',
         'initramfs': 'Rebuild initramfs',

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -273,7 +273,11 @@ class DiagnosisReportFormatter:
             )
 
         lines.append("")
-        lines.append(dim("Note: Currently checks fstab errors only. "
+        # Derive the checked categories from the loaded rules so this note
+        # can never go stale when new diagnose_rules/*.yaml files land.
+        from ..core.diagnosis import BOOT_ERROR_PATTERNS
+        categories = sorted({p.category for p in BOOT_ERROR_PATTERNS})
+        lines.append(dim(f"Note: Currently checks: {', '.join(categories)}. "
                          "If the VM still won't boot, check the serial console:"))
         gcloud_cmd = f"  $ gcloud compute instances get-serial-port-output {vm_name} --zone={zone}"
         if project:

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -370,5 +370,6 @@ def _category_label(category: str) -> str:
         'kernel': 'Check kernel',
         'filesystem': 'Fix filesystem',
         'initramfs': 'Rebuild initramfs',
+        'ssh': 'Fix SSH configuration',
     }
     return labels.get(category, f'Fix {category}')

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -446,5 +446,7 @@ def _category_label(category: str) -> str:
         'crypt': 'Handle encrypted (LUKS) disk',
         'raid': 'Repair RAID array',
         'machine_id': 'Regenerate machine-id',
+        'switchroot': 'Restore working init (switch_root)',
+        'systemd_early': 'Fix early systemd boot failure',
     }
     return labels.get(category, f'Fix {category}')

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -195,8 +195,35 @@ class DiagnosisReportFormatter:
                 seen.add(cat)
                 categories.append(cat)
 
+        # Detect-only categories (e.g. cpu_lockup) are runtime conditions:
+        # there is nothing to edit on the rescued disk, so rescue/restore
+        # steps do not apply to them.
+        from ..core.fix_catalog import (
+            SUPPORTED_FIX_CATEGORIES,
+            DETECT_ONLY_CATEGORIES,
+        )
+        disk_categories = [
+            c for c in categories if c not in DETECT_ONLY_CATEGORIES
+        ]
+        detect_only = [c for c in categories if c in DETECT_ONLY_CATEGORIES]
+        disk_errors = [
+            e for e in errors if e['category'] not in DETECT_ONLY_CATEGORIES
+        ]
+        detect_only_errors = [
+            e for e in errors if e['category'] in DETECT_ONLY_CATEGORIES
+        ]
+
+        # All findings are detect-only: print guidance without the
+        # rescue/restore workflow (rescue mode would not help here).
+        if not disk_categories:
+            lines.extend(self._format_detect_only_steps(
+                detect_only, detect_only_errors, vm_name, zone))
+            return "\n".join(lines)
+
+        categories = disk_categories
+        errors = disk_errors
+
         # Check if auto-repair is available AND can identify targets
-        from ..core.fix_catalog import SUPPORTED_FIX_CATEGORIES
         auto_fixable = [c for c in categories if c in SUPPORTED_FIX_CATEGORIES]
 
         # Auto-repair needs extractable identifiers to target specific entries.
@@ -252,7 +279,44 @@ class DiagnosisReportFormatter:
         lines.append("    3. Restore the VM:")
         lines.append(f"       $ gce-rescue restore {vm_name} --zone={zone}")
 
+        # Detect-only findings get their own guidance block, outside the
+        # rescue/restore steps.
+        if detect_only:
+            lines.append("")
+            lines.extend(self._format_detect_only_steps(
+                detect_only, detect_only_errors, vm_name, zone))
+
         return "\n".join(lines)
+
+    def _format_detect_only_steps(
+        self, categories: List[str], errors: List[Dict[str, Any]],
+        vm_name: str, zone: str
+    ) -> List[str]:
+        """Format guidance for detect-only categories (no rescue workflow).
+
+        Detect-only findings (e.g. CPU lockups) are runtime conditions, so
+        the guidance is rendered as plain steps, never as shell commands
+        inside a rescue/restore cycle.
+        """
+        lines: List[str] = []
+        for cat in categories:
+            lines.append(f"  {_category_label(cat)}:")
+            seen = set()
+            guidance = CATEGORY_FIX_GUIDANCE.get(cat)
+            if guidance:
+                guidance = guidance.replace(
+                    'VM_NAME', vm_name).replace('ZONE', zone)
+                seen.add(guidance)
+                lines.append(f"    - {guidance}")
+            for err in errors:
+                if err['category'] != cat:
+                    continue
+                for fix in err.get('suggested_fixes', []):
+                    fix = fix.replace('VM_NAME', vm_name).replace('ZONE', zone)
+                    if fix not in seen:
+                        seen.add(fix)
+                        lines.append(f"    - {fix}")
+        return lines
 
     def _format_healthy(self, diagnosis: Dict[str, Any]) -> str:
         """Format a healthy VM report."""

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -370,5 +370,6 @@ def _category_label(category: str) -> str:
         'kernel': 'Check kernel',
         'filesystem': 'Fix filesystem',
         'initramfs': 'Rebuild initramfs',
+        'cpu_lockup': 'Investigate CPU lockup',
     }
     return labels.get(category, f'Fix {category}')

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -370,5 +370,6 @@ def _category_label(category: str) -> str:
         'kernel': 'Check kernel',
         'filesystem': 'Fix filesystem',
         'initramfs': 'Rebuild initramfs',
+        'disk_full': 'Free disk space',
     }
     return labels.get(category, f'Fix {category}')

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -442,5 +442,9 @@ def _category_label(category: str) -> str:
         'disk_full': 'Free disk space',
         'ssh': 'Fix SSH configuration',
         'cpu_lockup': 'Investigate CPU lockup',
+        'lvm': 'Activate LVM volume group',
+        'crypt': 'Handle encrypted (LUKS) disk',
+        'raid': 'Repair RAID array',
+        'machine_id': 'Regenerate machine-id',
     }
     return labels.get(category, f'Fix {category}')

--- a/gce_rescue_v2/utils/report_formatter.py
+++ b/gce_rescue_v2/utils/report_formatter.py
@@ -448,5 +448,11 @@ def _category_label(category: str) -> str:
         'machine_id': 'Regenerate machine-id',
         'switchroot': 'Restore working init (switch_root)',
         'systemd_early': 'Fix early systemd boot failure',
+        'readonly': 'Recover read-only filesystem',
+        'oom': 'Investigate out-of-memory kills',
+        'selinux': 'Fix SELinux policy/relabel',
+        'startup_script': 'Fix startup script',
+        'cloud_init': 'Fix cloud-init configuration',
+        'network': 'Fix network configuration',
     }
     return labels.get(category, f'Fix {category}')


### PR DESCRIPTION
## Summary

Expands `diagnose` from fstab-only to **21 categories / 81 patterns** covering the Linux boot chain end to end. Detection only — **every new category ships `auto_repair: false`**, so `repair` behavior is completely unchanged (fstab-only). Diff: 29 files, +7,495 (mostly YAML pattern rules and their tests).

New categories by boot stage:

| Boot stage | Categories |
|---|---|
| Firmware / bootloader | `firmware`, `grub` |
| Kernel / initrd | `kernel` (panics), `initramfs` (dracut + BusyBox dialects), `switchroot` |
| Early userspace | `systemd_early`, `readonly` |
| Storage | `filesystem` (ext4/XFS/btrfs), `lvm`, `raid`, `crypt`, `disk_full` |
| Runtime | `oom`, `cpu_lockup` |
| Configuration / late boot | `selinux`, `machine_id`, `ssh`, `network`, `startup_script`, `cloud_init` |

Engine changes supporting the wider net:
- Per-category YAML flags: `detect_only` (runtime conditions rescue mode cannot fix — the CLI explains instead of offering repair) and `survives_boot_success` (findings a later successful boot does not clear, e.g. corrupt secondary disk)
- Tier-1 dedupe requires critical severity, so root-cause findings outrank generic symptoms when multiple patterns match one buffer
- Evidence extraction anchored on the regex match offset for accurate serial-context windows

## Test plan
- [x] 954 unit tests pass (`python -m pytest gce_rescue_v2/tests/ -v`)
- [x] Every category live-validated on real GCE VMs (Debian 12, Ubuntu 24.04, Rocky 9): each pattern group was reproduced with a real broken boot and each addition was red-teamed against false positives before landing (see per-commit `fix: harden ... against red-team findings` history)
- [x] Healthy-VM false-positive sweep: factory Debian 12 / Ubuntu 24.04 / Rocky 9 all diagnose clean, including known noise traps (RHEL grubenv-on-XFS lines, source-prefixed GRUB errors, cloud-init/netplan chatter)
- [x] Detect-only contract verified live: `disk_full` detected on a running VM; `repair` reports no automated fix available and never mutates the VM