### PR TITLE
feat: multi-category repair engine with hardened verification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must keep LF endings on every platform: they execute on
+# Linux rescue VMs, and fix scripts are embedded verbatim into startup
+# scripts (CRLF breaks bash keyword parsing).
+*.sh text eol=lf

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -310,7 +310,10 @@ EXAMPLES
         $ gce-rescue repair my-vm --zone=us-central1-a --quiet
 
 SUPPORTED FIXES
+    - filesystem: Repairs corrupted filesystems (fsck) before mounting
     - fstab: Comments out invalid UUID, device, or label entries
+    - initramfs: Rebuilds the initramfs for the newest installed kernel
+    - grub: Reinstalls GRUB and regenerates its configuration
 
 NOTES
     This command is Linux-only. For Windows VMs, use 'rescue' for manual fix.

--- a/gce_rescue_v2/cli/repair.py
+++ b/gce_rescue_v2/cli/repair.py
@@ -7,7 +7,7 @@ import uuid
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, TextIO
 from ..core.config import build_user_agent
 from ..utils.colors import error_prefix, warning_prefix, clear_lines, green, bold
 from ..utils.logger import setup_logging
@@ -17,6 +17,15 @@ from .preflight import (
     get_gcloud_config, _create_tracked_client, check_local_ssd_quiet_gate,
 )
 from .checkpoint_ui import _handle_checkpoint_rollback
+
+# Human-readable labels for fix categories, shared by the repair plan
+# display and the per-category result lines.
+FIX_LABELS = {
+    'fstab': 'Fix fstab',
+    'filesystem': 'Fix filesystem',
+    'initramfs': 'Rebuild initramfs',
+    'grub': 'Fix GRUB',
+}
 
 
 def _show_boot_verification(boot_verified: Optional[bool],
@@ -34,6 +43,25 @@ def _show_boot_verification(boot_verified: Optional[bool],
         print("Consider using rescue mode for manual investigation:")
         print(f"  $ gce-rescue rescue {vm_name} --zone={zone}")
     # If None, skip silently (couldn't verify)
+
+
+def _show_no_change_outcomes(result: Dict[str, Any],
+                             file: Optional[TextIO] = None) -> None:
+    """Print a [NO_CHANGE] line for each category whose fix found nothing.
+
+    Without these, a category whose fix script ran and reported NO_ISSUES
+    would simply vanish from the results. Categories with success/failed
+    outcomes keep their existing presentation (fix lines / error text), so
+    only 'no_issues' outcomes are rendered here. The key is absent when the
+    orchestrator could not attribute markers to categories.
+    """
+    for outcome in result.get('category_outcomes', []):
+        if outcome.get('kind') != 'no_issues':
+            continue
+        category = outcome.get('category', '')
+        label = FIX_LABELS.get(category, f'Fix {category}')
+        print(f"  [NO_CHANGE] {label}: no issues found - nothing to fix",
+              file=file or sys.stdout)
 
 
 def _show_repair_results(result: Dict[str, Any], vm_name: str,
@@ -57,6 +85,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         for line in fix_lines:
             colored_line = line.replace('[FIXED]', green('[FIXED]'), 1)
             print(f"  {colored_line}")
+        _show_no_change_outcomes(result)
         issue_word = "issue" if fixed_count == 1 else "issues"
         print(f"  {fixed_count} {issue_word} fixed.")
         if any('fstab' in line.lower() for line in fix_lines):
@@ -74,7 +103,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
     elif status == 'no_issues':
         print("")
         print("Repair results:")
-        print("  No issues needed fixing (fstab entries were already valid).")
+        print("  No issues needed fixing (boot configuration was already valid).")
         if snapshot_name:
             print(f"  Backup snapshot: {snapshot_name}")
         print("")
@@ -99,6 +128,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
             if any('fstab' in line.lower() for line in fix_lines):
                 print(f"  Original fstab backed up to: /etc/fstab.gce-repair-backup",
                       file=sys.stderr)
+        _show_no_change_outcomes(result, file=sys.stderr)
         print("", file=sys.stderr)
         print(f"Instance [{vm_name}] has been restored and is running.", file=sys.stderr)
         if snapshot_name:
@@ -122,6 +152,39 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         if project:
             ssh_cmd += f" --project={project}"
         print(ssh_cmd, file=sys.stderr)
+        restore_cmd = f"  $ gce-rescue restore {vm_name}"
+        if zone:
+            restore_cmd += f" --zone={zone}"
+        if project:
+            restore_cmd += f" --project={project}"
+        print(restore_cmd, file=sys.stderr)
+        return 1
+
+    elif status == 'fix_in_progress':
+        # resume() refused to restore: the previous session's fix scripts
+        # could not be confirmed complete, and restoring stops the VM -
+        # which would interrupt a still-running fsck/rebuild mid-write.
+        print("", file=sys.stderr)
+        print(f"{error_prefix()} {error}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("The VM was left in rescue mode; nothing was restored.",
+              file=sys.stderr)
+        print("Check the serial console for fix progress:", file=sys.stderr)
+        serial_cmd = f"  $ gcloud compute instances get-serial-port-output {vm_name}"
+        if zone:
+            serial_cmd += f" --zone={zone}"
+        if project:
+            serial_cmd += f" --project={project}"
+        print(serial_cmd, file=sys.stderr)
+        print("Re-run repair once the fix has finished:", file=sys.stderr)
+        repair_cmd = f"  $ gce-rescue repair {vm_name}"
+        if zone:
+            repair_cmd += f" --zone={zone}"
+        if project:
+            repair_cmd += f" --project={project}"
+        print(repair_cmd, file=sys.stderr)
+        print("To restore anyway (may interrupt a running fix):",
+              file=sys.stderr)
         restore_cmd = f"  $ gce-rescue restore {vm_name}"
         if zone:
             restore_cmd += f" --zone={zone}"
@@ -158,7 +221,7 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
 
     elif status == 'unknown':
         # All phases completed but repair markers not found in serial output.
-        # The fix likely applied but we couldn't parse confirmation.
+        # The fix may have applied but there is no confirmation.
         print("")
         print(f"{warning_prefix()} Repair completed but could not confirm fix results"
               f" from serial console.")
@@ -170,6 +233,17 @@ def _show_repair_results(result: Dict[str, Any], vm_name: str,
         if snapshot_name:
             print(f"Backup snapshot: {snapshot_name}")
         _show_boot_verification(boot_verified, boot_errors_after, vm_name, zone)
+        # Unconfirmed fix + post-restore boot STILL failing = the repair did
+        # not work; automation must see a non-zero exit (a VM was observed
+        # restored still kernel-panicking with exit 0 here). boot_verified
+        # None (inconclusive, e.g. serial disabled) keeps exit 0 with the
+        # warning above.
+        if boot_verified is False:
+            print(
+                f"\n{error_prefix()} Boot verification still detects errors - "
+                f"the repair likely did not apply.", file=sys.stderr
+            )
+            return 1
         return 0
 
     else:
@@ -617,6 +691,12 @@ def handle_repair(args: argparse.Namespace) -> int:
         block.append(f"    {step}. Enter rescue mode (stop VM, swap boot disk)")
         step += 1
         # Build fix descriptions with extracted identifiers
+        fix_descriptions = {
+            'filesystem': 'Repair filesystem errors (fsck before mount)',
+            'fstab': 'Fix /etc/fstab (comment out invalid entries)',
+            'initramfs': 'Rebuild the initramfs for the installed kernel',
+            'grub': 'Reinstall GRUB and regenerate its configuration',
+        }
         if fstab_targets:
             from ..utils.report_formatter import _extract_identifier
             identifiers = []
@@ -628,17 +708,9 @@ def handle_repair(args: argparse.Namespace) -> int:
                     identifiers.append(ident)
             if identifiers:
                 target_str = ', '.join(bold(i) for i in identifiers)
-                fix_descriptions = {
-                    'fstab': f'Fix /etc/fstab (comment out {target_str})',
-                }
-            else:
-                fix_descriptions = {
-                    'fstab': 'Fix /etc/fstab (comment out invalid entries)',
-                }
-        else:
-            fix_descriptions = {
-                'fstab': 'Fix /etc/fstab (comment out invalid entries)',
-            }
+                fix_descriptions['fstab'] = (
+                    f'Fix /etc/fstab (comment out {target_str})'
+                )
         for cat in fixable:
             desc = fix_descriptions.get(cat, f'Fix {cat}')
             block.append(f"    {step}. {desc}")
@@ -682,9 +754,8 @@ def handle_repair(args: argparse.Namespace) -> int:
     if snapshot_enabled:
         plan_parts.append("Snapshot")
     plan_parts.append("Rescue")
-    fix_labels = {'fstab': 'Fix fstab'}
     for cat in fixable:
-        plan_parts.append(fix_labels.get(cat, f'Fix {cat}'))
+        plan_parts.append(FIX_LABELS.get(cat, f'Fix {cat}'))
     plan_parts.append("Restore")
     print(f"  Plan:   {' -> '.join(plan_parts)}")
     print("")

--- a/gce_rescue_v2/operations/verify_startup.py
+++ b/gce_rescue_v2/operations/verify_startup.py
@@ -8,6 +8,18 @@ startup script executed successfully.
 import time
 from .base import BaseOperation, OperationResult, extract_error_message
 
+# Failure lines the base mount script prints right before exiting 1. Once one
+# of these is on the serial console the completion marker can never arrive,
+# so verification aborts immediately instead of polling out the full timeout
+# (observed live: 36 minutes spent waiting on a mount that had already
+# failed). The serial buffer is wiped on VM stop and every rescue starts with
+# a stop, so these lines can only come from the CURRENT rescue boot.
+STARTUP_FAILURE_MARKERS = (
+    'ERROR: All mount attempts failed',
+    'ERROR: Disk not found after 5 minutes',
+    'ERROR: No supported filesystem found!',
+)
+
 
 class VerifyStartupOperation(BaseOperation):
     """
@@ -24,7 +36,8 @@ class VerifyStartupOperation(BaseOperation):
         return "Verify Startup Script"
 
     def execute(self, vm_name: str, completion_marker: str = "GCE-RESCUE-COMPLETE",
-                timeout: int = 120, tracking_label: str = None) -> OperationResult:
+                timeout: int = 120, tracking_label: str = None,
+                expected_completion_value: str = 'COMPLETE') -> OperationResult:
         """
         Verify startup script completion by polling serial console.
 
@@ -33,6 +46,12 @@ class VerifyStartupOperation(BaseOperation):
             completion_marker: String to search for in serial output
             timeout: Maximum seconds to wait (default: 120)
             tracking_label: Optional tracking label for analytics
+            expected_completion_value: Exact guest-attribute value that counts
+                as completion. Guest attributes persist across stop/start/
+                restore and cannot be cleared from outside the VM, so the
+                orchestrator passes a per-session token here - a stale value
+                from a PREVIOUS rescue of the same VM must not short-circuit
+                this session's verification.
 
         Returns:
             OperationResult with success=True if marker found, False if timeout
@@ -89,7 +108,8 @@ class VerifyStartupOperation(BaseOperation):
                 # startup script. Checked before serial because the serial
                 # console can drop the script's final output burst before the
                 # process exits (the marker may never reach serial).
-                if self._completion_guest_attribute_set(compute, vm_name):
+                if self._completion_guest_attribute_set(
+                        compute, vm_name, expected_completion_value):
                     duration = time.time() - start_time
                     self._log_debug(
                         f"Completion guest attribute set in {duration:.1f}s"
@@ -125,6 +145,23 @@ class VerifyStartupOperation(BaseOperation):
                             rollback_data=None  # No rollback needed for verification
                         )
 
+                    # A terminal failure line means the marker can never
+                    # arrive - abort now instead of polling out the timeout.
+                    for failure_marker in STARTUP_FAILURE_MARKERS:
+                        if failure_marker in contents:
+                            self._log_debug(
+                                f"Startup script failed: {failure_marker!r}"
+                            )
+                            return OperationResult(
+                                operation_name=self.name,
+                                success=False,
+                                message=f"Startup script failed: {failure_marker}",
+                                error=(
+                                    f"Startup script reported a terminal "
+                                    f"failure: {failure_marker}"
+                                )
+                            )
+
                     # Log progress
                     self._log_debug(f"  Waiting for startup script... ({elapsed:.0f}s/{timeout}s)")
 
@@ -157,23 +194,28 @@ class VerifyStartupOperation(BaseOperation):
                 error=error_msg
             )
 
-    def _completion_guest_attribute_set(self, compute, vm_name: str) -> bool:
-        """Check whether the guest set gce-rescue/status=COMPLETE.
+    def _completion_guest_attribute_set(self, compute, vm_name: str,
+                                        expected_value: str = 'COMPLETE') -> bool:
+        """Check whether the guest set gce-rescue/status to THIS session's value.
 
         Reliable, deterministic completion signal (unlike serial scraping).
-        Returns False on any error (attribute not set yet, guest attributes
-        disabled, 404) so the caller keeps polling / falls back to serial.
+        The value comparison is exact (case-insensitive): guest attributes
+        survive stop/start/restore, so a stale value from a previous rescue
+        session must not count. Returns False on any error (attribute not set
+        yet, guest attributes disabled, 404) so the caller keeps polling /
+        falls back to serial.
         """
+        expected = expected_value.strip().upper()
         try:
             resp = compute.instances().getGuestAttributes(
                 project=self.project, zone=self.zone, instance=vm_name,
                 queryPath='gce-rescue/status'
             ).execute()
             # Querying a specific key returns variableValue; a path returns items.
-            if str(resp.get('variableValue', '')).strip().upper() == 'COMPLETE':
+            if str(resp.get('variableValue', '')).strip().upper() == expected:
                 return True
             for item in resp.get('queryValue', {}).get('items', []):
-                if str(item.get('value', '')).strip().upper() == 'COMPLETE':
+                if str(item.get('value', '')).strip().upper() == expected:
                     return True
         except Exception:
             return False

--- a/gce_rescue_v2/orchestration/compose.py
+++ b/gce_rescue_v2/orchestration/compose.py
@@ -9,10 +9,80 @@ Shared by the repair orchestrator (diagnosis-driven fixes) and the rescue
 orchestrator (custom fix scripts via --fix-script).
 """
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # Completion marker emitted by the base mount script to the serial console
 RESCUE_COMPLETE_MARKER = 'GCE-RESCUE-COMPLETE'
+
+# Delimiters for an optional pre-mount block inside a fix script. Code between
+# these exact marker lines is lifted out of the fix script and injected into
+# the base mount script BEFORE the mount attempt (see PREMOUNT_ANCHOR), so a
+# fix can repair the filesystem itself (e.g. fsck a corrupt superblock) before
+# the base script tries to mount it — a failed mount would otherwise abort the
+# startup script and no fix would ever run.
+PREMOUNT_BEGIN_MARKER = '# === GCE-REPAIR-PREMOUNT-BEGIN ==='
+PREMOUNT_END_MARKER = '# === GCE-REPAIR-PREMOUNT-END ==='
+
+# Injection point in the base mount script (rescue_mount.sh): the first line
+# of the filesystem-detection/mount section. At this point the disk-wait loop
+# has finished, so /dev/disk/by-id/google-${disk} exists and $disk is set, but
+# nothing has been mounted yet.
+PREMOUNT_ANCHOR = 'log "Detecting filesystem type..."'
+
+
+def extract_premount_blocks(fix_script: str) -> Tuple[List[str], str]:
+    """Split a fix script into its pre-mount blocks and post-mount remainder.
+
+    Pre-mount blocks are delimited by PREMOUNT_BEGIN_MARKER and
+    PREMOUNT_END_MARKER lines (matched ignoring surrounding whitespace); the
+    marker lines themselves are not included in either part. A script may
+    contain zero or more blocks.
+
+    Args:
+        fix_script: Fix script body (shebang already stripped).
+
+    Returns:
+        Tuple of (pre-mount blocks in order of appearance, remainder script
+        with the blocks and marker lines removed).
+
+    Raises:
+        ValueError: If a begin marker has no matching end marker (or vice
+            versa) — running half a pre-mount block would be unsafe.
+    """
+    blocks: List[str] = []
+    remainder_lines: List[str] = []
+    current_block: Optional[List[str]] = None
+
+    for line in fix_script.split('\n'):
+        stripped = line.strip()
+        if stripped == PREMOUNT_BEGIN_MARKER:
+            if current_block is not None:
+                raise ValueError(
+                    'Malformed fix script: nested '
+                    f'{PREMOUNT_BEGIN_MARKER} marker (previous block '
+                    'was never closed)'
+                )
+            current_block = []
+        elif stripped == PREMOUNT_END_MARKER:
+            if current_block is None:
+                raise ValueError(
+                    f'Malformed fix script: {PREMOUNT_END_MARKER} '
+                    'without a preceding begin marker'
+                )
+            blocks.append('\n'.join(current_block))
+            current_block = None
+        elif current_block is not None:
+            current_block.append(line)
+        else:
+            remainder_lines.append(line)
+
+    if current_block is not None:
+        raise ValueError(
+            f'Malformed fix script: {PREMOUNT_BEGIN_MARKER} '
+            'without a closing end marker'
+        )
+
+    return blocks, '\n'.join(remainder_lines)
 
 
 def strip_shebang(script: str) -> str:
@@ -31,6 +101,14 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
     so the orchestrator's verification (and any restore that follows) only
     proceeds after ALL fix scripts have finished — never mid-fix.
 
+    Fix scripts may carry an optional pre-mount block (see
+    extract_premount_blocks). Those blocks are lifted out and injected into
+    the base script right before the PREMOUNT_ANCHOR line — i.e. after the
+    disk-wait loop but before any mount attempt — so filesystem-level repairs
+    (fsck) can run even when the disk would fail to mount. The remainder of
+    each fix script is appended at the end as usual. Scripts without a
+    pre-mount block are composed exactly as before.
+
     Args:
         base_script: The mount script, with disk placeholder already resolved.
         fix_scripts: Fix script bodies to append (shebangs already stripped).
@@ -41,7 +119,20 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
 
     Returns:
         The combined startup script.
+
+    Raises:
+        ValueError: If a fix script has a malformed pre-mount block, or if a
+            pre-mount block is present but the base script lacks the
+            PREMOUNT_ANCHOR line (the block would silently never run).
     """
+    # Lift pre-mount blocks out of the fix scripts (order preserved)
+    premount_blocks: List[str] = []
+    fix_bodies: List[str] = []
+    for fix_script in fix_scripts:
+        blocks, remainder = extract_premount_blocks(fix_script)
+        premount_blocks.extend(blocks)
+        fix_bodies.append(remainder)
+
     # Move the completion signal (serial marker + guest attribute) to the very
     # end so verification only proceeds after all fixes finish. The base script
     # calls signal_complete; relocate that call (the echo lives inside the
@@ -53,10 +144,52 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
         '# completion signal moved to end (repair mode)\n',
         1,
     )
+    # The base script's trailing success log must move with the signal:
+    # left in place it prints BEFORE the fixes run, and the on-disk repair
+    # log then claims completion ahead of the actual fix output.
+    combined = combined.replace(
+        'log "=== Startup script completed successfully ==="\n',
+        '# completion log moved to end (repair mode)\n',
+        1,
+    )
+
+    # Inject pre-mount blocks before the base script's mount section
+    if premount_blocks:
+        if PREMOUNT_ANCHOR not in combined:
+            raise ValueError(
+                'Cannot inject pre-mount fix blocks: anchor line '
+                f'{PREMOUNT_ANCHOR!r} not found in the base mount script. '
+                'The base script and the pre-mount hook are out of sync.'
+            )
+        injection = '# === GCE Repair Pre-Mount Fixes ===\n'
+        injection += 'log "=== Running pre-mount repair fixes ==="\n'
+        for block in premount_blocks:
+            injection += block + '\n'
+        injection += 'log "=== Pre-mount repair fixes completed ==="\n\n'
+        combined = combined.replace(
+            PREMOUNT_ANCHOR, injection + PREMOUNT_ANCHOR, 1
+        )
 
     combined += '\n'
     combined += '\n# === GCE Repair Fix Scripts ===\n'
     combined += 'log "=== Starting repair fixes ==="\n\n'
+
+    # Preserve the previous session's on-disk repair log: this session's fix
+    # scripts overwrite gce-repair.log, which would erase the audit trail of
+    # earlier repairs on this disk. Runs once per session, before any fix
+    # body; harmless when sysroot is unmounted or no earlier log exists.
+    combined += (
+        "# Preserve the previous session's on-disk repair log: this session's fix\n"
+        '# scripts overwrite gce-repair.log, which would erase the audit trail of\n'
+        '# earlier repairs on this disk.\n'
+        'if mountpoint -q /mnt/sysroot 2>/dev/null'
+        ' && [ -f /mnt/sysroot/var/log/gce-repair.log ]; then\n'
+        '    { echo ""; echo "=== earlier gce-repair session'
+        " (archived $(date '+%Y-%m-%d %H:%M:%S')) ===\"; \\\n"
+        '        cat /mnt/sysroot/var/log/gce-repair.log; } \\\n'
+        '        >> /mnt/sysroot/var/log/gce-repair-history.log 2>/dev/null || true\n'
+        'fi\n\n'
+    )
 
     # Inject REPAIR_TARGETS variable for targeted fstab fixing (diagnosis mode)
     if repair_targets is not None:
@@ -68,8 +201,8 @@ def compose_startup_script(base_script: str, fix_scripts: List[str],
             combined += '# No specific repair targets extracted from diagnosis\n'
             combined += 'REPAIR_TARGETS=""\n\n'
 
-    for fix_script in fix_scripts:
-        combined += fix_script + '\n\n'
+    for fix_body in fix_bodies:
+        combined += fix_body + '\n\n'
 
     combined += 'log "=== Repair fixes completed ==="\n'
     combined += 'signal_complete\n'

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -4,8 +4,12 @@ GCE Rescue - Repair Orchestrator
 Automates the full repair flow: diagnose -> rescue (with embedded fix) -> restore.
 Fix scripts are embedded directly in the startup script - no SSH, no external tools.
 
-Supported fix categories:
+Supported fix categories (filesystem/initramfs/grub scripts land with this
+change):
     - fstab: Comments out invalid UUID/device/label entries
+    - filesystem: Repairs the filesystem (fsck) before the mount attempt
+    - initramfs: Rebuilds the initramfs inside the target chroot
+    - grub: Reinstalls/regenerates the GRUB configuration
 
 Usage:
     orchestrator = RepairOrchestrator(compute, project, zone, vm_name, config, logger)
@@ -43,6 +47,54 @@ from .restore import RestoreOrchestrator
 # Marker prefixes emitted by fix scripts to serial console
 REPAIR_LINE_MARKER = 'GCE-REPAIR-LINE:'
 REPAIR_RESULT_MARKER = 'GCE-REPAIR-RESULT:'
+
+# Fix scripts must run in dependency order, regardless of the order categories
+# appear in the diagnosis:
+#   1. filesystem — fsck first, so later fixes edit files on a clean
+#      (mountable) filesystem; its pre-mount block must also run before the
+#      base script's mount attempt.
+#   2. fstab — mount-config edits on the now-clean filesystem.
+#   3. initramfs — rebuild the initrd after config changes.
+#   4. grub — last, because GRUB config regeneration must see the rebuilt
+#      initrd to reference the correct images.
+# Categories not listed here keep their diagnosis order, after the known ones.
+FIX_EXECUTION_ORDER = ['filesystem', 'fstab', 'initramfs', 'grub']
+
+# Minimum verification timeouts (seconds) per fix category. The OS default
+# (300s Linux) only covers the disk mount; a forced fsck, a tool install, or
+# an initramfs rebuild inside the startup script routinely runs longer, and a
+# verification timeout mid-fix misreports the repair as mount_failed while
+# the fix is still writing to the disk. An explicit --verification-timeout
+# always wins over these floors.
+REPAIR_VERIFICATION_FLOOR = {
+    'filesystem': 1800,  # e2fsck -f / xfs_repair scale with disk size
+    'initramfs': 900,    # rebuild + possible tool install
+    'grub': 900,         # grub-install + config regeneration in chroot
+}
+
+# Line the base mount script logs at startup-script start. Serial output can
+# span several boots of the same VM within one rescue session; only markers
+# after the LAST occurrence of this banner belong to the current repair run
+# (earlier ones would double-count a previous attempt's fixes).
+BOOT_BANNER = '=== GCE Rescue Auto-Mount Started ==='
+
+# Per-session completion token the rescue orchestrator substitutes into the
+# startup script (SESSION_ID_PLACEHOLDER). After an interrupted repair the
+# token is still embedded in the VM's startup-script metadata, so resume()
+# can recover it and check the guest attribute the fix session would have
+# set on completion.
+_SESSION_TOKEN_RE = re.compile(r'COMPLETE-[0-9a-f]{12}')
+
+# Device-name heuristics for filesystem findings: on the ORIGINAL (booting)
+# VM the boot disk is the first device (sda / nvme0n1); LVM roots surface as
+# dm-* / mapper names. Anything clearly second-disk (sdb+, nvme1+, vdb+) is
+# not repairable by rescuing the boot disk.
+_BOOT_DEVICE_RE = re.compile(
+    r'\b(sda\d*|nvme0n1(?:p\d+)?|dm-\d+|mapper/[\w-]+)\b', re.IGNORECASE
+)
+_NONBOOT_DEVICE_RE = re.compile(
+    r'\b(sd[b-z]\d*|nvme[1-9]\d*n\d+(?:p\d+)?|vd[b-z]\d*)\b', re.IGNORECASE
+)
 
 # Maps raw rescue/restore step labels to user-friendly display names
 RESCUE_SUBSTEP_LABELS = {
@@ -179,6 +231,17 @@ class RepairOrchestrator:
             )
             return False
 
+        # Validate a custom fix script's pre-mount markers BEFORE any VM
+        # mutation (composition otherwise fails at rescue step 6, after the
+        # VM was stopped and disks swapped).
+        if self.config.fix_script:
+            from .compose import extract_premount_blocks
+            try:
+                extract_premount_blocks(strip_shebang(self.config.fix_script))
+            except ValueError as e:
+                self._log_error(f"Invalid --fix-script: {e}")
+                return False
+
         # Verify fix scripts exist for all supported categories
         fixes_dir = Path(__file__).parent.parent / 'startup_scripts' / 'fixes'
         for cat in SUPPORTED_FIX_CATEGORIES:
@@ -209,8 +272,38 @@ class RepairOrchestrator:
 
         return result.rollback_data
 
+    def _filesystem_errors_on_boot_disk(self, diagnosis: Dict[str, Any]) -> bool:
+        """Whether the filesystem findings could concern the boot disk.
+
+        filesystem patterns survive boot success, so a healthy-booting VM
+        with a corrupt SECONDARY disk still diagnoses 'filesystem' - but a
+        rescue cycle only ever fscks the boot disk, so repairing it would
+        stop the VM for nothing and report NO_ISSUES. Returns False only
+        when EVERY filesystem finding names a clearly non-boot device
+        (sdb+/nvme1+/vdb+); ambiguous findings keep the category fixable.
+        """
+        saw_any = False
+        for err in diagnosis.get('boot_errors', []):
+            if err.get('category') != 'filesystem':
+                continue
+            saw_any = True
+            text = ' '.join(
+                str(err.get(key, ''))
+                for key in ('detected_pattern', 'description', 'evidence')
+            )
+            if _BOOT_DEVICE_RE.search(text) or not _NONBOOT_DEVICE_RE.search(text):
+                return True
+        return not saw_any
+
     def get_fixable_categories(self, diagnosis: Dict[str, Any]) -> List[str]:
-        """Return list of categories from diagnosis that have fix scripts."""
+        """Return list of categories from diagnosis that have fix scripts.
+
+        The list is sorted into FIX_EXECUTION_ORDER (filesystem, fstab,
+        initramfs, grub) so fix scripts always compose in dependency order;
+        unknown categories keep their diagnosis order after the known ones.
+        filesystem is excluded when its findings only name non-boot devices
+        (see _filesystem_errors_on_boot_disk).
+        """
         categories = []
         seen = set()
         for err in diagnosis.get('boot_errors', []):
@@ -218,10 +311,28 @@ class RepairOrchestrator:
             if cat in SUPPORTED_FIX_CATEGORIES and cat not in seen:
                 seen.add(cat)
                 categories.append(cat)
+        if ('filesystem' in categories
+                and not self._filesystem_errors_on_boot_disk(diagnosis)):
+            categories.remove('filesystem')
+            self._log_debug(
+                "filesystem findings reference only non-boot devices; "
+                "excluded from rescue-based repair"
+            )
+        # Stable sort: known categories in execution order, unknowns after
+        # them in their original (diagnosis) order.
+        categories.sort(
+            key=lambda c: FIX_EXECUTION_ORDER.index(c)
+            if c in FIX_EXECUTION_ORDER else len(FIX_EXECUTION_ORDER)
+        )
         return categories
 
     def get_unfixable_categories(self, diagnosis: Dict[str, Any]) -> List[str]:
-        """Return list of categories from diagnosis that lack fix scripts."""
+        """Return list of categories from diagnosis that lack fix scripts.
+
+        Includes filesystem when its findings only name non-boot devices:
+        the category has a fix script, but rescuing the boot disk cannot
+        repair a secondary disk, so the user gets manual guidance instead.
+        """
         categories = []
         seen = set()
         for err in diagnosis.get('boot_errors', []):
@@ -229,6 +340,11 @@ class RepairOrchestrator:
             if cat not in SUPPORTED_FIX_CATEGORIES and cat not in seen:
                 seen.add(cat)
                 categories.append(cat)
+        if ('filesystem' not in categories
+                and any(e.get('category') == 'filesystem'
+                        for e in diagnosis.get('boot_errors', []))
+                and not self._filesystem_errors_on_boot_disk(diagnosis)):
+            categories.append('filesystem')
         return categories
 
     def execute(self, diagnosis: Dict[str, Any]) -> Dict[str, Any]:
@@ -246,11 +362,25 @@ class RepairOrchestrator:
             return {'status': 'no_fix', 'fixed_count': 0, 'fix_lines': [],
                     'error': None, 'snapshot_name': None, 'duration_seconds': 0}
 
+        # Destructive-fix guard: filesystem repair runs fsck/xfs_repair on
+        # the user's original disk - the pre-rescue snapshot is the ONLY
+        # rollback for whatever fsck rewrites, so it is non-negotiable here.
+        if 'filesystem' in fixable and not self.config.create_snapshot:
+            self._log_error(
+                "Filesystem repair runs a destructive fsck on the original "
+                "disk and requires the pre-rescue snapshot as its rollback. "
+                "Re-run without --no-snapshot."
+            )
+            return {'status': 'error', 'fixed_count': 0, 'fix_lines': [],
+                    'error': 'filesystem repair requires a snapshot '
+                             '(--no-snapshot was given)',
+                    'snapshot_name': None, 'duration_seconds': 0}
+
         # Generate repair startup script
         repair_script = self._generate_repair_script(diagnosis)
         self._log_debug(f"Generated repair script ({len(repair_script)} bytes)")
 
-        return self._run_repair_flow(repair_script)
+        return self._run_repair_flow(repair_script, fixable_categories=fixable)
 
     def execute_custom(self) -> Dict[str, Any]:
         """Execute repair with the custom fix script from config (--fix-script).
@@ -270,11 +400,15 @@ class RepairOrchestrator:
         return self._run_repair_flow(fix_script=self.config.fix_script)
 
     def _run_repair_flow(self, repair_script: Optional[str] = None,
-                         fix_script: Optional[str] = None) -> Dict[str, Any]:
+                         fix_script: Optional[str] = None,
+                         fixable_categories: Optional[List[str]] = None
+                         ) -> Dict[str, Any]:
         """Run the repair flow with the given fix payload.
 
         Shared by diagnosis-driven repair (execute), which passes a fully
-        composed startup script as repair_script, and custom fix scripts
+        composed startup script as repair_script plus its fixable_categories
+        (used to scale the verification timeout and to make the snapshot
+        mandatory for destructive categories), and custom fix scripts
         (execute_custom), which pass fix_script for per-OS composition inside
         the rescue orchestrator. Flow: rescue with the fix embedded -> parse
         repair results from serial console -> restore -> post-restore boot
@@ -301,6 +435,27 @@ class RepairOrchestrator:
             rescue_config.verification_timeout_override = (
                 self.config.verification_timeout_override
             )
+
+            categories = fixable_categories or []
+            # fsck rewrites the original disk in place; if the snapshot step
+            # fails there is no rollback, so its failure must abort the
+            # rescue instead of being logged and skipped.
+            if 'filesystem' in categories:
+                rescue_config.require_snapshot = True
+            # Raise the verification budget for long-running fix categories
+            # (fsck, initramfs rebuild) unless the user set an explicit
+            # timeout - see REPAIR_VERIFICATION_FLOOR.
+            if rescue_config.verification_timeout_override is None and categories:
+                floor = max(
+                    (REPAIR_VERIFICATION_FLOOR.get(c, 0) for c in categories),
+                    default=0,
+                )
+                if floor > rescue_config.effective_verification_timeout('linux'):
+                    rescue_config.verification_timeout_override = floor
+                    self._log_debug(
+                        f"Verification timeout raised to {floor}s for "
+                        f"long-running fix categories {categories}"
+                    )
 
             rescue = RescueOrchestrator(
                 compute=self.compute, project=self.project, zone=self.zone,
@@ -340,11 +495,49 @@ class RepairOrchestrator:
                 self._current_substep = 'Verifying fix'
             self._log_debug(f"Repair results: {repair_results}")
 
+            # Zip per-marker outcomes back onto the requested categories.
+            # Scripts compose in exactly the get_fixable_categories() order
+            # and each emits ONE result marker, so serial marker order ==
+            # category order. A length mismatch means serial dropped a
+            # marker - attribution would be a guess, so the key is omitted
+            # entirely (correctness over completeness). Custom --fix-script
+            # flows have no categories and never get the key.
+            if fixable_categories:
+                marker_results = repair_results.get('marker_results', [])
+                if len(marker_results) == len(fixable_categories):
+                    repair_results['category_outcomes'] = [
+                        {'category': category, 'kind': marker['kind'],
+                         'count': marker['count'], 'reason': marker['reason']}
+                        for category, marker
+                        in zip(fixable_categories, marker_results)
+                    ]
+                else:
+                    self._log_debug(
+                        f"Marker/category count mismatch "
+                        f"({len(marker_results)} markers for "
+                        f"{len(fixable_categories)} categories); omitting "
+                        f"per-category outcomes"
+                    )
+
             # If mount failed (no completion marker found by verify), don't restore
             if not rescue.verification_succeeded:
                 self._finish_progress(False)
                 self._log_error(
                     "Startup script did not complete. The disk may not have mounted."
+                )
+                # Fix scripts emit LINE/RESULT markers before the completion
+                # marker, so anything already parsed explains WHY the mount
+                # failed (e.g. an unrepairable filesystem).
+                if repair_results.get('error'):
+                    self._log_error(
+                        f"Reported by the fix script: {repair_results['error']}"
+                    )
+                for fix_line in repair_results.get('fix_lines', []):
+                    self._log_error(f"  {fix_line}")
+                self._log_error(
+                    "A long-running fix (fsck, initramfs rebuild) may still "
+                    "be executing - check the serial console before "
+                    "restoring, or the restore can interrupt it mid-write."
                 )
                 self._log_error(
                     "VM is in rescue mode for manual investigation."
@@ -469,11 +662,91 @@ class RepairOrchestrator:
             self._log_debug(f"Could not find rescue snapshot: {e}")
             return None
 
+    def _rescue_fixes_completed(self) -> bool:
+        """Whether the interrupted session's fix scripts COMPLETED.
+
+        resume() restores immediately, and restore stops the VM - if a fix
+        is still running (fsck mid-repair, initramfs mid-rebuild) that stop
+        interrupts it mid-write on the very disk being repaired. Completion
+        is confirmed by ANY of:
+          1. Session token: the rescue startup script (still in the VM's
+             metadata after an interruption) embeds a per-session
+             COMPLETE-<12hex> token; the script sets the gce-rescue/status
+             guest attribute to that exact token as its final step. A match
+             is the deterministic signal rescue verification itself uses.
+          2. Serial fallback: the current boot's serial output contains the
+             completion marker (covers older sessions and guest attributes
+             being unavailable).
+        Returns False when neither confirms - the caller must NOT restore.
+        """
+        try:
+            compute = self._create_tracked_client(self._ua('resume-check'))
+        except Exception as e:
+            self._log_debug(f"Could not create tracked client: {e}")
+            compute = self.compute
+
+        # Signal 1: session token from metadata matches the guest attribute
+        token = None
+        try:
+            vm_info = compute.instances().get(
+                project=self.project, zone=self.zone, instance=self.vm_name
+            ).execute()
+            for item in vm_info.get('metadata', {}).get('items', []):
+                if item.get('key') in ('startup-script',
+                                       'windows-startup-script-ps1'):
+                    match = _SESSION_TOKEN_RE.search(item.get('value') or '')
+                    if match:
+                        token = match.group(0)
+                        break
+        except Exception as e:
+            self._log_debug(f"Could not read startup-script metadata: {e}")
+
+        if token:
+            try:
+                resp = compute.instances().getGuestAttributes(
+                    project=self.project, zone=self.zone,
+                    instance=self.vm_name, queryPath='gce-rescue/status'
+                ).execute()
+                values = [str(resp.get('variableValue', ''))]
+                values += [
+                    str(item.get('value', ''))
+                    for item in resp.get('queryValue', {}).get('items', [])
+                ]
+                if any(v.strip().upper() == token.upper() for v in values):
+                    self._log_debug(
+                        "Fix completion confirmed via session guest attribute"
+                    )
+                    return True
+            except Exception as e:
+                self._log_debug(
+                    f"Could not read completion guest attribute: {e}"
+                )
+
+        # Signal 2 (fallback): completion marker on the current boot's serial
+        try:
+            serial_response = compute.instances().getSerialPortOutput(
+                project=self.project, zone=self.zone, instance=self.vm_name
+            ).execute()
+            windowed = self._window_to_last_boot(
+                serial_response.get('contents', '')
+            )
+            if RESCUE_COMPLETE_MARKER in windowed:
+                self._log_debug("Fix completion confirmed via serial marker")
+                return True
+        except Exception as e:
+            self._log_debug(f"Could not check serial for completion: {e}")
+
+        return False
+
     def resume(self) -> Dict[str, Any]:
         """Resume an interrupted repair: parse results from serial console + restore.
 
         Called when the VM is already in rescue mode from a previous repair attempt.
         Skips the rescue phase entirely.
+
+        Refuses to restore ('fix_in_progress') when the previous session's
+        fix scripts cannot be confirmed complete - restoring stops the VM,
+        which would interrupt a still-running fsck/rebuild mid-write.
 
         Returns:
             Dict with keys: status, fixed_count, fix_lines, error,
@@ -483,6 +756,45 @@ class RepairOrchestrator:
 
         # Look up snapshot from the original rescue phase
         snapshot_name = self._find_rescue_snapshot()
+
+        # Safety guard: only restore once the fix session is confirmed done.
+        if not self._rescue_fixes_completed():
+            self._log_error(
+                "Cannot confirm that the previous repair's fix scripts have "
+                "finished - the fix may still be running."
+            )
+            self._log_error(
+                "Restoring now would stop the VM and could interrupt a "
+                "long-running fix (fsck, initramfs rebuild) mid-write."
+            )
+            self._log_error("")
+            self._log_error("Check the serial console for progress:")
+            self._log_error(
+                f"  $ gcloud compute instances get-serial-port-output "
+                f"{self.vm_name} --zone={self.zone} --project={self.project}"
+            )
+            self._log_error("")
+            self._log_error("Re-run repair once the fix has finished:")
+            self._log_error(
+                f"  $ gce-rescue repair {self.vm_name} "
+                f"--zone={self.zone} --project={self.project}"
+            )
+            self._log_error("")
+            self._log_error(
+                "To restore anyway (deliberate manual override):"
+            )
+            self._log_error(
+                f"  $ gce-rescue restore {self.vm_name} "
+                f"--zone={self.zone} --project={self.project}"
+            )
+            return {
+                'status': 'fix_in_progress', 'fixed_count': 0,
+                'fix_lines': [],
+                'error': 'Fix completion could not be confirmed; '
+                         'the fix may still be running',
+                'snapshot_name': snapshot_name,
+                'duration_seconds': 0
+            }
 
         self._init_progress()
         start_time = time.time()
@@ -636,7 +948,7 @@ class RepairOrchestrator:
         script_dir = Path(__file__).parent.parent / 'startup_scripts'
         base_script_path = script_dir / 'rescue_mount.sh'
 
-        with open(base_script_path, 'r') as f:
+        with open(base_script_path, 'r', encoding='utf-8') as f:
             base_script = f.read()
 
         # Get original disk name for placeholder replacement
@@ -702,7 +1014,7 @@ class RepairOrchestrator:
                 f"Cannot proceed with repair — the fix would not be applied."
             )
 
-        with open(script_path, 'r') as f:
+        with open(script_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
         if not content.strip():
@@ -723,8 +1035,26 @@ class RepairOrchestrator:
         Looks for GCE-REPAIR-LINE: and GCE-REPAIR-RESULT: markers.
         Checks both default port and port 2 as fallback.
 
+        Each fix script emits exactly one GCE-REPAIR-RESULT marker, so a
+        multi-category repair produces several. They are aggregated into the
+        single status contract the CLI consumes (cli/repair.py):
+          - fixed_count is the SUM of all SUCCESS counts.
+          - 'failed' if ANY script reported FAILED; error joins all failure
+            reasons with '; '. Partial success is represented within this
+            status: fixed_count and fix_lines still carry the fixes that DID
+            apply, which the CLI's 'failed' branch already prints.
+          - else 'success' if any script reported SUCCESS.
+          - else 'no_issues' if any script reported NO_ISSUES.
+          - else 'unknown' (no markers found).
+
+        Alongside the aggregate, marker_results preserves the PER-SCRIPT
+        outcomes in serial order (one entry per GCE-REPAIR-RESULT marker):
+        {'kind': 'success'|'no_issues'|'failed', 'count': int,
+        'reason': Optional[str]}. Fix scripts compose in category order, so
+        the caller can zip this back onto the categories it requested.
+
         Returns:
-            Dict with: status, fixed_count, fix_lines, error
+            Dict with: status, fixed_count, fix_lines, error, marker_results
         """
         serial_output = ''
         try:
@@ -734,7 +1064,9 @@ class RepairOrchestrator:
                 project=self.project, zone=self.zone,
                 instance=self.vm_name
             ).execute()
-            serial_output = serial_response.get('contents', '')
+            serial_output = self._window_to_last_boot(
+                serial_response.get('contents', '')
+            )
 
             # If no repair markers found, try port 2 as fallback
             if REPAIR_RESULT_MARKER not in serial_output:
@@ -743,48 +1075,80 @@ class RepairOrchestrator:
                     project=self.project, zone=self.zone,
                     instance=self.vm_name, port=2
                 ).execute()
-                port2_output = serial_response.get('contents', '')
+                port2_output = self._window_to_last_boot(
+                    serial_response.get('contents', '')
+                )
                 if REPAIR_RESULT_MARKER in port2_output:
                     serial_output = port2_output
         except Exception as e:
             self._log_debug(f"Could not fetch serial console: {e}")
             return {
                 'status': 'unknown', 'fixed_count': 0,
-                'fix_lines': [], 'error': f'Could not read serial console: {e}'
+                'fix_lines': [], 'error': f'Could not read serial console: {e}',
+                'marker_results': []
             }
 
-        # Strip control characters that may interfere with marker detection
-        serial_output = serial_output.replace('\r', '')
-
-        # Extract repair lines
+        # Single pass: collect fix lines and aggregate result markers. The
+        # per-segment counter tracks [FIXED] lines since the previous result
+        # marker, so a SUCCESS marker with an unparseable count falls back to
+        # the count of ITS OWN script's fixes (not every script's lines).
         fix_lines = []
+        saw_success = False
+        saw_no_issues = False
+        fixed_count = 0
+        segment_fixed_lines = 0
+        failures: List[str] = []
+        marker_results: List[Dict[str, Any]] = []
+
         for line in serial_output.split('\n'):
             if REPAIR_LINE_MARKER in line:
                 idx = line.index(REPAIR_LINE_MARKER)
-                fix_lines.append(line[idx + len(REPAIR_LINE_MARKER):].strip())
-
-        # Extract repair result
-        status = 'unknown'
-        fixed_count = 0
-        error = None
-
-        for line in serial_output.split('\n'):
-            if REPAIR_RESULT_MARKER in line:
+                content = line[idx + len(REPAIR_LINE_MARKER):].strip()
+                fix_lines.append(content)
+                if content.startswith('[FIXED]'):
+                    segment_fixed_lines += 1
+            elif REPAIR_RESULT_MARKER in line:
                 idx = line.index(REPAIR_RESULT_MARKER)
                 result_str = line[idx + len(REPAIR_RESULT_MARKER):].strip()
 
                 if result_str.startswith('SUCCESS:'):
-                    status = 'success'
+                    saw_success = True
                     try:
-                        fixed_count = int(result_str.split(':')[1])
+                        count = int(result_str.split(':')[1])
                     except (ValueError, IndexError):
-                        fixed_count = len(fix_lines)
+                        count = segment_fixed_lines
+                    fixed_count += count
+                    marker_results.append(
+                        {'kind': 'success', 'count': count, 'reason': None}
+                    )
                 elif result_str.startswith('NO_ISSUES:'):
-                    status = 'no_issues'
-                    fixed_count = 0
+                    saw_no_issues = True
+                    marker_results.append(
+                        {'kind': 'no_issues', 'count': 0, 'reason': None}
+                    )
                 elif result_str.startswith('FAILED:'):
-                    status = 'failed'
-                    error = result_str.split(':', 1)[1] if ':' in result_str else 'Unknown'
+                    reason = result_str.split(':', 1)[1] if ':' in result_str else 'Unknown'
+                    failures.append(reason)
+                    marker_results.append(
+                        {'kind': 'failed', 'count': 0, 'reason': reason}
+                    )
+                segment_fixed_lines = 0
+
+        error = None
+        if failures:
+            # Any failure makes the whole repair 'failed'; fixed_count and
+            # fix_lines still reflect the fixes that DID apply (partial
+            # success), which the CLI's failed branch prints.
+            status = 'failed'
+            error = '; '.join(failures)
+        elif saw_success:
+            status = 'success'
+        elif saw_no_issues:
+            status = 'no_issues'
+            fixed_count = 0
+        else:
+            status = 'unknown'
+            fixed_count = 0
 
         if status == 'unknown':
             self._log_debug(
@@ -794,8 +1158,25 @@ class RepairOrchestrator:
 
         return {
             'status': status, 'fixed_count': fixed_count,
-            'fix_lines': fix_lines, 'error': error
+            'fix_lines': fix_lines, 'error': error,
+            'marker_results': marker_results
         }
+
+    @staticmethod
+    def _window_to_last_boot(serial_output: str) -> str:
+        """Slice serial output to the current boot's startup-script run.
+
+        Serial output accumulates across VM restarts within a session, so
+        markers from a PREVIOUS repair attempt would be aggregated (and
+        double-counted) into this one. Only content after the last mount
+        banner belongs to the current run; output without the banner is
+        returned whole (pre-banner failures, custom scripts).
+        """
+        serial_output = serial_output.replace('\r', '')
+        idx = serial_output.rfind(BOOT_BANNER)
+        if idx != -1:
+            return serial_output[idx:]
+        return serial_output
 
     def _verify_boot_after_repair(self) -> Dict[str, Any]:
         """Check if the VM boots successfully after repair.

--- a/gce_rescue_v2/orchestration/repair.py
+++ b/gce_rescue_v2/orchestration/repair.py
@@ -522,9 +522,21 @@ class RepairOrchestrator:
             # If mount failed (no completion marker found by verify), don't restore
             if not rescue.verification_succeeded:
                 self._finish_progress(False)
-                self._log_error(
-                    "Startup script did not complete. The disk may not have mounted."
-                )
+                # Be explicit when verification actually timed out (vs. an
+                # unknown state), including how long we waited — mirrors the
+                # rescue command's messaging (#133). Category floors can raise
+                # the timeout, so the number tells the user what was tried.
+                vr = getattr(rescue, 'verification_result', None)
+                if vr and vr.details and vr.details.get('timed_out'):
+                    secs = vr.details.get('timeout_seconds')
+                    self._log_error(
+                        f"Startup verification timed out after {secs}s. "
+                        "The disk may not have mounted."
+                    )
+                else:
+                    self._log_error(
+                        "Startup script did not complete. The disk may not have mounted."
+                    )
                 # Fix scripts emit LINE/RESULT markers before the completion
                 # marker, so anything already parsed explains WHY the mount
                 # failed (e.g. an unrepairable filesystem).

--- a/gce_rescue_v2/orchestration/rescue.py
+++ b/gce_rescue_v2/orchestration/rescue.py
@@ -10,6 +10,7 @@ Coordinates the rescue workflow:
 """
 
 import time
+import uuid
 from ..core.config import RescueConfig, OS_TYPE_WINDOWS, OS_TYPE_LINUX, build_user_agent
 from .compose import (
     compose_startup_script, compose_startup_script_windows, strip_shebang,
@@ -103,6 +104,13 @@ class RescueOrchestrator:
         self.logger = logger
         self.log_file = log_file
         self._startup_script_override = startup_script_override
+        # Per-session completion token for the guest-attribute signal. Guest
+        # attributes persist across stop/start/restore and cannot be cleared
+        # from outside the VM, so a bare COMPLETE left by a PREVIOUS rescue
+        # of this VM would make verification succeed instantly - before this
+        # session's startup script (and any embedded fixes) ran. The startup
+        # script writes this token; verification only accepts this token.
+        self._completion_token = f"COMPLETE-{uuid.uuid4().hex[:12]}"
         self._suppress_progress = suppress_progress
         self._progress_callback = progress_callback
         self.session_id = session_id
@@ -500,6 +508,18 @@ class RescueOrchestrator:
 
         self._log_debug("Creating validation runner")
 
+        # Validate a custom fix script's pre-mount markers BEFORE any VM
+        # mutation: composition happens at step 6 (VM already stopped, disks
+        # swapped), and a malformed block failing there strands the VM in a
+        # half-rescued state for a purely textual error.
+        if self.config.fix_script:
+            from .compose import extract_premount_blocks
+            try:
+                extract_premount_blocks(strip_shebang(self.config.fix_script))
+            except ValueError as e:
+                self._log_error(f"Invalid --fix-script: {e}")
+                return False
+
         runner = ValidationRunner()
 
         # Add validators with tracking labels
@@ -792,6 +812,13 @@ class RescueOrchestrator:
             if not self._should_skip_step(6):
                 self._log_debug("Setting rescue metadata...")
                 startup_script = self._generate_startup_script()
+                # Session-scope the guest-attribute completion signal. Done
+                # here (not in _generate_startup_script) so it also covers
+                # startup_script_override payloads composed by the repair
+                # orchestrator, which pass the placeholder through.
+                startup_script = startup_script.replace(
+                    'SESSION_ID_PLACEHOLDER', self._completion_token
+                )
 
                 if self.os_type == OS_TYPE_WINDOWS:
                     script_key = 'windows-startup-script-ps1'
@@ -946,10 +973,15 @@ class RescueOrchestrator:
                 self._update_progress("Attaching affected disk")
                 self._log_debug("Verifying startup script...")
                 verify_startup = VerifyStartupOperation(self.compute, self.project, self.zone, self.logger)
+                # expected_completion_value: only THIS session's token counts
+                # (stale guest attributes from previous rescues must not).
+                # If a resumed session re-runs step 9 with a fresh token, the
+                # serial-marker fallback still verifies completion.
                 result = verify_startup.execute(
                     vm_name=self.vm_name,
                     timeout=self.config.effective_verification_timeout(self.os_type),
-                    tracking_label=self._ua('vm-verify-startup')
+                    tracking_label=self._ua('vm-verify-startup'),
+                    expected_completion_value=self._completion_token
                 )
                 self.verification_succeeded = result.success
                 self.verification_result = result
@@ -1041,7 +1073,7 @@ class RescueOrchestrator:
             fallback_script = self._get_linux_fallback_script()
 
         if script_file.exists():
-            with open(script_file, 'r') as f:
+            with open(script_file, 'r', encoding='utf-8') as f:
                 script = f.read()
                 # Replace disk name placeholder
                 script = script.replace('DISK_NAME_PLACEHOLDER', self.original_disk_name)

--- a/gce_rescue_v2/startup_scripts/rescue_mount.sh
+++ b/gce_rescue_v2/startup_scripts/rescue_mount.sh
@@ -17,10 +17,14 @@ log() {
 
 # Signal rescue completion. Emits the serial marker (best-effort; serial can
 # drop the final output burst) AND sets a guest attribute the orchestrator
-# polls as the reliable, deterministic completion signal.
+# polls as the reliable, deterministic completion signal. The attribute value
+# is a per-session token (substituted by the orchestrator): guest attributes
+# persist across stop/start/restore and are never deletable from outside the
+# VM, so a bare COMPLETE from a PREVIOUS rescue of the same VM would make the
+# next session's verification succeed instantly - before its fixes ran.
 signal_complete() {
     echo "GCE-RESCUE-COMPLETE" >&2
-    curl -s -m 10 -X PUT --data "COMPLETE" -H "Metadata-Flavor: Google" \
+    curl -s -m 10 -X PUT --data "SESSION_ID_PLACEHOLDER" -H "Metadata-Flavor: Google" \
         "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/gce-rescue/status" \
         >/dev/null 2>&1 || true
 }

--- a/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
+++ b/gce_rescue_v2/startup_scripts/rescue_mount_windows.ps1
@@ -182,11 +182,14 @@ Write-Log "GCE-RESCUE-COMPLETE"
 # Reliable completion signal: set a guest attribute the orchestrator polls.
 # The serial console can drop the script's final output burst before the
 # process exits, so the marker above is best-effort; this is deterministic.
+# The value is a per-session token (substituted by the orchestrator): guest
+# attributes persist across stop/start/restore, so a stale COMPLETE from a
+# previous rescue would short-circuit the next session's verification.
 try {
     Invoke-RestMethod -Method PUT -Headers @{'Metadata-Flavor' = 'Google'} `
         -Uri 'http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/gce-rescue/status' `
-        -Body 'COMPLETE' -TimeoutSec 10 -ErrorAction SilentlyContinue | Out-Null
-    Write-Log "Set guest attribute gce-rescue/status=COMPLETE"
+        -Body 'SESSION_ID_PLACEHOLDER' -TimeoutSec 10 -ErrorAction SilentlyContinue | Out-Null
+    Write-Log "Set guest attribute gce-rescue/status (session-scoped)"
 } catch {
     Write-Log "WARNING: could not set completion guest attribute: $_"
 }

--- a/gce_rescue_v2/tests/test_cli.py
+++ b/gce_rescue_v2/tests/test_cli.py
@@ -413,6 +413,89 @@ class TestShowRepairResults:
         captured = capsys.readouterr()
         assert '3 issues fixed' in captured.out
 
+    def test_show_repair_results_no_change_line_for_no_issues_category(self, capsys):
+        """A category whose fix found nothing gets a [NO_CHANGE] line."""
+        result = {
+            'status': 'success',
+            'fixed_count': 1,
+            'fix_lines': ['[FIXED] fstab: Commented out bad UUID'],
+            'error': None,
+            'snapshot_name': None,
+            'duration_seconds': 30,
+            'category_outcomes': [
+                {'category': 'filesystem', 'kind': 'no_issues', 'count': 0,
+                 'reason': None},
+                {'category': 'fstab', 'kind': 'success', 'count': 1,
+                 'reason': None},
+            ],
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert ('[NO_CHANGE] Fix filesystem: no issues found - nothing to fix'
+                in captured.out)
+        # success outcomes keep their existing presentation (no extra line)
+        assert captured.out.count('[NO_CHANGE]') == 1
+
+    def test_show_repair_results_no_change_absent_without_key(self, capsys):
+        """No category_outcomes key (mismatch/custom flow): no [NO_CHANGE]."""
+        result = {
+            'status': 'success',
+            'fixed_count': 1,
+            'fix_lines': ['[FIXED] fstab: Commented out bad UUID'],
+            'error': None,
+            'snapshot_name': None,
+            'duration_seconds': 30,
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert '[NO_CHANGE]' not in captured.out
+
+    def test_show_repair_results_no_change_in_failed_partial_results(self, capsys):
+        """Failed repairs also show [NO_CHANGE] for untouched categories."""
+        result = {
+            'status': 'failed',
+            'fixed_count': 0,
+            'fix_lines': ['[SKIPPED] grub: unsupported layout'],
+            'error': 'grub-install returned 1',
+            'snapshot_name': None,
+            'duration_seconds': 30,
+            'category_outcomes': [
+                {'category': 'fstab', 'kind': 'no_issues', 'count': 0,
+                 'reason': None},
+                {'category': 'grub', 'kind': 'failed', 'count': 0,
+                 'reason': 'grub-install returned 1'},
+            ],
+        }
+        exit_code = cli._show_repair_results(result, 'my-vm')
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert ('[NO_CHANGE] Fix fstab: no issues found - nothing to fix'
+                in captured.err)
+
+    def test_show_repair_results_fix_in_progress(self, capsys):
+        """fix_in_progress: exit 1 with serial/re-run/restore guidance."""
+        result = {
+            'status': 'fix_in_progress',
+            'fixed_count': 0,
+            'fix_lines': [],
+            'error': 'Fix completion could not be confirmed; '
+                     'the fix may still be running',
+            'snapshot_name': None,
+            'duration_seconds': 0,
+        }
+        exit_code = cli._show_repair_results(
+            result, 'my-vm', zone='zone-a', project='proj'
+        )
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert 'still be running' in captured.err
+        assert 'rescue mode' in captured.err.lower()
+        assert 'get-serial-port-output my-vm --zone=zone-a' in captured.err
+        assert 'gce-rescue repair my-vm --zone=zone-a' in captured.err
+        assert 'gce-rescue restore my-vm --zone=zone-a' in captured.err
+
 
 # ---------------------------------------------------------------------------
 # CLI Handler Tests

--- a/gce_rescue_v2/tests/test_compose.py
+++ b/gce_rescue_v2/tests/test_compose.py
@@ -1,9 +1,15 @@
 """Tests for the startup-script composer (orchestration/compose.py)."""
 
+import pytest
+
 from gce_rescue_v2.orchestration.compose import (
+    PREMOUNT_ANCHOR,
+    PREMOUNT_BEGIN_MARKER,
+    PREMOUNT_END_MARKER,
     RESCUE_COMPLETE_MARKER,
     compose_startup_script,
     compose_startup_script_windows,
+    extract_premount_blocks,
     strip_shebang,
 )
 
@@ -65,6 +71,22 @@ class TestComposeStartupScript:
         assert 'mount /dev/sdb1 /mnt/sysroot' in script
         assert script.index('mount /dev/sdb1') < script.index(fix)
 
+    def test_trailing_success_log_relocated_with_signal(self):
+        """The base script's 'completed successfully' log must not print
+        before the fixes run (it moves to the end with the signal)."""
+        base = (
+            'log "mounting disk"\n'
+            'signal_complete\n'
+            'log "=== Startup script completed successfully ==="\n'
+        )
+        fix = 'fix body'
+        script = compose_startup_script(base, [fix], repair_targets=None)
+        # The only ACTIVE success log (compose appends its own) comes after
+        # the fix body; the base's copy is neutralized into a comment.
+        active = script.rindex('log "=== Startup script completed successfully ==="')
+        assert active > script.index(fix)
+        assert script.count('log "=== Startup script completed successfully ==="') == 1
+
     def test_none_targets_omits_repair_targets(self):
         """Custom (self-contained) scripts get no REPAIR_TARGETS variable."""
         script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=None)
@@ -90,6 +112,201 @@ class TestComposeStartupScript:
         assert script.index('first fix') < script.index('second fix')
         # Completion signal still after the LAST fix
         assert script.rindex('signal_complete') > script.index('second fix')
+
+
+class TestRepairLogArchival:
+    """compose appends a one-time snippet that archives the previous session's
+    on-disk repair log before this session's fixes overwrite it."""
+
+    def test_snippet_present_exactly_once(self):
+        """One archival snippet per session, regardless of fix count."""
+        script = compose_startup_script(
+            BASE_SCRIPT, ['fix one', 'fix two'], repair_targets=[]
+        )
+        assert script.count('gce-repair-history.log') == 1
+
+    def test_snippet_after_mount_before_first_fix(self):
+        """Archival must run after the mount but before any fix can
+        overwrite /var/log/gce-repair.log on the customer disk."""
+        script = compose_startup_script(
+            BASE_SCRIPT, ['first fix body'], repair_targets=[]
+        )
+        archive_pos = script.index('gce-repair-history.log')
+        assert script.index('mount /dev/sdb1') < archive_pos
+        assert archive_pos < script.index('first fix body')
+
+    def test_snippet_guarded_against_unmounted_sysroot(self):
+        """Unmounted sysroot or missing log must be a harmless no-op."""
+        script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=[])
+        assert 'mountpoint -q /mnt/sysroot' in script
+        assert '[ -f /mnt/sysroot/var/log/gce-repair.log ]' in script
+        assert '|| true' in script
+
+    def test_snippet_absent_from_windows_composition(self):
+        """The Linux log-archival snippet must not leak into PowerShell."""
+        script = compose_startup_script_windows(BASE_SCRIPT_WINDOWS, ['fix'])
+        assert 'gce-repair-history.log' not in script
+
+
+# Stand-in for rescue_mount.sh including the pre-mount anchor line: the
+# disk-wait loop has finished ($disk set, device present) but nothing is
+# mounted yet when the anchor line runs.
+BASE_SCRIPT_WITH_ANCHOR = (
+    'log "Waiting for disk to appear..."\n'
+    'disk=my-disk\n'
+    f'{PREMOUNT_ANCHOR}\n'
+    'mount /dev/sdb1 /mnt/sysroot\n'
+    'signal_complete\n'
+    'log "startup done"\n'
+)
+
+
+def _premount_fix(premount_body: str, post_body: str) -> str:
+    """Build a fix script with a pre-mount block followed by a normal body."""
+    return (
+        f'{PREMOUNT_BEGIN_MARKER}\n'
+        f'{premount_body}\n'
+        f'{PREMOUNT_END_MARKER}\n'
+        f'{post_body}\n'
+    )
+
+
+class TestExtractPremountBlocks:
+    """extract_premount_blocks splits pre-mount blocks from the remainder."""
+
+    def test_no_block_returns_script_unchanged(self):
+        script = 'log "fixing"\nfsck_stuff\n'
+        blocks, remainder = extract_premount_blocks(script)
+        assert blocks == []
+        assert remainder == script
+
+    def test_single_block_extracted(self):
+        script = _premount_fix('fsck -y "$dev"', 'log "post-mount fix"')
+        blocks, remainder = extract_premount_blocks(script)
+        assert blocks == ['fsck -y "$dev"']
+        assert 'log "post-mount fix"' in remainder
+        # Marker lines and block body are removed from the remainder
+        assert PREMOUNT_BEGIN_MARKER not in remainder
+        assert PREMOUNT_END_MARKER not in remainder
+        assert 'fsck -y' not in remainder
+
+    def test_multiple_blocks_in_one_script(self):
+        script = (
+            _premount_fix('first block', 'middle body')
+            + _premount_fix('second block', 'tail body')
+        )
+        blocks, remainder = extract_premount_blocks(script)
+        assert blocks == ['first block', 'second block']
+        assert 'middle body' in remainder
+        assert 'tail body' in remainder
+
+    def test_indented_markers_recognized(self):
+        """Marker lines are matched ignoring surrounding whitespace."""
+        script = (
+            f'    {PREMOUNT_BEGIN_MARKER}\n'
+            'fsck_line\n'
+            f'    {PREMOUNT_END_MARKER}\n'
+            'body\n'
+        )
+        blocks, remainder = extract_premount_blocks(script)
+        assert blocks == ['fsck_line']
+        assert 'body' in remainder
+
+    def test_unterminated_block_raises(self):
+        script = f'{PREMOUNT_BEGIN_MARKER}\nfsck_line\nbody\n'
+        with pytest.raises(ValueError, match='without a closing end marker'):
+            extract_premount_blocks(script)
+
+    def test_end_without_begin_raises(self):
+        script = f'body\n{PREMOUNT_END_MARKER}\n'
+        with pytest.raises(ValueError, match='without a preceding begin'):
+            extract_premount_blocks(script)
+
+
+class TestComposePremountInjection:
+    """compose_startup_script injects pre-mount blocks before the mount."""
+
+    def test_premount_block_injected_before_mount(self):
+        """The block must run before the anchor line (and thus the mount)."""
+        fix = _premount_fix('fsck -y /dev/sdb1', 'log "editing fstab"')
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, [fix], repair_targets=[]
+        )
+        assert script.index('fsck -y /dev/sdb1') < script.index(PREMOUNT_ANCHOR)
+        assert script.index(PREMOUNT_ANCHOR) < script.index('mount /dev/sdb1')
+
+    def test_premount_block_runs_after_disk_wait(self):
+        """The block is injected after the disk-wait loop, not before it."""
+        fix = _premount_fix('fsck -y /dev/sdb1', 'post body')
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, [fix], repair_targets=[]
+        )
+        assert script.index('Waiting for disk to appear') < \
+            script.index('fsck -y /dev/sdb1')
+
+    def test_remainder_appended_at_end(self):
+        """Everything outside the block stays in the fix section at the end."""
+        fix = _premount_fix('fsck -y /dev/sdb1', 'log "editing fstab"')
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, [fix], repair_targets=[]
+        )
+        assert script.index('mount /dev/sdb1') < \
+            script.index('log "editing fstab"')
+        # Pre-mount body must not be duplicated into the fix section
+        assert script.count('fsck -y /dev/sdb1') == 1
+        # Marker lines are consumed by extraction
+        assert PREMOUNT_BEGIN_MARKER not in script
+        assert PREMOUNT_END_MARKER not in script
+
+    def test_no_block_behavior_unchanged(self):
+        """A fix script without a block composes exactly as before."""
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, ['plain fix body'], repair_targets=[]
+        )
+        assert 'Pre-Mount Fixes' not in script
+        assert script.index(PREMOUNT_ANCHOR) < script.index('plain fix body')
+
+    def test_no_block_with_anchorless_base_still_composes(self):
+        """Scripts without blocks must not require the anchor (old base)."""
+        script = compose_startup_script(BASE_SCRIPT, ['fix'], repair_targets=[])
+        assert 'fix' in script
+
+    def test_multiple_scripts_blocks_injected_in_order(self):
+        """Blocks from multiple fix scripts are injected in script order."""
+        fs_fix = _premount_fix('fsck part', 'fs post body')
+        fstab_fix = 'fstab body only'
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, [fs_fix, fstab_fix], repair_targets=[]
+        )
+        anchor_pos = script.index(PREMOUNT_ANCHOR)
+        assert script.index('fsck part') < anchor_pos
+        # Post-mount bodies keep their order in the fix section
+        assert script.index('fs post body') > anchor_pos
+        assert script.index('fs post body') < script.index('fstab body only')
+
+    def test_blocks_from_two_scripts_ordered(self):
+        first = _premount_fix('block one', 'body one')
+        second = _premount_fix('block two', 'body two')
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, [first, second], repair_targets=[]
+        )
+        assert script.index('block one') < script.index('block two')
+        assert script.index('block two') < script.index(PREMOUNT_ANCHOR)
+
+    def test_anchor_missing_raises(self):
+        """A block with no anchor in the base script must fail loudly."""
+        fix = _premount_fix('fsck -y /dev/sdb1', 'post body')
+        with pytest.raises(ValueError, match='anchor line'):
+            compose_startup_script(BASE_SCRIPT, [fix], repair_targets=[])
+
+    def test_completion_signal_still_last(self):
+        """Marker relocation is unaffected by pre-mount injection."""
+        fix = _premount_fix('fsck -y /dev/sdb1', 'post body')
+        script = compose_startup_script(
+            BASE_SCRIPT_WITH_ANCHOR, [fix], repair_targets=[]
+        )
+        assert script.rindex('signal_complete') > script.index('post body')
+        assert script.count('signal_complete') == 1
 
 
 # Minimal stand-in for rescue_mount_windows.ps1: mount + marker + trailing

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -9,6 +9,7 @@ import pytest
 
 from gce_rescue_v2.orchestration.repair import (
     RepairOrchestrator,
+    FIX_EXECUTION_ORDER,
     REPAIR_LINE_MARKER,
     REPAIR_RESULT_MARKER,
     RESCUE_COMPLETE_MARKER,
@@ -149,7 +150,7 @@ class TestRepairOrchestrator:
             assert orch.diagnose() is None
 
     def test_get_fixable_categories(self):
-        """Should return only categories with fix scripts."""
+        """Should return only categories with fix scripts, in execution order."""
         compute = _make_compute()
         orch = RepairOrchestrator(
             compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
@@ -157,8 +158,8 @@ class TestRepairOrchestrator:
         diagnosis = {
             'boot_errors': [
                 {'category': 'fstab', 'severity': 'critical'},
-                {'category': 'grub', 'severity': 'error'},
                 {'category': 'fstab', 'severity': 'warning'},  # duplicate
+                {'category': 'kernel', 'severity': 'error'},  # no fix script
             ]
         }
         fixable = orch.get_fixable_categories(diagnosis)
@@ -173,12 +174,10 @@ class TestRepairOrchestrator:
         diagnosis = {
             'boot_errors': [
                 {'category': 'fstab', 'severity': 'critical'},
-                {'category': 'grub', 'severity': 'error'},
                 {'category': 'kernel', 'severity': 'error'},
             ]
         }
         unfixable = orch.get_unfixable_categories(diagnosis)
-        assert 'grub' in unfixable
         assert 'kernel' in unfixable
         assert 'fstab' not in unfixable
 
@@ -189,7 +188,7 @@ class TestRepairOrchestrator:
             compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
         )
         diagnosis = {
-            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+            'boot_errors': [{'category': 'kernel', 'severity': 'error'}]
         }
         result = orch.execute(diagnosis)
         assert result['status'] == 'no_fix'
@@ -238,6 +237,80 @@ class TestRepairOrchestrator:
             "projects/debian-cloud/global/images/family/debian-12"
         )
         assert captured['rescue_config'].custom_rescue_image_size_gb == 20
+
+
+# ---------------------------------------------------------------------------
+# TestFixExecutionOrdering
+# ---------------------------------------------------------------------------
+
+class TestFixExecutionOrdering:
+    """get_fixable_categories returns categories in fix execution order."""
+
+    def _make_orchestrator(self):
+        compute = _make_compute()
+        return RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+
+    def test_execution_order_constant(self):
+        """filesystem first, grub last (grub must see the rebuilt initrd)."""
+        assert FIX_EXECUTION_ORDER == [
+            'filesystem', 'fstab', 'initramfs', 'grub'
+        ]
+
+    def test_categories_sorted_into_execution_order(self):
+        """Diagnosis order must not leak into fix composition order."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [
+                {'category': 'grub', 'severity': 'critical'},
+                {'category': 'initramfs', 'severity': 'critical'},
+                {'category': 'fstab', 'severity': 'critical'},
+                {'category': 'filesystem', 'severity': 'critical'},
+            ]
+        }
+        # Simulate all four categories having fix scripts (the scripts for
+        # filesystem/initramfs/grub land in follow-up changes).
+        with patch(
+            'gce_rescue_v2.orchestration.repair.SUPPORTED_FIX_CATEGORIES',
+            {'fstab', 'filesystem', 'initramfs', 'grub'},
+        ):
+            fixable = orch.get_fixable_categories(diagnosis)
+        assert fixable == ['filesystem', 'fstab', 'initramfs', 'grub']
+
+    def test_subset_keeps_execution_order(self):
+        """A subset of known categories still sorts by execution order."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [
+                {'category': 'grub', 'severity': 'critical'},
+                {'category': 'filesystem', 'severity': 'critical'},
+            ]
+        }
+        with patch(
+            'gce_rescue_v2.orchestration.repair.SUPPORTED_FIX_CATEGORIES',
+            {'fstab', 'filesystem', 'initramfs', 'grub'},
+        ):
+            fixable = orch.get_fixable_categories(diagnosis)
+        assert fixable == ['filesystem', 'grub']
+
+    def test_unknown_categories_stable_after_known(self):
+        """Future categories keep diagnosis order, after the known ones."""
+        orch = self._make_orchestrator()
+        diagnosis = {
+            'boot_errors': [
+                {'category': 'zeta_future', 'severity': 'critical'},
+                {'category': 'grub', 'severity': 'critical'},
+                {'category': 'alpha_future', 'severity': 'critical'},
+                {'category': 'fstab', 'severity': 'critical'},
+            ]
+        }
+        with patch(
+            'gce_rescue_v2.orchestration.repair.SUPPORTED_FIX_CATEGORIES',
+            {'fstab', 'grub', 'zeta_future', 'alpha_future'},
+        ):
+            fixable = orch.get_fixable_categories(diagnosis)
+        assert fixable == ['fstab', 'grub', 'zeta_future', 'alpha_future']
 
 
 # ---------------------------------------------------------------------------
@@ -375,8 +448,8 @@ class TestRepairScript:
     def test_missing_fix_script_raises_error(self):
         """Fix script for category without a .sh file should raise, not silently skip."""
         orch = self._make_orchestrator()
-        with pytest.raises(FileNotFoundError, match="Fix script missing for category 'grub'"):
-            orch._get_fix_script('grub')
+        with pytest.raises(FileNotFoundError, match="Fix script missing for category 'kernel'"):
+            orch._get_fix_script('kernel')
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +522,84 @@ class TestRepairResultParsing:
         assert result['status'] == 'unknown'
         assert result['fixed_count'] == 0
 
+    def test_aggregate_multiple_success_results(self):
+        """Multiple SUCCESS markers (one per fix script) sum their counts."""
+        serial = (
+            "GCE-REPAIR-LINE:[FIXED] filesystem: fsck repaired /dev/sdb1\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: UUID for /data\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: device /dev/sdc1\n"
+            "GCE-REPAIR-RESULT:SUCCESS:2\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'success'
+        assert result['fixed_count'] == 3
+        assert len(result['fix_lines']) == 3
+        assert result['error'] is None
+
+    def test_aggregate_success_and_no_issues(self):
+        """SUCCESS + NO_ISSUES collapses to success with the SUCCESS count."""
+        serial = (
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: UUID for /data\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'success'
+        assert result['fixed_count'] == 1
+
+    def test_aggregate_success_and_failed(self):
+        """Any FAILED marker makes the overall status failed (partial fixes kept)."""
+        serial = (
+            "GCE-REPAIR-LINE:[FIXED] fstab: UUID for /data\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-REPAIR-RESULT:FAILED:grub.cfg regeneration failed\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'failed'
+        assert 'grub.cfg regeneration failed' in result['error']
+        # Partial success is preserved for the CLI's failed branch
+        assert result['fixed_count'] == 1
+        assert len(result['fix_lines']) == 1
+
+    def test_aggregate_failed_after_success_not_overridden(self):
+        """FAILED wins even when a later script reports SUCCESS."""
+        serial = (
+            "GCE-REPAIR-RESULT:FAILED:fsck could not repair\n"
+            "GCE-REPAIR-RESULT:SUCCESS:2\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'failed'
+        assert result['fixed_count'] == 2
+
+    def test_aggregate_multiple_failures_join_reasons(self):
+        """Multiple FAILED markers join all reasons in the error."""
+        serial = (
+            "GCE-REPAIR-RESULT:FAILED:first reason\n"
+            "GCE-REPAIR-RESULT:FAILED:second reason\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'failed'
+        assert 'first reason' in result['error']
+        assert 'second reason' in result['error']
+
+    def test_aggregate_all_no_issues(self):
+        """Only NO_ISSUES markers collapse to no_issues."""
+        serial = (
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'no_issues'
+        assert result['fixed_count'] == 0
+
     def test_parse_serial_console_error(self):
         """Should handle serial console fetch failure gracefully."""
         compute = Mock()
@@ -463,6 +614,339 @@ class TestRepairResultParsing:
         result = orch._parse_repair_results()
         assert result['status'] == 'unknown'
         assert result['error'] is not None
+        assert result['marker_results'] == []
+
+    # --- per-marker outcomes (marker_results) ---
+
+    def test_marker_results_preserve_serial_order_mixed_kinds(self):
+        """One entry per RESULT marker, in serial order, with kind/count/reason."""
+        serial = (
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: UUID for /data\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-REPAIR-RESULT:FAILED:grub install failed\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['marker_results'] == [
+            {'kind': 'no_issues', 'count': 0, 'reason': None},
+            {'kind': 'success', 'count': 1, 'reason': None},
+            {'kind': 'failed', 'count': 0, 'reason': 'grub install failed'},
+        ]
+        # Aggregate contract unchanged alongside the new key
+        assert result['status'] == 'failed'
+        assert result['fixed_count'] == 1
+
+    def test_marker_results_empty_without_markers(self):
+        """No RESULT markers -> empty marker_results list."""
+        orch = self._make_orchestrator("just some boot output\n")
+        result = orch._parse_repair_results()
+        assert result['marker_results'] == []
+
+    def test_marker_results_malformed_count_uses_segment_fallback(self):
+        """An unparseable SUCCESS count records its own segment's count."""
+        serial = (
+            "GCE-REPAIR-LINE:[FIXED] grub: Reinstalled GRUB\n"
+            "GCE-REPAIR-LINE:[FIXED] grub: Regenerated config\n"
+            "GCE-REPAIR-RESULT:SUCCESS:oops\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['marker_results'] == [
+            {'kind': 'success', 'count': 2, 'reason': None},
+        ]
+
+    def test_marker_results_windowed_to_current_boot(self):
+        """Markers from a previous boot are not in marker_results."""
+        banner = '=== GCE Rescue Auto-Mount Started ==='
+        serial = (
+            f"{banner}\n"
+            "GCE-REPAIR-RESULT:FAILED:old attempt\n"
+            f"{banner}\n"
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['marker_results'] == [
+            {'kind': 'no_issues', 'count': 0, 'reason': None},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# TestRepairHardening
+# ---------------------------------------------------------------------------
+
+class TestRepairHardening:
+    """Guards for multi-category repair: serial windowing, snapshot
+    requirement, verification-timeout floors, and non-boot-disk filtering."""
+
+    BANNER = '=== GCE Rescue Auto-Mount Started ==='
+
+    def _make_orchestrator(self, serial_output='', config=None,
+                           debug_console=False):
+        compute = _make_compute(serial_output=serial_output)
+        logger = _make_logger()
+        if debug_console:
+            # Debug console level disables the spinner/progress display so
+            # flow tests do not write progress lines to stdout.
+            logger.console_level = logging.DEBUG
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', config=config, logger=logger
+        )
+        orch._create_tracked_client = lambda label: compute
+        return orch
+
+    # --- serial-output windowing (one rescue session, several boots) ---
+
+    def test_markers_from_previous_boot_not_counted(self):
+        """Only markers after the LAST mount banner belong to this run."""
+        serial = (
+            f"{self.BANNER}\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: old attempt\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            f"{self.BANNER}\n"
+            "GCE-REPAIR-LINE:[FIXED] grub: Reinstalled GRUB to /dev/sdb (BIOS)\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['fixed_count'] == 1
+        assert len(result['fix_lines']) == 1
+        assert 'grub' in result['fix_lines'][0]
+
+    def test_previous_boot_failure_does_not_taint_current(self):
+        """A FAILED marker from an earlier boot must not fail this run."""
+        serial = (
+            f"{self.BANNER}\n"
+            "GCE-REPAIR-RESULT:FAILED:old attempt failed\n"
+            f"{self.BANNER}\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'success'
+        assert result['error'] is None
+
+    def test_output_without_banner_parsed_whole(self):
+        """No banner (custom scripts, pre-banner failures): parse everything."""
+        serial = "GCE-REPAIR-RESULT:SUCCESS:2\n"
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'success'
+        assert result['fixed_count'] == 2
+
+    # --- malformed SUCCESS count falls back to its OWN segment ---
+
+    def test_malformed_success_count_uses_own_segment(self):
+        """An unparseable count falls back to that script's [FIXED] lines,
+        not every script's lines."""
+        serial = (
+            "GCE-REPAIR-LINE:[FIXED] filesystem: e2fsck repaired /dev/sdb1\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-REPAIR-LINE:[FIXED] grub: Reinstalled GRUB\n"
+            "GCE-REPAIR-LINE:[FIXED] grub: Regenerated config\n"
+            "GCE-REPAIR-LINE:[WARNING] grub: informational only\n"
+            "GCE-REPAIR-RESULT:SUCCESS:oops\n"
+        )
+        orch = self._make_orchestrator(serial)
+        result = orch._parse_repair_results()
+        assert result['status'] == 'success'
+        # 1 (parsed) + 2 (grub segment's [FIXED] lines; WARNING not counted)
+        assert result['fixed_count'] == 3
+
+    # --- snapshot guard for destructive fixes ---
+
+    def test_fstab_repair_allows_no_snapshot(self):
+        """Non-destructive categories keep --no-snapshot working."""
+        config = RescueConfig(create_snapshot=False)
+        orch = self._make_orchestrator(config=config)
+        diagnosis = {'boot_errors': [{
+            'category': 'fstab', 'severity': 'critical',
+            'detected_pattern': 'mount: bad UUID',
+        }]}
+        sentinel = {'status': 'success'}
+        with patch.object(orch, '_generate_repair_script',
+                          return_value='script'):
+            with patch.object(orch, '_run_repair_flow',
+                              return_value=sentinel) as flow:
+                result = orch.execute(diagnosis)
+        assert result is sentinel
+        assert flow.called
+
+    # --- verification-timeout floors and require_snapshot propagation ---
+
+    def _run_flow_capture_config(self, config=None, categories=None):
+        orch = self._make_orchestrator(config=config, debug_console=True)
+        captured = {}
+
+        class _FakeRescue:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.snapshot_name = None
+
+            def execute(self):
+                return False  # Short-circuit the flow after config capture
+
+        with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator',
+                   _FakeRescue):
+            result = orch._run_repair_flow(
+                'script', fixable_categories=categories
+            )
+        assert result['status'] == 'rescue_failed'
+        return captured['config']
+
+    def test_filesystem_raises_verification_timeout_and_requires_snapshot(self):
+        cfg = self._run_flow_capture_config(
+            categories=['filesystem', 'fstab', 'grub']
+        )
+        assert cfg.verification_timeout_override == 1800
+        assert cfg.require_snapshot is True
+
+    def test_grub_only_gets_smaller_floor_without_snapshot_requirement(self):
+        cfg = self._run_flow_capture_config(categories=['grub'])
+        assert cfg.verification_timeout_override == 900
+        assert cfg.require_snapshot is False
+
+    def test_fstab_only_keeps_os_default_timeout(self):
+        cfg = self._run_flow_capture_config(categories=['fstab'])
+        assert cfg.verification_timeout_override is None
+
+    def test_explicit_timeout_override_beats_category_floor(self):
+        config = RescueConfig(verification_timeout_override=120)
+        cfg = self._run_flow_capture_config(
+            config=config, categories=['filesystem']
+        )
+        assert cfg.verification_timeout_override == 120
+
+    # --- filesystem findings on non-boot disks are not rescue-fixable ---
+
+    def _fs_diagnosis(self, *patterns):
+        return {'boot_errors': [
+            {'category': 'filesystem', 'severity': 'critical',
+             'detected_pattern': p} for p in patterns
+        ]}
+
+    def test_filesystem_on_secondary_disk_not_fixable(self):
+        """Rescuing the boot disk cannot fsck a corrupt SECONDARY disk."""
+        orch = self._make_orchestrator()
+        diagnosis = self._fs_diagnosis('EXT4-fs error (device sdb1): bad block')
+        assert orch.get_fixable_categories(diagnosis) == []
+        assert 'filesystem' in orch.get_unfixable_categories(diagnosis)
+
+    # --- custom fix script pre-mount markers validated pre-flight ---
+
+    def test_validate_rejects_malformed_premount_markers(self):
+        """A BEGIN without END must fail validate(), not rescue step 6."""
+        config = RescueConfig(fix_script=(
+            '#!/bin/bash\n'
+            '# === GCE-REPAIR-PREMOUNT-BEGIN ===\n'
+            'echo unterminated\n'
+        ))
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', config=config,
+            logger=_make_logger()
+        )
+        with patch.object(orch, '_create_tracked_client',
+                          return_value=compute):
+            assert orch.validate() is False
+
+
+# ---------------------------------------------------------------------------
+# TestCategoryOutcomes
+# ---------------------------------------------------------------------------
+
+class TestCategoryOutcomes:
+    """Per-category outcome attribution in _run_repair_flow().
+
+    Scripts compose in get_fixable_categories() order and each emits one
+    RESULT marker, so serial marker order == category order and the two
+    lists zip 1:1. On any length mismatch the key is omitted (attribution
+    would be a guess)."""
+
+    def _run_flow(self, serial, fixable_categories=None, fix_script=None):
+        compute = _make_compute(serial_output=serial)
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        orch._verify_boot_after_repair = lambda: {
+            'verified': True, 'errors': []
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = True
+        mock_rescue.snapshot_name = 'pre-rescue-boot-123'
+        mock_rescue.verification_succeeded = True
+        mock_restore = MagicMock()
+        mock_restore.execute.return_value = True
+
+        with patch.object(orch, '_init_progress'), \
+                patch.object(orch, '_update_progress'), \
+                patch.object(orch, '_finish_progress'), \
+                patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator',
+                      return_value=mock_rescue), \
+                patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator',
+                      return_value=mock_restore):
+            return orch._run_repair_flow(
+                'script' if fix_script is None else None,
+                fix_script=fix_script,
+                fixable_categories=fixable_categories,
+            )
+
+    def test_outcomes_zip_categories_in_composition_order(self):
+        """Markers map 1:1 onto categories when the counts match."""
+        serial = (
+            "GCE-REPAIR-RESULT:NO_ISSUES:0\n"
+            "GCE-REPAIR-LINE:[FIXED] fstab: UUID for /data\n"
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        result = self._run_flow(
+            serial, fixable_categories=['filesystem', 'fstab']
+        )
+        assert result['category_outcomes'] == [
+            {'category': 'filesystem', 'kind': 'no_issues', 'count': 0,
+             'reason': None},
+            {'category': 'fstab', 'kind': 'success', 'count': 1,
+             'reason': None},
+        ]
+
+    def test_marker_count_mismatch_omits_key(self):
+        """Serial dropped a marker: no guessing, the key is absent."""
+        serial = (
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        result = self._run_flow(
+            serial, fixable_categories=['filesystem', 'fstab']
+        )
+        assert 'category_outcomes' not in result
+
+    def test_custom_fix_script_flow_omits_key(self):
+        """--fix-script flows have no categories: never attribute."""
+        serial = (
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        result = self._run_flow(serial, fix_script='#!/bin/bash\necho fix\n')
+        assert 'category_outcomes' not in result
+
+    def test_failed_marker_keeps_reason_in_outcomes(self):
+        """A failed category carries its reason for per-category display."""
+        serial = (
+            "GCE-REPAIR-RESULT:SUCCESS:1\n"
+            "GCE-REPAIR-RESULT:FAILED:grub-install returned 1\n"
+            "GCE-RESCUE-COMPLETE\n"
+        )
+        result = self._run_flow(
+            serial, fixable_categories=['fstab', 'grub']
+        )
+        assert result['status'] == 'failed'
+        assert result['category_outcomes'][1] == {
+            'category': 'grub', 'kind': 'failed', 'count': 0,
+            'reason': 'grub-install returned 1',
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -877,16 +1361,13 @@ class TestSupportedCategories:
     def test_fstab_is_supported(self):
         assert 'fstab' in SUPPORTED_FIX_CATEGORIES
 
-    def test_grub_is_not_supported(self):
-        assert 'grub' not in SUPPORTED_FIX_CATEGORIES
-
     def test_kernel_is_not_supported(self):
         """kernel is detect-only — no auto-repair fix script exists."""
         assert 'kernel' not in SUPPORTED_FIX_CATEGORIES
 
-    def test_initramfs_is_not_supported(self):
-        """initramfs stays unsupported until fixes/initramfs_fix.sh lands."""
-        assert 'initramfs' not in SUPPORTED_FIX_CATEGORIES
+    def test_supported_set_is_exactly_the_shipped_scripts(self):
+        """The full auto-repairable set — update when a new fix script lands."""
+        assert SUPPORTED_FIX_CATEGORIES == {'fstab'}
 
     def test_fix_script_exists_for_each_supported_category(self):
         """Every supported category should have a corresponding fix script."""
@@ -989,7 +1470,7 @@ class TestRepairExecuteReturnValues:
             compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
         )
         diagnosis = {
-            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+            'boot_errors': [{'category': 'kernel', 'severity': 'error'}]
         }
         result = orch.execute(diagnosis)
         assert result['snapshot_name'] is None
@@ -1002,7 +1483,7 @@ class TestRepairExecuteReturnValues:
             compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
         )
         diagnosis = {
-            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+            'boot_errors': [{'category': 'kernel', 'severity': 'error'}]
         }
         result = orch.execute(diagnosis)
         assert 'duration_seconds' in result
@@ -1016,7 +1497,7 @@ class TestRepairExecuteReturnValues:
             compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
         )
         diagnosis = {
-            'boot_errors': [{'category': 'grub', 'severity': 'error'}]
+            'boot_errors': [{'category': 'kernel', 'severity': 'error'}]
         }
         result = orch.execute(diagnosis)
         # Duration should be captured for no_fix result
@@ -1043,6 +1524,9 @@ class TestRepairResumeMethod:
         orch._find_rescue_snapshot = lambda: snapshot_name
         orch._create_tracked_client = lambda label: compute
         orch._verify_boot_after_repair = lambda: {'verified': None, 'errors': []}
+        # Completion confirmed: these tests exercise the restore path, not
+        # the fix_in_progress guard (covered by TestResumeSafetyGuard).
+        orch._rescue_fixes_completed = lambda: True
         return orch
 
     def test_resume_sets_total_steps_to_2(self):
@@ -1133,6 +1617,144 @@ class TestRepairResumeMethod:
 
                             result = orch.resume()
                             assert result['snapshot_name'] is None
+
+
+# ---------------------------------------------------------------------------
+# TestResumeSafetyGuard
+# ---------------------------------------------------------------------------
+
+class TestResumeSafetyGuard:
+    """resume() must not restore (stop the VM) while the previous session's
+    fix scripts may still be running - a restore mid-fsck/mid-rebuild
+    corrupts the very disk being repaired."""
+
+    TOKEN = 'COMPLETE-abc123def456'
+
+    def _make_orchestrator(self, metadata_items=None, guest_attr=None,
+                           serial_output=''):
+        vm_info = {
+            'status': 'RUNNING',
+            'disks': [{
+                'boot': True,
+                'source': 'projects/p/zones/z/disks/rescue-disk',
+                'deviceName': 'rescue-disk',
+            }],
+            'metadata': {'items': metadata_items or [], 'fingerprint': 'abc'},
+        }
+        compute = _make_compute(vm_info=vm_info, serial_output=serial_output)
+        if guest_attr is None:
+            compute.instances.return_value.getGuestAttributes.return_value \
+                .execute.side_effect = Exception('404 attribute not set')
+        else:
+            compute.instances.return_value.getGuestAttributes.return_value \
+                .execute.return_value = guest_attr
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        return orch
+
+    def _script_metadata(self, key='startup-script'):
+        return [{'key': key,
+                 'value': f'#!/bin/bash\n... {self.TOKEN} ...\n'}]
+
+    # --- _rescue_fixes_completed() signal checks ---
+
+    def test_confirmed_via_session_token_guest_attribute(self):
+        """Token from metadata matching gce-rescue/status confirms completion."""
+        orch = self._make_orchestrator(
+            metadata_items=self._script_metadata(),
+            guest_attr={'variableValue': self.TOKEN},
+        )
+        assert orch._rescue_fixes_completed() is True
+
+    def test_confirmed_via_windows_startup_script_token(self):
+        """Token embedded in windows-startup-script-ps1 is also recovered."""
+        orch = self._make_orchestrator(
+            metadata_items=self._script_metadata(
+                key='windows-startup-script-ps1'
+            ),
+            guest_attr={'queryValue': {'items': [{'value': self.TOKEN}]}},
+        )
+        assert orch._rescue_fixes_completed() is True
+
+    def test_confirmed_via_serial_fallback_without_token(self):
+        """No token in metadata: the serial completion marker still counts."""
+        orch = self._make_orchestrator(
+            metadata_items=[],
+            serial_output='boot output\nGCE-RESCUE-COMPLETE\n',
+        )
+        assert orch._rescue_fixes_completed() is True
+
+    def test_stale_guest_attr_falls_back_to_serial(self):
+        """A stale non-session guest attribute must not confirm by itself,
+        but the serial marker still can."""
+        orch = self._make_orchestrator(
+            metadata_items=self._script_metadata(),
+            guest_attr={'variableValue': 'COMPLETE'},  # previous-era value
+            serial_output='GCE-RESCUE-COMPLETE\n',
+        )
+        assert orch._rescue_fixes_completed() is True
+
+    def test_unconfirmed_returns_false(self):
+        """No matching guest attribute and no serial marker: not confirmed."""
+        orch = self._make_orchestrator(
+            metadata_items=self._script_metadata(),
+            guest_attr={'variableValue': 'COMPLETE'},
+            serial_output='fsck is still running...\n',
+        )
+        assert orch._rescue_fixes_completed() is False
+
+    def test_marker_from_previous_boot_not_confirmed(self):
+        """A completion marker BEFORE the last mount banner belongs to an
+        earlier boot and must not confirm the current fix."""
+        banner = '=== GCE Rescue Auto-Mount Started ==='
+        orch = self._make_orchestrator(
+            metadata_items=[],
+            serial_output=(
+                f'GCE-RESCUE-COMPLETE\n{banner}\nrunning e2fsck...\n'
+            ),
+        )
+        assert orch._rescue_fixes_completed() is False
+
+    # --- resume() behavior on the guard ---
+
+    def _resume(self, confirmed):
+        compute = _make_compute()
+        orch = RepairOrchestrator(
+            compute, 'proj', 'zone-a', 'vm-1', logger=_make_logger()
+        )
+        orch._create_tracked_client = lambda label: compute
+        orch._find_rescue_snapshot = lambda: 'pre-rescue-boot-123'
+        orch._rescue_fixes_completed = lambda: confirmed
+        orch._verify_boot_after_repair = lambda: {
+            'verified': None, 'errors': []
+        }
+
+        mock_restore = MagicMock()
+        mock_restore.execute.return_value = True
+
+        with patch.object(orch, '_init_progress'), \
+                patch.object(orch, '_update_progress'), \
+                patch.object(orch, '_finish_progress'), \
+                patch('gce_rescue_v2.orchestration.repair.RestoreOrchestrator',
+                      return_value=mock_restore) as restore_class:
+            result = orch.resume()
+        return result, restore_class
+
+    def test_unconfirmed_blocks_restore(self):
+        """Unconfirmed completion: no restore, status fix_in_progress."""
+        result, restore_class = self._resume(confirmed=False)
+        assert result['status'] == 'fix_in_progress'
+        assert 'still be running' in result['error']
+        assert result['snapshot_name'] == 'pre-rescue-boot-123'
+        restore_class.assert_not_called()
+
+    def test_confirmed_proceeds_to_restore(self):
+        """Confirmed completion: resume restores as before."""
+        result, restore_class = self._resume(confirmed=True)
+        assert result['status'] != 'fix_in_progress'
+        restore_class.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1335,6 +1957,7 @@ class TestRepairResumeRestoreFailure:
         )
         orch._create_tracked_client = lambda label: compute
         orch._find_rescue_snapshot = lambda: 'pre-rescue-boot-123'
+        orch._rescue_fixes_completed = lambda: True
         orch._progress_lock = __import__('threading').Lock()
         orch._progress_started = False
 
@@ -1358,6 +1981,7 @@ class TestRepairResumeRestoreFailure:
         )
         orch._create_tracked_client = lambda label: compute
         orch._find_rescue_snapshot = lambda: None
+        orch._rescue_fixes_completed = lambda: True
         orch._progress_lock = __import__('threading').Lock()
         orch._progress_started = False
 

--- a/gce_rescue_v2/tests/test_repair.py
+++ b/gce_rescue_v2/tests/test_repair.py
@@ -1811,6 +1811,39 @@ class TestRepairMountFailure:
         assert result['fixed_count'] == 0
         assert result['snapshot_name'] == 'pre-rescue-boot-123'
 
+    def test_mount_failed_timeout_message_includes_duration(self):
+        """When verification timed out, the error must say so with the
+        duration (mirrors the rescue command's #133 messaging)."""
+        compute = _make_compute()
+        logger = MagicMock()
+        orch = RepairOrchestrator(compute, 'proj', 'zone-a', 'vm-1', logger=logger)
+        orch._create_tracked_client = lambda label: compute
+
+        diagnosis = {
+            'boot_errors': [{'category': 'fstab', 'severity': 'critical'}]
+        }
+
+        mock_rescue = MagicMock()
+        mock_rescue.execute.return_value = True
+        mock_rescue.snapshot_name = None
+        mock_rescue.verification_succeeded = False
+        mock_rescue.verification_result = OperationResult(
+            operation_name='Verify startup script',
+            success=False,
+            message='timed out',
+            rollback_data={},
+            details={'timed_out': True, 'timeout_seconds': 900},
+        )
+
+        with patch.object(orch, '_init_progress'):
+            with patch.object(orch, '_update_progress'):
+                with patch.object(orch, '_finish_progress'):
+                    with patch('gce_rescue_v2.orchestration.repair.RescueOrchestrator', return_value=mock_rescue):
+                        orch.execute(diagnosis)
+
+        logged = ' '.join(str(c) for c in logger.error.call_args_list)
+        assert 'timed out after 900s' in logged
+
     def test_mount_failed_does_not_restore(self):
         """Mount failure should NOT trigger restore (VM stays in rescue mode)."""
         compute = _make_compute()

--- a/gce_rescue_v2/tests/test_rescue.py
+++ b/gce_rescue_v2/tests/test_rescue.py
@@ -1,5 +1,6 @@
 import time
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -721,3 +722,54 @@ class TestFixScriptComposition:
         script = orch._generate_startup_script()
         assert 'DISK_NAME_PLACEHOLDER' not in script
         assert 'PASSWORD_PLACEHOLDER' not in script
+
+
+class TestFixScriptPremountValidation:
+    """validate() rejects malformed --fix-script pre-mount markers before
+    any VM mutation (the repair-side twin lives in test_repair.py)."""
+
+    def _make_orchestrator(self, fix_script, compute):
+        config = RescueConfig()
+        config.fix_script = fix_script
+        return RescueOrchestrator(
+            compute=compute, project='p', zone='z', vm_name='vm-1',
+            config=config, suppress_progress=True,
+        )
+
+    def test_validate_rejects_malformed_premount_markers(self):
+        """A BEGIN without END must fail validate(), not rescue step 6."""
+        compute = MagicMock()
+        orch = self._make_orchestrator(
+            '#!/bin/bash\n'
+            '# === GCE-REPAIR-PREMOUNT-BEGIN ===\n'
+            'echo unterminated\n',
+            compute,
+        )
+        assert orch.validate() is False
+        # The check fires before any validator runs: no API call of any kind,
+        # so the VM is untouched.
+        assert compute.mock_calls == []
+
+    def test_validate_accepts_well_formed_premount_markers(self, monkeypatch):
+        """A balanced BEGIN/END block passes the check and validation
+        proceeds to the regular validator run."""
+        compute = MagicMock()
+        orch = self._make_orchestrator(
+            '#!/bin/bash\n'
+            '# === GCE-REPAIR-PREMOUNT-BEGIN ===\n'
+            'fsck -y "$dev"\n'
+            '# === GCE-REPAIR-PREMOUNT-END ===\n'
+            'echo post-mount fix\n',
+            compute,
+        )
+        results = MagicMock()
+        results.all_passed.return_value = True
+        results.get_result.return_value = None
+        runner = MagicMock()
+        runner.run_all.return_value = results
+        monkeypatch.setattr(
+            'gce_rescue_v2.orchestration.rescue.ValidationRunner',
+            lambda: runner,
+        )
+        assert orch.validate() is True
+        runner.run_all.assert_called_once()

--- a/gce_rescue_v2/tests/test_verify_startup.py
+++ b/gce_rescue_v2/tests/test_verify_startup.py
@@ -231,6 +231,55 @@ class TestVerifyStartupOperation:
         assert result.success is True
         assert "completed" in result.message.lower()
 
+    def test_guest_attr_session_token_accepted(self):
+        """The session token value counts as completion when expected."""
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'variableValue': 'COMPLETE-abc123def456'
+        }
+        assert self.operation._completion_guest_attribute_set(
+            self.mock_compute, 'vm', expected_value='COMPLETE-abc123def456'
+        ) is True
+
+    def test_guest_attr_stale_complete_rejected_for_session_token(self):
+        """A stale COMPLETE from a previous rescue must NOT satisfy a
+        session-token verification (guest attributes persist across
+        stop/start/restore and would short-circuit repeat repairs)."""
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'variableValue': 'COMPLETE'
+        }
+        assert self.operation._completion_guest_attribute_set(
+            self.mock_compute, 'vm', expected_value='COMPLETE-abc123def456'
+        ) is False
+
+    def test_execute_stale_guest_attr_does_not_short_circuit(self):
+        """execute() with a session token ignores a stale COMPLETE and times
+        out when neither the token nor the serial marker appears."""
+        self.mock_compute.instances().getGuestAttributes().execute.return_value = {
+            'variableValue': 'COMPLETE'  # from a previous rescue session
+        }
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'booting... no marker'
+        }
+        with patch('time.sleep'), patch('time.time', side_effect=[0, 0, 20, 20]):
+            result = self.operation.execute(
+                vm_name='test-vm', timeout=10,
+                expected_completion_value='COMPLETE-abc123def456'
+            )
+        assert result.success is False
+
+    def test_startup_failure_marker_aborts_early(self):
+        """A terminal failure line on serial fails verification immediately
+        instead of polling out the timeout (a mount that already failed can
+        never produce the completion marker)."""
+        self.mock_compute.instances().getSerialPortOutput().execute.return_value = {
+            'contents': 'mounting...\nERROR: All mount attempts failed\n'
+        }
+        result = self.operation.execute(vm_name='test-vm', timeout=600)
+        assert result.success is False
+        assert 'All mount attempts failed' in result.message
+        # One poll was enough - no timeout wait
+        assert self.mock_compute.instances().getSerialPortOutput().execute.call_count == 1
+
     def test_rollback_returns_true(self):
         """Test rollback always returns True (no-op for verification)."""
         # Act


### PR DESCRIPTION

First of two PRs extending auto-repair beyond fstab. This one is the engine: everything `repair` needs to run several fix categories safely in one rescue cycle. The fix scripts themselves (filesystem, initramfs, GRUB) follow in a second PR — until then, behavior is unchanged for users (fstab remains the only auto-repairable category), but the machinery below is in place and fully exercised by tests.

## What changes

**Multi-category execution.** `repair` composes all fixable categories into one rescue cycle instead of assuming a single fix. Fixes run in dependency order — filesystem checks first (a dirty filesystem can make every later fix fail or lie), then fstab, initramfs, and GRUB last. Serial-console results aggregate across multiple `GCE-REPAIR-RESULT` markers, and parsing windows to the current boot's output so markers from a previous attempt are never counted.

**Pre-mount hook.** Startup-script composition now supports a pre-mount stage: filesystem checks must run against an unmounted disk, so composed scripts can execute marked segments before the mount attempt. Custom `--fix-script` inputs with malformed pre-mount markers are rejected at pre-flight rather than failing inside the rescue VM.

**Per-session completion tokens.** The rescue completion signal now carries a per-session token (in both the Linux and Windows mount scripts). Previously a stale completion marker from an earlier rescue could short-circuit verification of a later one — a repeated repair on the same VM could report success without having run.

**Verification hardening.**
- Category-based verification timeout floors: destructive/slow fixes get a floor of 1800s (filesystem) or 900s (GRUB/initramfs) instead of the OS default; an explicit `--verification-timeout` still wins.
- Mandatory-snapshot guard: categories that rewrite the disk in place (filesystem) refuse to run with `--no-snapshot`.
- Filesystem findings are scoped to the boot disk: errors on a secondary disk are reported as not rescue-fixable instead of triggering a pointless boot-disk rescue cycle. Ambiguous findings fail open.
- Resumed sessions get a completion guard so a fix that already ran isn't re-applied.

**Housekeeping.** `.gitattributes` pins `*.sh` to LF (fix scripts are embedded verbatim into startup scripts; CRLF breaks bash parsing on the rescue VM).

## Validation

- 1020 tests passing (+66 over develop): aggregation, execution ordering, floors, snapshot guard, device scoping, token substitution, pre-mount composition, resume guard.
- The engine + scripts combination has been validated live end to end on Debian, Ubuntu, and Rocky/RHEL VMs with real induced boot failures (filesystem corruption, broken GRUB config, missing initramfs) — those results ship with the scripts PR, which lands the categories this engine executes.
