### PR TITLE
feat: bundled Windows BCD repair script for repair --fix-script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ps1 text eol=lf

--- a/gce_rescue_v2/cli/__init__.py
+++ b/gce_rescue_v2/cli/__init__.py
@@ -293,7 +293,7 @@ NOTES
     # REPAIR COMMAND
     repair_parser = subparsers.add_parser(
         'repair',
-        help='Diagnose and auto-fix boot issues (Linux only)',
+        help='Diagnose and auto-fix boot issues',
         description='Automatically diagnose and repair boot issues. Combines'
                     ' diagnose, rescue (with embedded fix), and restore into a'
                     ' single command.',
@@ -310,10 +310,13 @@ EXAMPLES
         $ gce-rescue repair my-vm --zone=us-central1-a --quiet
 
 SUPPORTED FIXES
-    - fstab: Comments out invalid UUID, device, or label entries
+    - fstab: Comments out invalid UUID, device, or label entries (Linux)
+    - Custom fix scripts via --fix-script (Linux and Windows), e.g. the
+      bundled Windows BCD repair script (startup_scripts/fixes/windows_bcd_fix.ps1)
 
 NOTES
-    This command is Linux-only. For Windows VMs, use 'rescue' for manual fix.
+    Diagnosis-driven repair is Linux-only. Windows VMs are supported with
+    --fix-script, which skips diagnosis and runs the supplied script.
     The VM will be stopped during repair and restarted when complete.
         """
     )

--- a/gce_rescue_v2/startup_scripts/fixes/windows_bcd_fix.ps1
+++ b/gce_rescue_v2/startup_scripts/fixes/windows_bcd_fix.ps1
@@ -25,6 +25,15 @@
 # supported offline equivalent of bootrec /rebuildbcd, which only runs against
 # the live system. bcdboot never touches user data; the pre-rescue snapshot is
 # the rollback.
+#
+# Scope limits (deliberate):
+# - bcdboot writes a fresh DEFAULT store: custom BCD entries and settings
+#   (extra boot entries, debug/testsigning flags, custom timeouts) are not
+#   preserved. Intended for broken or missing BCDs, where there is nothing
+#   to preserve.
+# - BitLocker: a locked volume cannot be read, and rebuilding boot files on
+#   an encrypted disk can trigger BitLocker recovery. The script detects a
+#   locked-looking volume and REFUSES with guidance instead of guessing.
 
 $FixReason = ""
 $Fixes = 0
@@ -42,7 +51,32 @@ foreach ($vol in Get-Volume | Where-Object { $_.DriveLetter -and $_.DriveLetter 
 }
 
 if (-not $winVolume) {
-    $FixReason = "no offline Windows installation found on the attached disk (no <drive>:\Windows\System32\config\SYSTEM)"
+    # --- Distinguish "no Windows there" from "Windows there but unreadable".
+    # A BitLocker-locked OS volume mounts with a drive letter but an unreadable
+    # filesystem (FileSystemType 'Unknown'). Flag large fixed volumes in that
+    # state; confirm with manage-bde when the BitLocker tools exist (they are
+    # an optional feature, so never assume).
+    $lockedSuspects = @()
+    foreach ($vol in Get-Volume | Where-Object { $_.DriveLetter -and $_.DriveLetter -ne 'C' }) {
+        if ($vol.FileSystemType -eq 'Unknown' -and $vol.Size -gt 10GB) {
+            $suspect = "$($vol.DriveLetter):"
+            if (Get-Command manage-bde.exe -ErrorAction SilentlyContinue) {
+                $bde = & manage-bde.exe -status "$suspect" 2>&1 | Out-String
+                if ($bde -match 'Lock Status:\s+Locked') {
+                    $suspect = "$suspect (BitLocker: Locked)"
+                }
+            }
+            $lockedSuspects += $suspect
+        }
+    }
+
+    if ($lockedSuspects.Count -gt 0) {
+        $FixReason = ("volume(s) $($lockedSuspects -join ', ') appear BitLocker-locked/unreadable - " +
+            "BCD rebuild is not attempted on encrypted volumes. Unlock first in the rescue VM " +
+            "(manage-bde -unlock <drive>: -RecoveryPassword <key>; requires the BitLocker feature), then re-run")
+    } else {
+        $FixReason = "no offline Windows installation found on the attached disk (no <drive>:\Windows\System32\config\SYSTEM)"
+    }
 } else {
     $winLetter = $winVolume.DriveLetter
     Write-Log "GCE-REPAIR-LINE:[INFO] bcd: found offline Windows at ${winLetter}:\Windows"

--- a/gce_rescue_v2/startup_scripts/fixes/windows_bcd_fix.ps1
+++ b/gce_rescue_v2/startup_scripts/fixes/windows_bcd_fix.ps1
@@ -1,0 +1,131 @@
+# GCE Rescue - Windows BCD repair fix script (for use with: repair --fix-script)
+#
+# Rebuilds the Boot Configuration Data (BCD) store and boot files of an
+# OFFLINE Windows installation - the fix for boot failures like
+#   0xc000000e / 0xc0000225 / 0xc000000f "Windows Boot Manager ... a required
+#   device isn't connected", "Boot Configuration Data ... missing/corrupt".
+#
+# This is NOT a diagnosis-driven auto-repair category (Windows auto-repair is
+# not wired into the orchestrator). It is a self-contained script an engineer
+# passes explicitly:
+#   gce-rescue repair VM --zone=ZONE --project=PROJECT \
+#       --fix-script=gce_rescue_v2/startup_scripts/fixes/windows_bcd_fix.ps1
+#
+# The repair flow rescues the VM (mounting the affected disk at a drive letter
+# via rescue_mount_windows.ps1), runs THIS script, then restores. Write-Log,
+# and the affected Windows volume mounted read-write, are already available.
+#
+# Contract (like the Linux fix scripts): emit GCE-REPAIR-LINE for each action
+# and exactly ONE GCE-REPAIR-RESULT (SUCCESS:<n> | NO_ISSUES:0 | FAILED:<reason>)
+# on every path. Never call 'exit' - it would abort the composed startup script
+# before the completion marker. A single result-emission block at the end.
+#
+# Mechanism: bcdboot rebuilds the BCD + boot files on the EFI System Partition
+# (or the BIOS system partition) from the offline install's \Windows. It is the
+# supported offline equivalent of bootrec /rebuildbcd, which only runs against
+# the live system. bcdboot never touches user data; the pre-rescue snapshot is
+# the rollback.
+
+$FixReason = ""
+$Fixes = 0
+
+# --- Locate the affected Windows volume (the drive the rescue mount attached).
+# The rescue mount script assigns D: (or the next free letter) to the affected
+# disk's large partition. The Windows install is the one carrying \Windows.
+$winVolume = $null
+foreach ($vol in Get-Volume | Where-Object { $_.DriveLetter -and $_.DriveLetter -ne 'C' }) {
+    $winPath = "$($vol.DriveLetter):\Windows\System32\config\SYSTEM"
+    if (Test-Path $winPath) {
+        $winVolume = $vol
+        break
+    }
+}
+
+if (-not $winVolume) {
+    $FixReason = "no offline Windows installation found on the attached disk (no <drive>:\Windows\System32\config\SYSTEM)"
+} else {
+    $winLetter = $winVolume.DriveLetter
+    Write-Log "GCE-REPAIR-LINE:[INFO] bcd: found offline Windows at ${winLetter}:\Windows"
+
+    # --- Identify the affected disk number from the Windows partition, so we
+    # look for its OWN system partition (never the rescue disk's).
+    $winPartition = Get-Partition -DriveLetter $winLetter -ErrorAction SilentlyContinue
+    $diskNumber = $winPartition.DiskNumber
+
+    # --- Detect firmware: an EFI System Partition on the affected disk means
+    # UEFI; otherwise treat as BIOS/MBR.
+    $espGuid = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+    $esp = Get-Partition -DiskNumber $diskNumber -ErrorAction SilentlyContinue |
+        Where-Object { $_.GptType -eq $espGuid } | Select-Object -First 1
+
+    $sysLetter = $null
+    $assignedAccessPath = $false
+    if ($esp) {
+        # Ensure the ESP has an access path so bcdboot can write to it. ESPs are
+        # small (~100MB) and normally get no drive letter, so assign a temp one.
+        $sysLetter = ($esp.DriveLetter)
+        if (-not $sysLetter) {
+            foreach ($letter in 'S', 'T', 'U', 'V', 'W') {
+                $used = (Get-Partition | Where-Object { $_.DriveLetter }).DriveLetter
+                if ($letter -notin $used) {
+                    try {
+                        Set-Partition -DiskNumber $diskNumber -PartitionNumber $esp.PartitionNumber `
+                            -NewDriveLetter $letter -ErrorAction Stop
+                        $sysLetter = $letter
+                        $assignedAccessPath = $true
+                        Write-Log "GCE-REPAIR-LINE:[INFO] bcd: mounted EFI system partition at ${letter}:"
+                    } catch {
+                        Write-Log "  WARNING: could not assign a letter to the ESP: $_"
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    # --- Rebuild the BCD + boot files with bcdboot from the offline install.
+    if ($sysLetter) {
+        # UEFI: write to the ESP with the UEFI firmware target.
+        $bcdCmd = "bcdboot ${winLetter}:\Windows /s ${sysLetter}: /f UEFI"
+    } else {
+        # BIOS/MBR: no ESP; bcdboot writes to the active system partition and
+        # updates the BIOS boot code. /f BIOS targets legacy firmware.
+        $bcdCmd = "bcdboot ${winLetter}:\Windows /f BIOS"
+    }
+    Write-Log "GCE-REPAIR-LINE:[INFO] bcd: running $bcdCmd"
+
+    try {
+        $output = & cmd.exe /c "$bcdCmd 2>&1"
+        $rc = $LASTEXITCODE
+        Write-Log "  bcdboot output: $output"
+        if ($rc -eq 0) {
+            $Fixes = 1
+            Write-Log "GCE-REPAIR-LINE:[FIXED] bcd: Rebuilt the Boot Configuration Data for ${winLetter}:\Windows"
+        } else {
+            $FixReason = "bcdboot failed (exit $rc): $output"
+        }
+    } catch {
+        $FixReason = "bcdboot threw: $_"
+    }
+
+    # --- Release the temp ESP letter so restore is clean.
+    if ($assignedAccessPath -and $sysLetter) {
+        try {
+            Remove-PartitionAccessPath -DiskNumber $diskNumber `
+                -PartitionNumber $esp.PartitionNumber `
+                -AccessPath "${sysLetter}:\" -ErrorAction Stop
+            Write-Log "  Released temporary ESP letter ${sysLetter}:"
+        } catch {
+            Write-Log "  WARNING: could not release ESP letter ${sysLetter}: $_"
+        }
+    }
+}
+
+# --- Single result-emission point (no 'exit' anywhere above) -----------------
+if ($FixReason -ne "") {
+    Write-Log "GCE-REPAIR-RESULT:FAILED:$FixReason"
+} elseif ($Fixes -gt 0) {
+    Write-Log "GCE-REPAIR-RESULT:SUCCESS:$Fixes"
+} else {
+    Write-Log "GCE-REPAIR-RESULT:NO_ISSUES:0"
+}

--- a/gce_rescue_v2/tests/test_windows_support.py
+++ b/gce_rescue_v2/tests/test_windows_support.py
@@ -8,11 +8,17 @@ Tests:
 4. Correct rescue image selection
 """
 
+import re
+from pathlib import Path
 from unittest.mock import Mock, patch
 import pytest
 
 from gce_rescue_v2.core.config import OS_TYPE_LINUX, OS_TYPE_WINDOWS, RescueConfig
 from gce_rescue_v2.utils.os_detection import detect_os_type, get_os_display_name
+
+_BCD_FIX_SCRIPT = (
+    Path(__file__).parent.parent / 'startup_scripts' / 'fixes' / 'windows_bcd_fix.ps1'
+)
 
 
 class TestOSDetection:
@@ -198,3 +204,57 @@ class TestConfigWindows:
         assert config.windows_rescue_image_family == 'windows-2022'
         assert config.windows_rescue_image_project == 'windows-cloud'
         assert config.windows_rescue_disk_size_gb == 50
+
+
+class TestWindowsBcdFixScript:
+    """The canned BCD-repair fix script (--fix-script) must honor the repair
+    marker protocol and rebuild the BCD from the offline install via bcdboot."""
+
+    def _script(self) -> str:
+        return _BCD_FIX_SCRIPT.read_text(encoding='utf-8')
+
+    def test_script_exists(self):
+        assert _BCD_FIX_SCRIPT.exists()
+
+    def test_emits_result_marker(self):
+        assert 'GCE-REPAIR-RESULT:' in self._script()
+
+    def test_single_result_emission_block(self):
+        """SUCCESS / NO_ISSUES / FAILED are mutually exclusive branches at the
+        end - exactly one result marker fires per run."""
+        text = self._script()
+        assert 'GCE-REPAIR-RESULT:SUCCESS:$Fixes' in text
+        assert 'GCE-REPAIR-RESULT:NO_ISSUES:0' in text
+        assert 'GCE-REPAIR-RESULT:FAILED:$FixReason' in text
+        # All result emissions live after the single-emission-point banner.
+        marker = text.index('Single result-emission point')
+        for m in re.finditer(r'GCE-REPAIR-RESULT:', text):
+            assert m.start() > marker
+
+    def test_never_calls_exit(self):
+        # 'exit' would abort the composed startup script before the completion
+        # marker. Ignore comment lines and quoted strings (e.g. a log message
+        # mentioning a bcdboot "exit" code is not a shell exit).
+        for line in self._script().splitlines():
+            code = line.split('#', 1)[0]
+            code = re.sub(r'"[^"]*"', '""', code)
+            code = re.sub(r"'[^']*'", "''", code)
+            assert not re.search(r'\bexit\b', code), f"must not call exit: {line!r}"
+
+    def test_uses_bcdboot_offline(self):
+        text = self._script()
+        assert 'bcdboot' in text
+        # Targets the offline install's \Windows, both firmware modes.
+        assert '/f UEFI' in text
+        assert '/f BIOS' in text
+
+    def test_locates_windows_by_config_hive(self):
+        # Finds the offline install by its registry hive, not a hardcoded D:.
+        assert 'Windows\\System32\\config\\SYSTEM' in self._script()
+
+    def test_releases_temp_esp_letter(self):
+        # Cleans up the temporary ESP drive letter so restore is clean.
+        assert 'Remove-PartitionAccessPath' in self._script()
+
+    def test_uses_lf_line_endings(self):
+        assert b'\r' not in _BCD_FIX_SCRIPT.read_bytes()

--- a/gce_rescue_v2/tests/test_windows_support.py
+++ b/gce_rescue_v2/tests/test_windows_support.py
@@ -256,5 +256,31 @@ class TestWindowsBcdFixScript:
         # Cleans up the temporary ESP drive letter so restore is clean.
         assert 'Remove-PartitionAccessPath' in self._script()
 
+    def test_refuses_bitlocker_locked_volumes(self):
+        # A locked volume is unreadable and rebuilding boot files on an
+        # encrypted disk can trigger BitLocker recovery - the script must
+        # refuse with guidance, not guess.
+        text = self._script()
+        assert 'BitLocker-locked' in text
+        assert 'manage-bde -unlock' in text
+
+    def test_bitlocker_detection_never_assumes_tools(self):
+        # manage-bde is an optional feature; the definitive check must be
+        # guarded so its absence cannot break the script.
+        assert 'Get-Command manage-bde.exe' in self._script()
+
+    def test_locked_volume_heuristic_is_filesystem_based(self):
+        # The heuristic works without BitLocker tooling: a locked OS volume
+        # surfaces with an unreadable filesystem.
+        text = self._script()
+        assert "FileSystemType -eq 'Unknown'" in text
+
+    def test_documents_custom_entry_scope(self):
+        # The header must state that bcdboot writes a fresh default store and
+        # custom BCD entries are not preserved.
+        text = self._script()
+        assert 'fresh DEFAULT store' in text
+        assert 'custom BCD entries' in text
+
     def test_uses_lf_line_endings(self):
         assert b'\r' not in _BCD_FIX_SCRIPT.read_bytes()


### PR DESCRIPTION
Fixes #150.

## What

Adds a ready-to-use fix script, `startup_scripts/fixes/windows_bcd_fix.ps1`, that rebuilds a corrupted or missing Boot Configuration Data store on a Windows VM through the existing `repair --fix-script` path:

```
gce-rescue repair VM_NAME --zone=ZONE --fix-script=.../windows_bcd_fix.ps1
```

No orchestrator changes — the script rides the same custom-fix-script mechanism used for the disaster-recovery work, so it is a pure addition.

## Why

BCD corruption (missing store, broken `device`/`osdevice` entries, interrupted Windows updates) is a recurring class of unbootable-Windows-VM cases, failing at `0xc000000e` / `0xc0000001` / `0xc0000034`. Recovery today means a manual rescue session and hand-typed `bcdboot`/`bcdedit` commands. This packages that procedure as a one-command repair.

## How it works

From the rescue environment, the script:

1. Locates the offline Windows installation by probing mounted volumes for `\Windows\System32\config\SYSTEM` (no hardcoded drive letters).
2. Detects firmware type from the affected disk's partition layout (EFI System Partition GPT type → UEFI, otherwise BIOS).
3. UEFI: mounts the ESP under a temporary letter, runs `bcdboot <win>:\Windows /s <esp>: /f UEFI`, releases the letter. BIOS: `bcdboot ... /f BIOS`.
4. Follows the fix-script contract: `GCE-REPAIR-LINE` progress markers, exactly one `GCE-REPAIR-RESULT:(SUCCESS:n|NO_ISSUES:0|FAILED:reason)`, never calls `exit`.
5. **Refuses BitLocker-locked volumes.** A locked volume is unreadable, and rebuilding boot files on an encrypted disk can trigger BitLocker recovery — the script detects a locked-looking volume (unreadable filesystem; confirmed via `manage-bde` when the tooling exists) and fails with unlock guidance instead of guessing. The header also documents that `bcdboot` writes a fresh default store, so custom BCD entries are not preserved — this fix is for broken/missing BCDs, where there is nothing to preserve.

Also included:

- `.gitattributes` now pins `*.ps1` to LF (Windows checkouts smudged the scripts to CRLF, breaking the fix-script contract tests; committed content was already LF, so this changes no history).
- The `repair` help text no longer claims the command is Linux-only: diagnosis-driven repair remains Linux-only, but Windows is supported via `--fix-script`, and the help now says so with the bundled script as the example.

## Validation

- Live-validated end to end: corrupted a windows-2022 VM's BCD store (`bcdedit /deletevalue` on `device` + `osdevice`; VM unbootable at `0xc0000001`, confirmed on both serial ports), then ran `repair --fix-script=windows_bcd_fix.ps1`. The script found the offline install at `D:\Windows`, mounted the ESP, ran `bcdboot /f UEFI`, reported `GCE-REPAIR-RESULT:SUCCESS:1`, and the VM booted normally after restore — 9m33s end to end, verified independently on serial ports 1 and 2.
- The validation used a windows-2019 rescue image (`--rescue-image`) so the repair is attributable to this script alone.
- `TestWindowsBcdFixScript` (14 tests) pins the contract: hive-based Windows detection, firmware detection, ESP letter release, marker discipline, single result emission, no `exit` calls, LF endings, BitLocker refusal path, and the tooling-independence of the locked-volume detection.
- Full suite: 966 tests passing.
